### PR TITLE
chore: update README to include instructions to manually install rustc components

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,11 @@ A Bevy CLI tool.
 
 ## Nightly Rust
 
-The Bevy CLI includes a [custom linter](bevy_lint) that integrates directly with `rustc` through [`#![feature(rustc_private)]`](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html). Because of this, building this project requires nightly Rust with the `rustc-dev` component. If you use Rustup, a pinned version will be automatically installed when you compile this project based on the contents of [`rust-toolchain.toml`](rust-toolchain.toml).
+The Bevy CLI includes a [custom linter](bevy_lint) that integrates directly with `rustc` through [`#![feature(rustc_private)]`](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html).Because of this, building this project requires nightly Rust with the `rustc-dev` component. If you use Rustup, a pinned version will be automatically installed when you compile this project based on the contents of [`rust-toolchain.toml`](rust-toolchain.toml).
+
+However, some components may be still missing due to a [`rustup` bug](https://github.com/rust-lang/rustup/issues/3255). If you get `can't find crate` errors when trying to build, run the following commands to manually add the required components:
+
+```
+rustup component add rust-src rustc-dev llvm-tools-preview
+rustup component add --toolchain nightly rust-src rustc-dev llvm-tools-preview
+```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ The Bevy CLI includes a [custom linter](bevy_lint) that integrates directly with
 However, some components may be still missing due to a [`rustup` bug](https://github.com/rust-lang/rustup/issues/3255). If you get `can't find crate` errors when trying to build, run the following commands to manually add the required components:
 
 ```
-rustup component add rust-src rustc-dev llvm-tools-preview
-rustup component add --toolchain nightly rust-src rustc-dev llvm-tools-preview
+rustup component add rustc-dev llvm-tools-preview
+rustup component add --toolchain nightly rustc-dev llvm-tools-preview
 ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,4 +6,4 @@
 # so that builds are reproducible.
 channel = "nightly-2024-08-21"
 # These components are required to use `rustc` crates.
-components = ["rustc-dev", "llvm-tools-preview"]
+components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,4 +6,4 @@
 # so that builds are reproducible.
 channel = "nightly-2024-08-21"
 # These components are required to use `rustc` crates.
-components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
+components = ["rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
I got bit by this when trying to build the CLI for the first time. Apparently, there's [a bug](https://github.com/rust-lang/rustup/issues/3255) in `rustup` that causes components to not be installed when nightly is selected. Fortunately, installing them manually works just fine, so I added instructions for it to the README.