### PR TITLE
Add `clippy_utils` as a dependency to `bevy_lint`

### DIFF
--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # work with the currently pinned nightly Rust version. When the Rust version changes, this too
 # needs to be updated!
 [dependencies.clippy_utils]
-version = "0.1.82"
+version = "=0.1.82"
 git = "https://github.com/rust-lang/rust-clippy"
 rev = "e8ac4ea4187498052849531b86114a1eec5314a1"
 

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.1.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-[dependencies]
-clippy_utils = { version = "0.1.82", git = "https://github.com/rust-lang/rust-clippy", rev = "e8ac4ea4187498052849531b86114a1eec5314a1" }
+# Contains a series of useful utilities when writing lints. The version and commit were chosen to
+# work with the currently pinned nightly Rust version. When the Rust version changes, this too
+# needs to be updated!
+[dependencies.clippy_utils]
+version = "0.1.82"
+git = "https://github.com/rust-lang/rust-clippy"
+rev = "e8ac4ea4187498052849531b86114a1eec5314a1"
 
 [package.metadata.rust-analyzer]
 # Enables Rust-Analyzer support for `rustc` crates.

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+clippy_utils = { version = "0.1.82", git = "https://github.com/rust-lang/rust-clippy", rev = "e8ac4ea4187498052849531b86114a1eec5314a1" }
 
 [package.metadata.rust-analyzer]
 # Enables Rust-Analyzer support for `rustc` crates.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
-# If you modify this file, please also update `.github/workflows/ci.yml` so that Github Actions
-# will install the correct version of Rust.
+# If you modify this file, please also update `RUST_TOOLCHAIN` in `.github/workflows/ci.yml` and
+# the `clippy_utils` version in `bevy_lint/Cargo.toml`.
 
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version


### PR DESCRIPTION
Fixes #19, please see the issue description for motivation!

I chose [this commit](https://github.com/rust-lang/rust-clippy/tree/e8ac4ea4187498052849531b86114a1eec5314a1/clippy_utils) because it was the most recent and actually compiled with the configured nightly. We may need to fidget with this version in the future if we encounter any issues with it.