### PR TITLE
Add wrapper for wasm_bindgen CLI

### DIFF
--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod arg_builder;
 pub(crate) mod rustup;
+pub(crate) mod wasm_bindgen;

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -8,14 +8,13 @@ pub(crate) const PACKAGE: &str = "wasm-bindgen-cli";
 pub(crate) const PROGRAM: &str = "wasm-bindgen";
 
 /// Determine the path to the folder where the Wasm build artifacts are stored.
-pub(crate) fn get_target_folder(is_release: bool) -> String {
-    let profile = if is_release { "release" } else { "debug" };
+pub(crate) fn get_target_folder(profile: &str) -> String {
     format!("target/wasm32-unknown-unknown/{profile}")
 }
 
 /// Bundle the Wasm build for the web.
-pub(crate) fn bundle(package_name: &str, is_release: bool) -> anyhow::Result<()> {
-    let target_folder = get_target_folder(is_release);
+pub(crate) fn bundle(package_name: &str, profile: &str) -> anyhow::Result<()> {
+    let target_folder = get_target_folder(profile);
 
     let status = Command::new(PROGRAM)
         .args(

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -7,13 +7,13 @@ use super::arg_builder::ArgBuilder;
 pub(crate) const PACKAGE: &str = "wasm-bindgen-cli";
 pub(crate) const PROGRAM: &str = "wasm-bindgen";
 
-/// Determine the path to the folder where the WASM build artifacts are stored.
+/// Determine the path to the folder where the Wasm build artifacts are stored.
 pub(crate) fn get_target_folder(is_release: bool) -> String {
     let profile = if is_release { "release" } else { "debug" };
     format!("target/wasm32-unknown-unknown/{profile}")
 }
 
-/// Bundle the WASM build for the web.
+/// Bundle the Wasm build for the web.
 pub(crate) fn bundle(package_name: &str, is_release: bool) -> anyhow::Result<()> {
     let target_folder = get_target_folder(is_release);
 

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -1,0 +1,33 @@
+#![expect(dead_code, reason = "Will be used for the build/run commands")]
+
+use std::process::Command;
+
+use super::arg_builder::ArgBuilder;
+
+pub(crate) const PACKAGE: &str = "wasm-bindgen-cli";
+pub(crate) const PROGRAM: &str = "wasm-bindgen";
+
+/// Determine the path to the folder where the WASM build artifacts are stored.
+pub(crate) fn get_target_folder(is_release: bool) -> String {
+    let profile = if is_release { "release" } else { "debug" };
+    format!("target/wasm32-unknown-unknown/{profile}")
+}
+
+/// Bundle the WASM build for the web.
+pub(crate) fn bundle(package_name: &str, is_release: bool) -> anyhow::Result<()> {
+    let target_folder = get_target_folder(is_release);
+
+    let status = Command::new(PROGRAM)
+        .args(
+            ArgBuilder::new()
+                .arg("--no-typescript")
+                .add_with_value("--out-name", "bevy_app")
+                .add_with_value("--out-dir", &target_folder)
+                .add_with_value("--target", "web")
+                .arg(format!("{target_folder}/{package_name}.wasm")),
+        )
+        .status()?;
+
+    anyhow::ensure!(status.success(), "Failed to bundle project for the web.");
+    Ok(())
+}


### PR DESCRIPTION
Further work towards #24 

`wasm_bindgen` is used to generate JS bindings for the WASM executable.