### PR TITLE
Add wrapper for rustup command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "anyhow",
  "cargo-generate",
  "clap",
+ "dialoguer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ anyhow = "1.0.86"
 
 # Generates new Bevy projects from templates
 cargo-generate = "0.21.3"
+dialoguer = { version = "0.11.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,6 @@ anyhow = "1.0.86"
 
 # Generates new Bevy projects from templates
 cargo-generate = "0.21.3"
+
+# Better CLI user input
 dialoguer = { version = "0.11.0", default-features = false }

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -1,0 +1,3 @@
+//! Wrappers and utilities to deal with external CLI applications, like `cargo`.
+
+pub(crate) mod rustup;

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -23,18 +23,17 @@ fn is_target_installed(target: &str) -> bool {
 }
 
 /// Install a compilation target, if it is not already installed.
-pub(crate) fn install_target_if_needed(target: &str, ask_user: bool) -> anyhow::Result<()> {
+pub(crate) fn install_target_if_needed(target: &str) -> anyhow::Result<()> {
     if is_target_installed(target) {
         return Ok(());
     }
 
     // Abort if the user doesn't want to install it
-    if ask_user
-        && !Confirm::new()
-            .with_prompt(format!(
-                "Compilation target `{target}` is missing, should I install it for you?",
-            ))
-            .interact()?
+    if !Confirm::new()
+        .with_prompt(format!(
+            "Compilation target `{target}` is missing, should I install it for you?",
+        ))
+        .interact()?
     {
         exit(1);
     }

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -2,15 +2,18 @@
 
 #![expect(dead_code, reason = "Will be used for build/run commands")]
 
-use std::process::Command;
+use std::{env, ffi::OsString, process::Command};
 
 use dialoguer::Confirm;
 
-const PROGRAM: &str = "rustup";
+/// The rustup command can be customized via the `BEVY_CLI_RUSTUP` env
+fn program() -> OsString {
+    env::var_os("BEVY_CLI_RUSTUP").unwrap_or("rustup".into())
+}
 
 /// Given a target triple, determine if it is already installed.
 fn is_target_installed(target: &str) -> bool {
-    let output = Command::new(PROGRAM).arg("target").arg("list").output();
+    let output = Command::new(program()).arg("target").arg("list").output();
 
     // Check if the target list has an entry like this:
     // <target_triple> (installed)
@@ -36,7 +39,7 @@ pub(crate) fn install_target_if_needed(target: &str) -> anyhow::Result<()> {
         anyhow::bail!("User does not want to install target `{target}`.");
     }
 
-    let mut cmd = Command::new(PROGRAM);
+    let mut cmd = Command::new(program());
     cmd.arg("target").arg("add").arg(target);
 
     anyhow::ensure!(

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -15,9 +15,7 @@ fn is_target_installed(target: &str) -> bool {
     // Check if the target list has an entry like this:
     // <target_triple> (installed)
     let Ok(output) = output else { return false };
-    let Ok(list) = String::from_utf8(output.stdout) else {
-        return false;
-    };
+    let list = String::from_utf8_lossy(&output.stdout);
     list.lines()
         .any(|line| line.contains(target) && line.contains("(installed)"))
 }

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -41,9 +41,9 @@ pub(crate) fn install_target_if_needed(target: &str) -> anyhow::Result<()> {
     let mut cmd = Command::new(PROGRAM);
     cmd.arg("target").arg("add").arg(target);
 
-    if !cmd.output()?.status.success() {
-        Err(anyhow::anyhow!("Failed to install target `{}`.", target))
-    } else {
-        Ok(())
-    }
+    anyhow::ensure!(
+        cmd.output()?.status.success(),
+        "Failed to install target `{target}`."
+    );
+    Ok(())
 }

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -14,17 +14,12 @@ fn is_target_installed(target: &str) -> bool {
 
     // Check if the target list has an entry like this:
     // <target_triple> (installed)
-    if let Ok(output) = output {
-        if let Ok(list) = String::from_utf8(output.stdout) {
-            for line in list.lines() {
-                if line.contains(target) && line.contains("(installed)") {
-                    return true;
-                }
-            }
-        }
-    }
-
-    false
+    let Ok(output) = output else { return false };
+    let Ok(list) = String::from_utf8(output.stdout) else {
+        return false;
+    };
+    list.lines()
+        .any(|line| line.contains(target) && line.contains("(installed)"))
 }
 
 /// Install a compilation target, if it is not already installed.

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -1,0 +1,55 @@
+//! Utilities for the `rustup` CLI tool.
+
+#![expect(dead_code, reason = "Will be used for build/run commands")]
+
+use std::process::{exit, Command};
+
+use dialoguer::Confirm;
+
+const PROGRAM: &str = "rustup";
+
+/// Given a target triple, determine if it is already installed.
+fn is_target_installed(target: &str) -> bool {
+    let output = Command::new(PROGRAM).arg("target").arg("list").output();
+
+    // Check if the target list has an entry like this:
+    // <target_triple> (installed)
+    if let Ok(output) = output {
+        if let Ok(list) = String::from_utf8(output.stdout) {
+            for line in list.lines() {
+                if line.contains(target) && line.contains("(installed)") {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Install a compilation target, if it is not already installed.
+pub(crate) fn install_target_if_needed(target: &str, ask_user: bool) -> anyhow::Result<()> {
+    if is_target_installed(target) {
+        return Ok(());
+    }
+
+    // Abort if the user doesn't want to install it
+    if ask_user
+        && !Confirm::new()
+            .with_prompt(format!(
+                "Compilation target `{target}` is missing, should I install it for you?",
+            ))
+            .interact()?
+    {
+        exit(1);
+    }
+
+    let mut cmd = Command::new(PROGRAM);
+    cmd.arg("target").arg("add").arg(target);
+
+    if !cmd.output()?.status.success() {
+        Err(anyhow::anyhow!("Failed to install target `{}`.", target))
+    } else {
+        Ok(())
+    }
+}

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -2,7 +2,7 @@
 
 #![expect(dead_code, reason = "Will be used for build/run commands")]
 
-use std::process::{exit, Command};
+use std::process::Command;
 
 use dialoguer::Confirm;
 
@@ -33,7 +33,7 @@ pub(crate) fn install_target_if_needed(target: &str) -> anyhow::Result<()> {
         ))
         .interact()?
     {
-        exit(1);
+        anyhow::bail!("User does not want to install target `{target}`.");
     }
 
     let mut cmd = Command::new(PROGRAM);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! The library backend for the Bevy CLI.
 
+pub mod external_cli;
 pub mod lint;
 pub mod template;


### PR DESCRIPTION
For targeting the web, the user might need to install the WASM targets.
This PR adds utilities to make this easier