### PR TITLE
Configure default binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ name = "bevy_cli"
 version = "0.1.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+default-run = "bevy"
 
 [[bin]]
 name = "bevy"


### PR DESCRIPTION
# Objective

```
$ cargo run
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: bevy, bevy_lint_driver
```

# Solution

Configure the `default-run` manifest option