### PR TITLE
Add lint: `bevy::main_return_without_appexit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "accesskit"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf780eb737f2d4a49ffbd512324d53ad089070f813f7be7f99dbd5123a7f448"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +39,18 @@ checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
 dependencies = [
  "as-slice",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
 
 [[package]]
 name = "anstream"
@@ -111,6 +129,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "auth-git2"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +165,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "bevy"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043c9ad4b6fc4ca52d779873a8ca792a4e37842d07fce95363c9e17e36a1d8a0"
+dependencies = [
+ "bevy_internal",
+]
+
+[[package]]
+name = "bevy_a11y"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a976cb539d6a5a3ff579cdb78187a6bcfbffa7e8224ea28f23d8b983d9389"
+dependencies = [
+ "accesskit",
+ "bevy_app",
+ "bevy_derive",
+ "bevy_ecs",
+]
+
+[[package]]
+name = "bevy_app"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5361d0f8a8677a5d0102cfe7321a7ecd2a8b9a4f887ce0dde1059311cf9cd42"
+dependencies = [
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
+ "console_error_panic_hook",
+ "downcast-rs",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "bevy_cli"
 version = "0.1.0-dev"
 dependencies = [
@@ -137,11 +213,297 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de706862871a1fe99ea619bff2f99d73e43ad82f19ef866a9e19a14c957c8537"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_derive"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbfc33a4c6b80760bb8bf850a2cc65a1e031da62fd3ca8b552189104dc98514"
+dependencies = [
+ "bevy_macro_utils",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_diagnostic"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebb154e0cc78e3bbfbfdb42fb502b14c1cd47e72f16e6d4228dfe6233ba6cbd"
+dependencies = [
+ "bevy_app",
+ "bevy_core",
+ "bevy_ecs",
+ "bevy_tasks",
+ "bevy_time",
+ "bevy_utils",
+ "const-fnv1a-hash",
+]
+
+[[package]]
+name = "bevy_ecs"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee4222406637f3c8e3991a99788cfcde76097bf997c311f1b6297364057483f"
+dependencies = [
+ "bevy_ecs_macros",
+ "bevy_ptr",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
+ "bitflags 2.6.0",
+ "concurrent-queue",
+ "fixedbitset 0.5.7",
+ "nonmax",
+ "petgraph",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "bevy_ecs_macros"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b573430b67aff7bde8292257494f39343401379bfbda64035ba4918bba7b20"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_hierarchy"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b912b37e1bc4dbb2aa40723199f74c8b06c4fbb6da0bb4585131df28ef66e"
+dependencies = [
+ "bevy_app",
+ "bevy_core",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_utils",
+ "smallvec",
+]
+
+[[package]]
+name = "bevy_input"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd3a54e67cc3ba17971de7b1a7e64eda84493c1e7bb6bfa11c6cf8ac124377b"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_utils",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
+name = "bevy_internal"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d435cac77c568f3aef65f786a5fee0e53c81950c5258182dd2c1d6cd6c4fec"
+dependencies = [
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_core",
+ "bevy_derive",
+ "bevy_diagnostic",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_input",
+ "bevy_log",
+ "bevy_math",
+ "bevy_ptr",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+]
+
+[[package]]
 name = "bevy_lint"
 version = "0.1.0-dev"
 dependencies = [
  "anyhow",
+ "bevy",
  "clippy_utils",
+]
+
+[[package]]
+name = "bevy_log"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67240c7596c8f0653e50fce35a60196516817449235193246599facba9002e02"
+dependencies = [
+ "android_log-sys",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_utils",
+ "tracing-log",
+ "tracing-subscriber",
+ "tracing-wasm",
+]
+
+[[package]]
+name = "bevy_macro_utils"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc65e570012e64a21f3546df68591aaede8349e6174fb500071677f54f06630"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "toml_edit 0.22.20",
+]
+
+[[package]]
+name = "bevy_math"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5421792749dda753ab3718e77d27bfce38443daf1850b836b97530b6245a4581"
+dependencies = [
+ "bevy_reflect",
+ "glam",
+ "rand",
+ "serde",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "bevy_ptr"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61baa1bdc1f4a7ac2c18217570a7cc04e1cd54d38456e91782f0371c79afe0a8"
+
+[[package]]
+name = "bevy_reflect"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2508785a4a5809f25a237eec4fee2c91a4dbcf81324b2bbc2d6c52629e603781"
+dependencies = [
+ "bevy_ptr",
+ "bevy_reflect_derive",
+ "bevy_utils",
+ "downcast-rs",
+ "erased-serde",
+ "glam",
+ "serde",
+ "smallvec",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
+name = "bevy_reflect_derive"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "967d5da1882ec3bb3675353915d3da909cafac033cbf31e58727824a1ad2a288"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_tasks"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77865f310b1fc48fb05b7c4adbe76607ec01d0c14f8ab4caba4d714c86439946"
+dependencies = [
+ "async-executor",
+ "futures-lite",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "bevy_time"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e4d53ec32a1b16492396951d04de0d2d90e924bf9adcb8d1adacab5ab6c17c"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_utils",
+ "crossbeam-channel",
+ "thiserror",
+]
+
+[[package]]
+name = "bevy_transform"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5493dce84427d00a9266e8e4386d738a72ee8640423b62dfcecb6dfccbfe0d2"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_math",
+ "bevy_reflect",
+ "thiserror",
+]
+
+[[package]]
+name = "bevy_utils"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb0ec333b5965771153bd746f92ffd8aeeb9d008a8620ffd9ed474859381a5e"
+dependencies = [
+ "ahash",
+ "bevy_utils_proc_macros",
+ "getrandom",
+ "hashbrown",
+ "thread_local",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "bevy_utils_proc_macros"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f1ab8f2f6f58439d260081d89a42b02690e5fdd64f814edc9417d33fcf2857"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_window"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e88a20db64ea8204540afb4699295947c454738fd50293f7b32ab8be857a6"
+dependencies = [
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_utils",
+ "raw-window-handle",
+ "smol_str",
 ]
 
 [[package]]
@@ -172,9 +534,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.7",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytemuck"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "byteorder"
@@ -316,6 +690,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +710,22 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "const-fnv1a-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "const-random"
@@ -355,6 +754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -467,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +922,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +952,18 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "form_urlencoded"
@@ -562,6 +998,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,8 +1039,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -822,6 +1285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+dependencies = [
+ "bytemuck",
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,8 +1304,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -839,6 +1313,11 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -881,7 +1360,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.7",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -957,6 +1436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1111,6 +1599,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,12 +1644,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "normpath"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1214,6 +1727,18 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1314,6 +1839,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1936,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,8 +1969,17 @@ checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1434,8 +1990,14 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1589,6 +2151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +2170,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -1615,6 +2195,15 @@ dependencies = [
  "autocfg",
  "static_assertions",
  "version_check",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1702,6 +2291,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1822,6 +2421,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2567,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,6 +2608,93 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -15,6 +15,7 @@ name = "bevy_lint_driver"
 path = "src/bin/driver.rs"
 
 [dependencies]
+# Easy error propagation and contexts
 anyhow = "1.0.86"
 
 # Contains a series of useful utilities when writing lints. The version and commit were chosen to
@@ -24,6 +25,10 @@ anyhow = "1.0.86"
 version = "=0.1.82"
 git = "https://github.com/rust-lang/rust-clippy"
 rev = "e8ac4ea4187498052849531b86114a1eec5314a1"
+
+[dev-dependencies]
+# Used to test lints that need Bevy's types
+bevy = { version = "0.14.2", default-features = false }
 
 [package.metadata.rust-analyzer]
 # Enables Rust-Analyzer support for `rustc` crates.

--- a/bevy_lint/src/callback.rs
+++ b/bevy_lint/src/callback.rs
@@ -16,10 +16,7 @@ impl Callbacks for BevyLintCallback {
             }
 
             store.register_lints(crate::lints::LINTS);
-
-            store.register_late_pass(|_| {
-                Box::new(crate::lints::main_return_without_appexit::MainReturnWithoutAppExit)
-            });
+            crate::lints::register_passes(store);
         }));
     }
 }

--- a/bevy_lint/src/callback.rs
+++ b/bevy_lint/src/callback.rs
@@ -14,6 +14,8 @@ impl Callbacks for BevyLintCallback {
             if let Some(previous) = &previous {
                 (previous)(session, store);
             }
+
+            store.register_lints(crate::lints::LINTS);
         }));
     }
 }

--- a/bevy_lint/src/callback.rs
+++ b/bevy_lint/src/callback.rs
@@ -16,6 +16,10 @@ impl Callbacks for BevyLintCallback {
             }
 
             store.register_lints(crate::lints::LINTS);
+
+            store.register_late_pass(|_| {
+                Box::new(crate::lints::main_return_without_appexit::MainReturnWithoutAppExit)
+            });
         }));
     }
 }

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -6,6 +6,7 @@
 // This is a list of every single `rustc` crate used within this library. If you need another, add
 // it here!
 extern crate rustc_driver;
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_interface;
 extern crate rustc_lint;

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -6,7 +6,6 @@
 // This is a list of every single `rustc` crate used within this library. If you need another, add
 // it here!
 extern crate rustc_driver;
-extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_interface;
 extern crate rustc_lint;

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -1,11 +1,15 @@
 // Enables linking to `rustc` crates.
 #![feature(rustc_private)]
+// Allows chaining `if let` multiple times using `&&`.
+#![feature(let_chains)]
 
 // This is a list of every single `rustc` crate used within this library. If you need another, add
 // it here!
 extern crate rustc_driver;
+extern crate rustc_hir;
 extern crate rustc_interface;
 extern crate rustc_lint;
+extern crate rustc_span;
 
 mod callback;
 pub mod lints;

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -9,6 +9,7 @@ extern crate rustc_driver;
 extern crate rustc_hir;
 extern crate rustc_interface;
 extern crate rustc_lint;
+extern crate rustc_session;
 extern crate rustc_span;
 
 mod callback;

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -5,7 +5,9 @@
 // it here!
 extern crate rustc_driver;
 extern crate rustc_interface;
+extern crate rustc_lint;
 
 mod callback;
+pub mod lints;
 
 pub use self::callback::BevyLintCallback;

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -15,6 +15,6 @@ extern crate rustc_span;
 
 mod callback;
 pub mod lints;
-pub mod paths;
+mod paths;
 
 pub use self::callback::BevyLintCallback;

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -15,5 +15,6 @@ extern crate rustc_span;
 
 mod callback;
 pub mod lints;
+pub mod paths;
 
 pub use self::callback::BevyLintCallback;

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -31,9 +31,8 @@
 //! ```
 
 use clippy_utils::{
-    diagnostics::span_lint_and_then, is_entrypoint_fn, sym, ty::match_type, visitors::for_each_expr,
+    diagnostics::span_lint, is_entrypoint_fn, sym, ty::match_type, visitors::for_each_expr,
 };
-use rustc_errors::Applicability;
 use rustc_hir::{
     def_id::LocalDefId, intravisit::FnKind, Body, Expr, ExprKind, FnDecl, FnRetTy, Ty, TyKind,
 };
@@ -62,37 +61,27 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
         _: Span,
         local_def_id: LocalDefId,
     ) {
-        // Only check `fn main()`.
-        if is_entrypoint_fn(cx, local_def_id.into()) {
+        // Look for `fn main()`.
+        if is_entrypoint_fn(cx, local_def_id.into())
             // Ensure the function either returns nothing or the unit type. If the entrypoint
             // returns something else, we're assuming that the user knows what they're doing.
-            // Additionally, we collect the span of the return position for better diagnostics.
-            let fn_return_span = match declaration.output {
+            && match declaration.output {
                 // The function signature is the default `fn main()`.
-                FnRetTy::DefaultReturn(span) => span,
+                FnRetTy::DefaultReturn(_) => true,
                 // The function signature is `fn main() -> ()`.
-                FnRetTy::Return(&Ty {
-                    kind: TyKind::Tup(&[]),
-                    span,
-                    ..
-                }) => span,
-                // The function returns something else, exit early.
-                _ => return,
-            };
-
+                FnRetTy::Return(&Ty { kind: TyKind::Tup(&[]), .. }) => {true},
+                _ => false,
+            }
+        {
             // Iterate over each expression within the entrypoint function, finding and reporting
             // `App::run()` calls.
-            for_each_expr(cx, body, |expr| find_app_run_call(cx, expr, fn_return_span));
+            for_each_expr(cx, body, |expr| find_app_run_call(cx, expr));
         }
     }
 }
 
 /// Finds expressions that call `App::run()` and emits [`MAIN_RETURN_WITHOUT_APPEXIT`].
-fn find_app_run_call<'tcx>(
-    cx: &LateContext<'tcx>,
-    expr: &Expr<'tcx>,
-    fn_return_span: Span,
-) -> ControlFlow<()> {
+fn find_app_run_call<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) -> ControlFlow<()> {
     // Find a method call that matches `.run()`.
     if let ExprKind::MethodCall(path, src, _, span) = expr.kind
         && path.ident.name == sym!(run)
@@ -102,19 +91,11 @@ fn find_app_run_call<'tcx>(
 
         // If `src` is a Bevy `App`, emit the lint.
         if match_type(cx, ty, &["bevy_app", "app", "App"]) {
-            span_lint_and_then(
+            span_lint(
                 cx,
                 MAIN_RETURN_WITHOUT_APPEXIT,
                 span,
                 MAIN_RETURN_WITHOUT_APPEXIT.desc,
-                |diag| {
-                    diag.span_suggestion(
-                        fn_return_span,
-                        "try",
-                        "-> AppExit",
-                        Applicability::MaybeIncorrect,
-                    );
-                },
             );
         }
     }

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -31,8 +31,7 @@
 //! ```
 
 use clippy_utils::{
-    diagnostics::span_lint_and_then, is_entrypoint_fn, peel_middle_ty_refs, sym, ty::match_type,
-    visitors::for_each_expr,
+    diagnostics::span_lint_and_then, is_entrypoint_fn, sym, ty::match_type, visitors::for_each_expr,
 };
 use rustc_errors::Applicability;
 use rustc_hir::{
@@ -84,7 +83,7 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
                 {
                     // Get the type of `src` for `src.run()`. We peel away all references because
                     // both `App` and `&mut App` are allowed.
-                    let ty = peel_middle_ty_refs(cx.typeck_results().expr_ty(src)).0;
+                    let ty = cx.typeck_results().expr_ty(src).peel_refs();
 
                     // If `src` is a Bevy `App`, emit the lint.
                     if match_type(cx, ty, &crate::paths::APP) {

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -2,31 +2,19 @@ use clippy_utils::{
     diagnostics::span_lint, is_entrypoint_fn, sym, ty::match_type, visitors::for_each_expr,
 };
 use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, Expr, ExprKind, FnDecl, FnRetTy};
-use rustc_lint::{LateContext, LateLintPass, Level, Lint, LintPass, LintVec};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::Span;
 use std::ops::ControlFlow;
 
-pub static MAIN_RETURN_WITHOUT_APPEXIT: &Lint = &Lint {
-    name: "bevy::main_return_without_appexit",
-    default_level: Level::Warn,
-    desc: "an entrypoint that calls `App::run()` does not return `AppExit`",
-    is_externally_loaded: true,
-    ..Lint::default_fields_for_macro()
-};
-
-#[derive(Clone, Copy, Debug)]
-pub struct MainReturnWithoutAppExit;
-
-impl LintPass for MainReturnWithoutAppExit {
-    fn name(&self) -> &'static str {
-        MAIN_RETURN_WITHOUT_APPEXIT.name
-    }
+declare_tool_lint! {
+    pub bevy::MAIN_RETURN_WITHOUT_APPEXIT,
+    Warn,
+    "an entrypoint that calls `App::run()` does not return `AppExit`"
 }
 
-impl MainReturnWithoutAppExit {
-    pub fn get_lints() -> LintVec {
-        vec![MAIN_RETURN_WITHOUT_APPEXIT]
-    }
+declare_lint_pass! {
+    MainReturnWithoutAppExit => [MAIN_RETURN_WITHOUT_APPEXIT]
 }
 
 impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -66,12 +66,13 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
         if is_entrypoint_fn(cx, local_def_id.into())
             // Ensure the function either returns nothing or the unit type. If the entrypoint
             // returns something else, we're assuming that the user knows what they're doing.
-            && match declaration.output {
+            && matches!(
+                declaration.output,
                 // The function signature is the default `fn main()`.
-                FnRetTy::DefaultReturn(_) => true,
+                FnRetTy::DefaultReturn(..) | 
                 // The function signature is `fn main() -> ()`.
-                FnRetTy::Return(&Ty { kind: TyKind::Tup(&[]), .. }) => true,
-                _ => false,
+                FnRetTy::Return(&Ty { kind: TyKind::Tup(&[]), .. })
+            )
             }
         {
             // Iterate over each expression within the entrypoint function, finding and reporting

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -85,7 +85,7 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
                     let ty = cx.typeck_results().expr_ty(src);
 
                     // If `src` is a Bevy `App`, emit the lint.
-                    if match_type(cx, ty, &["bevy_app", "app", "App"]) {
+                    if match_type(cx, ty, &crate::paths::APP) {
                         span_lint_and_then(
                             cx,
                             MAIN_RETURN_WITHOUT_APPEXIT,

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -69,11 +69,10 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
             && matches!(
                 declaration.output,
                 // The function signature is the default `fn main()`.
-                FnRetTy::DefaultReturn(..) | 
+                FnRetTy::DefaultReturn(..)
                 // The function signature is `fn main() -> ()`.
-                FnRetTy::Return(&Ty { kind: TyKind::Tup(&[]), .. })
+                | FnRetTy::Return(&Ty { kind: TyKind::Tup(&[]), .. })
             )
-            }
         {
             // Iterate over each expression within the entrypoint function, finding and reporting
             // `App::run()` calls.

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -1,5 +1,6 @@
-use clippy_utils::{diagnostics::span_lint, is_entrypoint_fn};
-use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, FnDecl, FnRetTy};
+use std::ops::ControlFlow;
+use clippy_utils::{diagnostics::span_lint, is_entrypoint_fn, match_def_path, sym, visitors::for_each_expr};
+use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, Expr, ExprKind, FnDecl, FnRetTy};
 use rustc_lint::{LateContext, LateLintPass, Level, Lint, LintPass, LintVec};
 use rustc_span::Span;
 
@@ -32,14 +33,39 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
         cx: &LateContext<'tcx>,
         _: FnKind<'tcx>,
         declaration: &'tcx FnDecl<'tcx>,
-        _: &'tcx Body<'tcx>,
+        body: &'tcx Body<'tcx>,
         _: Span,
         local_def_id: LocalDefId,
     ) {
         // We're looking for `fn main()` with no return type that calls `App::run()`.
         if is_entrypoint_fn(cx, local_def_id.into())
-            && let FnRetTy::DefaultReturn(return_span) = declaration.output {
-            span_lint(cx, MAIN_RETURN_WITHOUT_APPEXIT, return_span, "AAAA!");
+            && let FnRetTy::DefaultReturn(_) = declaration.output
+        {
+            // Iterate over each expression within the entrypoint function, finding and reporting
+            // `App::run()` calls.
+            for_each_expr(cx, body, |expr| find_app_run_call(cx, expr));
         }
     }
+}
+
+fn find_app_run_call<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) -> ControlFlow<()> {
+    // Find a method call that matches `.run()`.
+    if let ExprKind::MethodCall(path, src, _, span) = expr.kind
+        && path.ident.name == sym!(run)
+    {
+        // Get the type of `src` for `src.run()`.
+        let ty = cx.typeck_results().expr_ty(src);
+
+        // May not be necessary if `match_ty` is used instead.
+        let Some(adt) = ty.ty_adt_def() else {
+            return ControlFlow::Continue(());
+        };
+
+        // Syms may be incorrect.
+        if match_def_path(cx, adt.did(), &["bevy", "prelude", "App"]) {
+            span_lint(cx, MAIN_RETURN_WITHOUT_APPEXIT, span, "AAA!!");
+        }
+    }
+
+    ControlFlow::Continue(())
 }

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -1,0 +1,45 @@
+use clippy_utils::{diagnostics::span_lint, is_entrypoint_fn};
+use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, FnDecl, FnRetTy};
+use rustc_lint::{LateContext, LateLintPass, Level, Lint, LintPass, LintVec};
+use rustc_span::Span;
+
+pub static MAIN_RETURN_WITHOUT_APPEXIT: &Lint = &Lint {
+    name: "bevy::main_return_without_appexit",
+    default_level: Level::Warn,
+    desc: "an entrypoint that calls `App::run()` does not return `AppExit`",
+    is_externally_loaded: true,
+    ..Lint::default_fields_for_macro()
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct MainReturnWithoutAppExit;
+
+impl LintPass for MainReturnWithoutAppExit {
+    fn name(&self) -> &'static str {
+        MAIN_RETURN_WITHOUT_APPEXIT.name
+    }
+}
+
+impl MainReturnWithoutAppExit {
+    pub fn get_lints() -> LintVec {
+        vec![MAIN_RETURN_WITHOUT_APPEXIT]
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: FnKind<'tcx>,
+        declaration: &'tcx FnDecl<'tcx>,
+        _: &'tcx Body<'tcx>,
+        _: Span,
+        local_def_id: LocalDefId,
+    ) {
+        // We're looking for `fn main()` with no return type that calls `App::run()`.
+        if is_entrypoint_fn(cx, local_def_id.into())
+            && let FnRetTy::DefaultReturn(return_span) = declaration.output {
+            span_lint(cx, MAIN_RETURN_WITHOUT_APPEXIT, return_span, "AAAA!");
+        }
+    }
+}

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -1,3 +1,32 @@
+//! Checks for `fn main()` entrypoints that call `App::run()` but do not return `AppExit`.
+//!
+//! # Why is this bad?
+//!
+//! `AppExit` is used to determine whether the `App` exited successful or due to an error. Returning
+//! it from `main()` will set the exit code, which allows external processes to detect whether there
+//! was an error.
+//!
+//! # Example
+//!
+//! ```rust
+//! # use bevy::prelude::*;
+//! #
+//! fn main() {
+//!     App::new().run();
+//! }
+//! ```
+//!
+//! Use instead:
+//!
+//! ```rust
+//! # use bevy::prelude::*;
+//! #
+//! fn main() -> AppExit {
+//!     // Note the removed semicolon.
+//!     App::new().run()
+//! }
+//! ```
+
 use clippy_utils::{
     diagnostics::span_lint, is_entrypoint_fn, sym, ty::match_type, visitors::for_each_expr,
 };

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -15,4 +15,8 @@ macro_rules! define_lints {
     };
 }
 
-define_lints! {}
+define_lints! {
+    mod main_return_without_appexit {
+        lint: MAIN_RETURN_WITHOUT_APPEXIT,
+    }
+}

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -1,0 +1,16 @@
+macro_rules! define_lints {
+    {
+        $(mod $module:ident {
+            lints: [$($lint:ident),+],
+            passes: [],
+        })*
+    } => {
+        // Declare all modules as private.
+        $(mod $module;)*
+
+        // Re-export all lint definitions.
+        $(pub use self::$module::{$($lint),*};)*
+    };
+}
+
+define_lints! {}

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -3,18 +3,14 @@ use rustc_lint::Lint;
 macro_rules! define_lints {
     {
         $(mod $module:ident {
-            lints: [$($lint:ident),+],
-            passes: [],
+            lint: $lint:ident$(,)?
         })*
     } => {
         // Declare all modules as private.
-        $(mod $module;)*
-
-        // Re-export all lint definitions.
-        $(pub use self::$module::{$($lint),*};)*
+        $(pub mod $module;)*
 
         pub static LINTS: &[&Lint] = &[
-            $($(self::$module::$lint)*,)*
+            $(self::$module::$lint,)*
         ];
     };
 }

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -1,22 +1,5 @@
 use rustc_lint::Lint;
 
-macro_rules! define_lints {
-    {
-        $(mod $module:ident {
-            lint: $lint:ident$(,)?
-        })*
-    } => {
-        // Declare all modules as private.
-        $(pub mod $module;)*
+pub mod main_return_without_appexit;
 
-        pub static LINTS: &[&Lint] = &[
-            $(self::$module::$lint,)*
-        ];
-    };
-}
-
-define_lints! {
-    mod main_return_without_appexit {
-        lint: MAIN_RETURN_WITHOUT_APPEXIT,
-    }
-}
+pub static LINTS: &[&Lint] = &[main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT];

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -1,3 +1,5 @@
+use rustc_lint::Lint;
+
 macro_rules! define_lints {
     {
         $(mod $module:ident {
@@ -10,6 +12,10 @@ macro_rules! define_lints {
 
         // Re-export all lint definitions.
         $(pub use self::$module::{$($lint),*};)*
+
+        pub static LINTS: &[&Lint] = &[
+            $($(self::$module::$lint)*,)*
+        ];
     };
 }
 

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -4,6 +4,6 @@ pub mod main_return_without_appexit;
 
 pub static LINTS: &[&Lint] = &[main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT];
 
-pub fn register_passes(store: &mut LintStore) {
+pub(crate) fn register_passes(store: &mut LintStore) {
     store.register_late_pass(|_| Box::new(main_return_without_appexit::MainReturnWithoutAppExit));
 }

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -1,5 +1,9 @@
-use rustc_lint::Lint;
+use rustc_lint::{Lint, LintStore};
 
 pub mod main_return_without_appexit;
 
 pub static LINTS: &[&Lint] = &[main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT];
+
+pub fn register_passes(store: &mut LintStore) {
+    store.register_late_pass(|_| Box::new(main_return_without_appexit::MainReturnWithoutAppExit));
+}

--- a/bevy_lint/src/paths.rs
+++ b/bevy_lint/src/paths.rs
@@ -1,0 +1,9 @@
+//! A collection of hardcoded types and functions that the linter uses.
+//!
+//! Since Bevy is a 3rd-party crate, we cannot easily add diagnostic items to it. In lieu of this,
+//! we hardcode the paths to the items we need here, for easy referencing.
+//!
+//! Also see: [`match_type()`](clippy_utils::ty::match_type),
+//! [`match_def_path()`](clippy_utils::match_def_path).
+
+pub const APP: [&str; 3] = ["bevy_app", "app", "App"];


### PR DESCRIPTION
This is the first lint! Closes #53. Please see the module documentation or [this link](https://hackmd.io/4ciCsSb7SxyqnteFzirEDA?view#main_return_without_appexit) for information about what the lint does.

## Design decisions

- Lint modules are there documentation, and as such are public.
  
  ![image](https://github.com/user-attachments/assets/2626287d-ceab-4743-9f98-0ddbf559d3e0)

- `lints/mod.rs` has the `LINTS` static for `register_passes()` function, so you don't have to remember to touch `BevyLintCallback` each time you add a lint.
- For now, lints are going to be manually added as modules, to `LINTS`, and to `register_passes()`. I tried using a macro, but it was too complicated and not worth it.
- Lints should be declared with the builtin `declare_tool_lint!` and `declare_lint_pass!` macros.

## Current drawbacks

- This lint does not detect if you emit `AppExit` through some other means, such as:

  ```rust
  fn main() {
    let app_exit = App::new().run();
    println!("{app_exit:?}");
  }
  ```

  I found this too complicated for a first lint, so I'm going to create a follow-up issue to tackle this.
- Lints currently do not support be silenced / changing levels. `#[allow(bevy::main_return_without_appexit)]`, `-A bevy::main_return_without_appexit`, and adding `main_return_without_appexit = "allow"` to `Cargo.toml` all fail. This is another follow-up issue.
- I have not created the lint groups yet, so this is not within the `bevy::style` category yet. This is the final follow-up that I know of.

## Testing!

Now for the fun part! Because there are no UI tests (yet), manually paste the following in `bevy_lint/examples/lint_test.rs`:

```rust
use bevy::prelude::*;

fn main() {
    App::new().run();
}
```

Then, run the following:

```bash
cd bevy_lint
cargo build
cargo run -- --example lint_test
```

The outputted warning should look like this:

```bash
warning: an entrypoint that calls `App::run()` does not return `AppExit`
 --> bevy_lint/examples/lint_test.rs:4:16
  |
3 | fn main() {
  |          - help: try: `-> AppExit`
4 |     App::new().run();
  |                ^^^^^
  |
  = note: `App::run()` returns `AppExit`, which can be used to determine whether the app exited successfully or not
  = note: `#[warn(bevy::main_return_without_appexit)]` on by default
```