### PR TITLE
Small changes to manual component installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The Bevy CLI includes a [custom linter](bevy_lint) that integrates directly with
 
 However, some components may be still missing due to a [`rustup` bug](https://github.com/rust-lang/rustup/issues/3255). If you get `can't find crate` errors when trying to build, run the following commands to manually add the required components:
 
-```
-rustup component add rustc-dev llvm-tools-preview
-rustup component add --toolchain nightly rustc-dev llvm-tools-preview
+```bash
+rustup component add --toolchain nightly-2024-08-21 rustc-dev llvm-tools-preview
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Bevy CLI tool.
 
 ## Nightly Rust
 
-The Bevy CLI includes a [custom linter](bevy_lint) that integrates directly with `rustc` through [`#![feature(rustc_private)]`](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html).Because of this, building this project requires nightly Rust with the `rustc-dev` component. If you use Rustup, a pinned version will be automatically installed when you compile this project based on the contents of [`rust-toolchain.toml`](rust-toolchain.toml).
+The Bevy CLI includes a [custom linter](bevy_lint) that integrates directly with `rustc` through [`#![feature(rustc_private)]`](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html). Because of this, building this project requires nightly Rust with the `rustc-dev` component. If you use Rustup, a pinned version will be automatically installed when you compile this project based on the contents of [`rust-toolchain.toml`](rust-toolchain.toml).
 
 However, some components may be still missing due to a [`rustup` bug](https://github.com/rust-lang/rustup/issues/3255). If you get `can't find crate` errors when trying to build, run the following commands to manually add the required components:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
-# If you modify this file, please also update `RUST_TOOLCHAIN` in `.github/workflows/ci.yml` and
-# the `clippy_utils` version in `bevy_lint/Cargo.toml`.
+# If you modify this file, please also update `RUST_TOOLCHAIN` in `.github/workflows/ci.yml`, the
+# `clippy_utils` version in `bevy_lint/Cargo.toml`, and the toolchain in `README.md`.
 
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version


### PR DESCRIPTION
I caught a few things after #28 was merged, so this implements them. I modified the component installation command to target the specific nightly version that we have pinned, since that should be the only toolchain that should matter.