### PR TITLE
Change version to 0.1.0-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_cli"
-version = "0.1.0"
+version = "0.1.0-dev"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
The main [Bevy](https://github.com/bevyengine/bevy) repository uses the "-dev" suffix in the version number when working on the unreleased version. I suggest we adopt this practice so people can tell the difference between the released and unstable versions.

When 0.1.0 of this crate is released, we'll temporarily set it to "0.1.0" before upgrading it to "0.2.0-dev" afterwards.