### PR TITLE
Create lint groups

### DIFF
--- a/bevy_lint/src/callback.rs
+++ b/bevy_lint/src/callback.rs
@@ -15,7 +15,7 @@ impl Callbacks for BevyLintCallback {
                 (previous)(session, store);
             }
 
-            store.register_lints(crate::lints::LINTS);
+            crate::lints::register_lints(store);
             crate::lints::register_passes(store);
         }));
     }

--- a/bevy_lint/src/groups.rs
+++ b/bevy_lint/src/groups.rs
@@ -1,0 +1,66 @@
+use crate::LintGroup;
+use rustc_lint::Level;
+
+/// A group of deny-by-default lints that check for outright wrong or useless code.
+///
+/// These lints are carefully picked to be free of false-positives. You should avoid
+/// `#[allow(...)]`-ing these lints without a _very_ good reason.
+pub static CORRECTNESS: LintGroup = LintGroup {
+    name: "bevy::correctness",
+    level: Level::Deny,
+};
+
+/// A group similar to [`CORRECTNESS`] that checks for suspicious or usually wrong code.
+///
+/// As compared to [`CORRECTNESS`], it may be possible that the linted code may be written
+/// intentionally. Even still, you usually want to fix these lints instead of `#[allow(...)]`-ing
+/// them.
+pub static SUSPICIOUS: LintGroup = LintGroup {
+    name: "bevy::suspicious",
+    level: Level::Warn,
+};
+
+/// A group that offers suggestions on how to simplify your code.
+pub static COMPLEXITY: LintGroup = LintGroup {
+    name: "bevy::complexity",
+    level: Level::Warn,
+};
+
+/// A group that suggests how to increase the performance of your code.
+pub static PERFORMANCE: LintGroup = LintGroup {
+    name: "bevy::performance",
+    level: Level::Warn,
+};
+
+/// A group of lints that encourage idiomatic code.
+///
+/// These lints are opinionated and may be freely disabled if you disagree with their suggestions.
+pub static STYLE: LintGroup = LintGroup {
+    name: "bevy::style",
+    level: Level::Warn,
+};
+
+/// A group of lints that make the linter incredibly nit-picky.
+///
+/// If you enable this group, expect to liberally apply `#[allow(...)]` attributes throughout your
+/// code.
+pub static PEDANTIC: LintGroup = LintGroup {
+    name: "bevy::pedantic",
+    level: Level::Allow,
+};
+
+/// A group of opt-in lints that restrict you from writing certain code.
+///
+/// These are designed for scenarios where you want to increase the consistency of your code-base
+/// and reject certain patterns. They should not all be enabled at once, but instead specific lints
+/// should be individually enabled.
+pub static RESTRICTION: LintGroup = LintGroup {
+    name: "bevy::restriction",
+    level: Level::Allow,
+};
+
+/// A group of unstable lints that may be removed at any time for any reason.
+pub static NURSERY: LintGroup = LintGroup {
+    name: "bevy::nursery",
+    level: Level::Allow,
+};

--- a/bevy_lint/src/groups.rs
+++ b/bevy_lint/src/groups.rs
@@ -3,7 +3,7 @@ use rustc_lint::Level;
 
 /// A group of deny-by-default lints that check for outright wrong or useless code.
 ///
-/// These lints are carefully picked to be free of false-positives. You should avoid
+/// These lints are carefully picked to be free of false positives. You should avoid
 /// `#[allow(...)]`-ing these lints without a _very_ good reason.
 pub static CORRECTNESS: LintGroup = LintGroup {
     name: "bevy::correctness",
@@ -12,9 +12,7 @@ pub static CORRECTNESS: LintGroup = LintGroup {
 
 /// A group similar to [`CORRECTNESS`] that checks for suspicious or usually wrong code.
 ///
-/// As compared to [`CORRECTNESS`], it may be possible that the linted code may be written
-/// intentionally. Even still, you usually want to fix these lints instead of `#[allow(...)]`-ing
-/// them.
+/// The linted code may have been written intentionally, but should probably still be fixed.
 pub static SUSPICIOUS: LintGroup = LintGroup {
     name: "bevy::suspicious",
     level: Level::Warn,

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -16,7 +16,12 @@ extern crate rustc_session;
 extern crate rustc_span;
 
 mod callback;
+pub mod groups;
+mod lint;
 pub mod lints;
 mod paths;
 
-pub use self::callback::BevyLintCallback;
+pub use self::{
+    callback::BevyLintCallback,
+    lint::{BevyLint, LintGroup},
+};

--- a/bevy_lint/src/lint.rs
+++ b/bevy_lint/src/lint.rs
@@ -1,0 +1,47 @@
+use rustc_lint::{Level, Lint};
+
+/// A Bevy lint definition and its associated group.
+///
+/// The level of the lint must be the same as the level of the group.
+pub struct BevyLint {
+    pub lint: &'static Lint,
+    pub group: &'static LintGroup,
+}
+
+/// Represents a lint group.
+pub struct LintGroup {
+    /// The name of the lint group.
+    ///
+    /// This will be used when trying to enable / disable the group, such as through
+    /// `#![allow(group)]`. By convention, this should start with `bevy::`.
+    pub name: &'static str,
+
+    // The default level all lints within this group should be.
+    pub level: Level,
+}
+
+#[macro_export]
+macro_rules! declare_bevy_lint {
+    {
+        $(#[$attr:meta])*
+        $vis:vis $name:ident,
+        $group:ident,
+        $desc:expr
+    } => {
+        $(#[$attr])*
+        $vis static $name: &$crate::lint::BevyLint = &$crate::lint::BevyLint {
+            lint: &::rustc_lint::Lint {
+                name: concat!("bevy::", stringify!($name)),
+                default_level: $crate::groups::$group.level,
+                desc: $desc,
+                edition_lint_opts: None,
+                report_in_external_macro: false,
+                future_incompatible: None,
+                is_externally_loaded: true,
+                feature_gate: None,
+                crate_level_only: false,
+            },
+            group: &$crate::groups::$group,
+        };
+    };
+}

--- a/bevy_lint/src/lint.rs
+++ b/bevy_lint/src/lint.rs
@@ -26,7 +26,7 @@ macro_rules! declare_bevy_lint {
         $(#[$attr:meta])*
         $vis:vis $name:ident,
         $group:ident,
-        $desc:expr
+        $desc:expr$(,)?
     } => {
         $(#[$attr])*
         $vis static $name: &$crate::lint::BevyLint = &$crate::lint::BevyLint {

--- a/bevy_lint/src/lints/insert_event_resource.rs
+++ b/bevy_lint/src/lints/insert_event_resource.rs
@@ -51,7 +51,7 @@ use std::borrow::Cow;
 declare_bevy_lint! {
     pub INSERT_EVENT_RESOURCE,
     SUSPICIOUS,
-    "called `App::insert_resource(Events<T>)` or `App::init_resource::<Events<T>>()` instead of `App::add_event::<T>()`"
+    "called `App::insert_resource(Events<T>)` or `App::init_resource::<Events<T>>()` instead of `App::add_event::<T>()`",
 }
 
 declare_lint_pass! {

--- a/bevy_lint/src/lints/insert_event_resource.rs
+++ b/bevy_lint/src/lints/insert_event_resource.rs
@@ -49,7 +49,7 @@ use std::borrow::Cow;
 
 declare_tool_lint! {
     pub bevy::INSERT_EVENT_RESOURCE,
-    Deny,
+    Warn,
     "called `App::insert_resource(Events<T>)` or `App::init_resource::<Events<T>>()` instead of `App::add_event::<T>()`"
 }
 

--- a/bevy_lint/src/lints/insert_event_resource.rs
+++ b/bevy_lint/src/lints/insert_event_resource.rs
@@ -35,6 +35,7 @@
 //! App::new().add_event::<MyEvent>().run();
 //! ```
 
+use crate::declare_bevy_lint;
 use clippy_utils::{
     diagnostics::span_lint_and_sugg, source::snippet_with_applicability, sym, ty::match_type,
 };
@@ -43,18 +44,18 @@ use rustc_hir::{Expr, ExprKind, GenericArg, GenericArgs, Path, PathSegment, QPat
 use rustc_hir_analysis::lower_ty;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{Ty, TyKind};
-use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_session::declare_lint_pass;
 use rustc_span::Span;
 use std::borrow::Cow;
 
-declare_tool_lint! {
-    pub bevy::INSERT_EVENT_RESOURCE,
-    Warn,
+declare_bevy_lint! {
+    pub INSERT_EVENT_RESOURCE,
+    SUSPICIOUS,
     "called `App::insert_resource(Events<T>)` or `App::init_resource::<Events<T>>()` instead of `App::add_event::<T>()`"
 }
 
 declare_lint_pass! {
-    InsertEventResource => [INSERT_EVENT_RESOURCE]
+    InsertEventResource => [INSERT_EVENT_RESOURCE.lint]
 }
 
 impl<'tcx> LateLintPass<'tcx> for InsertEventResource {
@@ -103,7 +104,7 @@ fn check_insert_resource(cx: &LateContext<'_>, args: &[Expr], method_span: Span)
 
         span_lint_and_sugg(
             cx,
-            INSERT_EVENT_RESOURCE,
+            INSERT_EVENT_RESOURCE.lint,
             method_span,
             "called `App::insert_resource(Events<T>)` instead of `App::add_event::<T>()`",
             "inserting an `Events` resource does not fully setup that event",
@@ -165,7 +166,7 @@ fn check_init_resource<'tcx>(cx: &LateContext<'tcx>, path: &PathSegment<'tcx>, m
 
             span_lint_and_sugg(
                 cx,
-                INSERT_EVENT_RESOURCE,
+                INSERT_EVENT_RESOURCE.lint,
                 method_span,
                 "called `App::init_resource::<Events<T>>()` instead of `App::add_event::<T>()`",
                 "inserting an `Events` resource does not fully setup that event",

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -44,7 +44,7 @@ use std::ops::ControlFlow;
 
 declare_tool_lint! {
     pub bevy::MAIN_RETURN_WITHOUT_APPEXIT,
-    Warn,
+    Allow,
     "an entrypoint that calls `App::run()` does not return `AppExit`"
 }
 

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -30,6 +30,7 @@
 //! }
 //! ```
 
+use crate::declare_bevy_lint;
 use clippy_utils::{
     diagnostics::span_lint_and_then, is_entrypoint_fn, sym, ty::match_type, visitors::for_each_expr,
 };
@@ -38,18 +39,18 @@ use rustc_hir::{
     def_id::LocalDefId, intravisit::FnKind, Body, ExprKind, FnDecl, FnRetTy, Ty, TyKind,
 };
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_session::declare_lint_pass;
 use rustc_span::Span;
 use std::ops::ControlFlow;
 
-declare_tool_lint! {
-    pub bevy::MAIN_RETURN_WITHOUT_APPEXIT,
-    Allow,
+declare_bevy_lint! {
+    pub MAIN_RETURN_WITHOUT_APPEXIT,
+    PEDANTIC,
     "an entrypoint that calls `App::run()` does not return `AppExit`"
 }
 
 declare_lint_pass! {
-    MainReturnWithoutAppExit => [MAIN_RETURN_WITHOUT_APPEXIT]
+    MainReturnWithoutAppExit => [MAIN_RETURN_WITHOUT_APPEXIT.lint]
 }
 
 impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
@@ -89,9 +90,9 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
                     if match_type(cx, ty, &crate::paths::APP) {
                         span_lint_and_then(
                             cx,
-                            MAIN_RETURN_WITHOUT_APPEXIT,
+                            MAIN_RETURN_WITHOUT_APPEXIT.lint,
                             method_span,
-                            MAIN_RETURN_WITHOUT_APPEXIT.desc,
+                            MAIN_RETURN_WITHOUT_APPEXIT.lint.desc,
                             |diag| {
                                 diag.note("`App::run()` returns `AppExit`, which can be used to determine whether the app exited successfully or not");
                                 match declaration.output {

--- a/bevy_lint/src/lints/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/main_return_without_appexit.rs
@@ -46,7 +46,7 @@ use std::ops::ControlFlow;
 declare_bevy_lint! {
     pub MAIN_RETURN_WITHOUT_APPEXIT,
     PEDANTIC,
-    "an entrypoint that calls `App::run()` does not return `AppExit`"
+    "an entrypoint that calls `App::run()` does not return `AppExit`",
 }
 
 declare_lint_pass! {

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -1,71 +1,17 @@
-use rustc_lint::{Lint, LintId, LintStore};
+use crate::BevyLint;
+use rustc_lint::{Lint, LintStore};
 
 pub mod insert_event_resource;
 pub mod main_return_without_appexit;
 
-/// A group of deny-by-default lints that check for outright wrong or useless code.
-///
-/// These lints are carefully picked to be free of false-positives. You should avoid
-/// `#[allow(...)]`-ing these lints without a _very_ good reason.
-pub static CORRECTNESS: &[&Lint] = &[];
-
-/// A group similar to [`CORRECTNESS`] that checks for suspicious or usually wrong code.
-///
-/// As compared to [`CORRECTNESS`], it may be possible that the linted code may be written
-/// intentionally. Even still, you usually want to fix these lints instead of `#[allow(...)]`-ing
-/// them.
-pub static SUSPICIOUS: &[&Lint] = &[insert_event_resource::INSERT_EVENT_RESOURCE];
-
-/// A group that offers suggestions on how to simplify your code.
-pub static COMPLEXITY: &[&Lint] = &[];
-
-/// A group that suggests how to increase the performance of your code.
-pub static PERFORMANCE: &[&Lint] = &[];
-
-/// A group of lints that encourage idiomatic code.
-///
-/// These lints are opinionated and may be freely disabled if you disagree with their suggestions.
-pub static STYLE: &[&Lint] = &[];
-
-/// A group of lints that make the linter incredibly nit-picky.
-///
-/// If you enable this group, expect to liberally apply `#[allow(...)]` attributes throughout your
-/// code.
-pub static PEDANTIC: &[&Lint] = &[main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT];
-
-/// A group of opt-in lints that restrict you from writing certain code.
-///
-/// These are designed for scenarios where you want to increase the consistency of your code-base
-/// and reject certain patterns. They should not all be enabled at once, but instead specific lints
-/// should be individually enabled.
-pub static RESTRICTION: &[&Lint] = &[];
+pub static LINTS: &[&BevyLint] = &[
+    insert_event_resource::INSERT_EVENT_RESOURCE,
+    main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT,
+];
 
 pub(crate) fn register_lints(store: &mut LintStore) {
-    store.register_lints(CORRECTNESS);
-    store.register_lints(SUSPICIOUS);
-    store.register_lints(COMPLEXITY);
-    store.register_lints(PERFORMANCE);
-    store.register_lints(STYLE);
-    store.register_lints(PEDANTIC);
-    store.register_lints(RESTRICTION);
-
-    /// Shorthand for registering a group of lints.
-    fn register_group(store: &mut LintStore, name: &'static str, lints: &'static [&'static Lint]) {
-        store.register_group(
-            true,
-            name,
-            None,
-            lints.iter().copied().map(LintId::of).collect(),
-        );
-    }
-
-    register_group(store, "bevy::correctness", CORRECTNESS);
-    register_group(store, "bevy::suspicious", SUSPICIOUS);
-    register_group(store, "bevy::complexity", COMPLEXITY);
-    register_group(store, "bevy::performance", PERFORMANCE);
-    register_group(store, "bevy::style", STYLE);
-    register_group(store, "bevy::pedantic", PEDANTIC);
-    register_group(store, "bevy::restriction", RESTRICTION);
+    let lints: Vec<&Lint> = LINTS.iter().map(|x| x.lint).collect();
+    store.register_lints(&lints);
 }
 
 pub(crate) fn register_passes(store: &mut LintStore) {

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -3,13 +3,42 @@ use rustc_lint::{Lint, LintId, LintStore};
 pub mod insert_event_resource;
 pub mod main_return_without_appexit;
 
-pub static CORRECTNESS: &[&Lint] = &[insert_event_resource::INSERT_EVENT_RESOURCE];
-pub static SUSPICIOUS: &[&Lint] = &[];
+/// A group of deny-by-default lints that check for outright wrong or useless code.
+///
+/// These lints are carefully picked to be free of false-positives. You should avoid
+/// `#[allow(...)]`-ing these lints without a _very_ good reason.
+pub static CORRECTNESS: &[&Lint] = &[];
+
+/// A group similar to [`CORRECTNESS`] that checks for suspicious or usually wrong code.
+///
+/// As compared to [`CORRECTNESS`], it may be possible that the linted code may be written
+/// intentionally. Even still, you usually want to fix these lints instead of `#[allow(...)]`-ing
+/// them.
+pub static SUSPICIOUS: &[&Lint] = &[insert_event_resource::INSERT_EVENT_RESOURCE];
+
+/// A group that offers suggestions on how to simplify your code.
 pub static COMPLEXITY: &[&Lint] = &[];
+
+/// A group that suggests how to increase the performance of your code.
 pub static PERFORMANCE: &[&Lint] = &[];
-pub static STYLE: &[&Lint] = &[main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT];
+
+/// A group of lints that encourage idiomatic code.
+///
+/// These lints are opinionated and may be freely disabled if you disagree with their suggestions.
+pub static STYLE: &[&Lint] = &[];
+
+/// A group of lints that make the linter incredibly nit-picky.
+///
+/// If you enable this group, expect to liberally apply `#[allow(...)]` attributes throughout your
+/// code.
+pub static PEDANTIC: &[&Lint] = &[main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT];
+
+/// A group of opt-in lints that restrict you from writing certain code.
+///
+/// These are designed for scenarios where you want to increase the consistency of your code-base
+/// and reject certain patterns. They should not all be enabled at once, but instead specific lints
+/// should be individually enabled.
 pub static RESTRICTION: &[&Lint] = &[];
-pub static NURSERY: &[&Lint] = &[];
 
 pub(crate) fn register_lints(store: &mut LintStore) {
     store.register_lints(CORRECTNESS);
@@ -17,8 +46,8 @@ pub(crate) fn register_lints(store: &mut LintStore) {
     store.register_lints(COMPLEXITY);
     store.register_lints(PERFORMANCE);
     store.register_lints(STYLE);
+    store.register_lints(PEDANTIC);
     store.register_lints(RESTRICTION);
-    store.register_lints(NURSERY);
 
     /// Shorthand for registering a group of lints.
     fn register_group(store: &mut LintStore, name: &'static str, lints: &'static [&'static Lint]) {
@@ -35,8 +64,8 @@ pub(crate) fn register_lints(store: &mut LintStore) {
     register_group(store, "bevy::complexity", COMPLEXITY);
     register_group(store, "bevy::performance", PERFORMANCE);
     register_group(store, "bevy::style", STYLE);
+    register_group(store, "bevy::pedantic", PEDANTIC);
     register_group(store, "bevy::restriction", RESTRICTION);
-    register_group(store, "bevy::nursery", NURSERY);
 }
 
 pub(crate) fn register_passes(store: &mut LintStore) {

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -1,12 +1,43 @@
-use rustc_lint::{Lint, LintStore};
+use rustc_lint::{Lint, LintId, LintStore};
 
 pub mod insert_event_resource;
 pub mod main_return_without_appexit;
 
-pub static LINTS: &[&Lint] = &[
-    insert_event_resource::INSERT_EVENT_RESOURCE,
-    main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT,
-];
+pub static CORRECTNESS: &[&Lint] = &[insert_event_resource::INSERT_EVENT_RESOURCE];
+pub static SUSPICIOUS: &[&Lint] = &[];
+pub static COMPLEXITY: &[&Lint] = &[];
+pub static PERFORMANCE: &[&Lint] = &[];
+pub static STYLE: &[&Lint] = &[main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT];
+pub static RESTRICTION: &[&Lint] = &[];
+pub static NURSERY: &[&Lint] = &[];
+
+pub(crate) fn register_lints(store: &mut LintStore) {
+    store.register_lints(CORRECTNESS);
+    store.register_lints(SUSPICIOUS);
+    store.register_lints(COMPLEXITY);
+    store.register_lints(PERFORMANCE);
+    store.register_lints(STYLE);
+    store.register_lints(RESTRICTION);
+    store.register_lints(NURSERY);
+
+    /// Shorthand for registering a group of lints.
+    fn register_group(store: &mut LintStore, name: &'static str, lints: &'static [&'static Lint]) {
+        store.register_group(
+            true,
+            name,
+            None,
+            lints.iter().copied().map(LintId::of).collect(),
+        );
+    }
+
+    register_group(store, "bevy::correctness", CORRECTNESS);
+    register_group(store, "bevy::suspicious", SUSPICIOUS);
+    register_group(store, "bevy::complexity", COMPLEXITY);
+    register_group(store, "bevy::performance", PERFORMANCE);
+    register_group(store, "bevy::style", STYLE);
+    register_group(store, "bevy::restriction", RESTRICTION);
+    register_group(store, "bevy::nursery", NURSERY);
+}
 
 pub(crate) fn register_passes(store: &mut LintStore) {
     store.register_late_pass(|_| Box::new(insert_event_resource::InsertEventResource));


### PR DESCRIPTION
Closes #90.

This PR implements lint groups! These, just like Clippy's groups, allow enabling and disable multiple lints at a time based on their categories. I, stealing Clippy's groups, have added:

- Correctness: Zero-false-positives deny-by-default "if you hit these, you're wrong" lints
- Suspicious: Like Correctness, but the behavior causing the lint may actually be intended. These are warnings, not hard errors.
- Complexity: Hey, you! That `while` you wrote there could be a `for `loop! (This category checks for overly-complex code with good alternatives.)
- Performance: Anything that can be changed to improve performance. (No, this doesn't warn if you call `std::thread::sleep()`, that's your own fault.)
- Style: By far the most controversial of them all, this category enforces "idiomatic Bevy code". What does that mean? Fantastic question, let's bikeshed this into oblivion!
  - In all serious, because this is on-by-default, I'm going to be _very_ conservative adding anything to this category. Serious thought is required!
- Pedantic: Similar to Style, but disabled by default. This category is the nit-picky math teacher you had that one time who hated shortcuts, calculators, and mental math.
- Restriction: Opt-in lints that you may want for specific purposes, such as requiring all components to derive `Reflect`.
- Nursery: A category for unstable and flaky lints that may be knighted one day into full-on lints. For now, this category should not be used, since `bevy_lint` hasn't been released yet!

As part of this PR, I've changed a few things about how lints are defined.

1. Lints are declared with the `declare_bevy_lint!` macro. This is very similar to the `declare_tool_lint!` that we've used before.
2. `BevyLint` struct: contains the `Lint` struct and a reference to the lint group this is a member of.
3. `LintGroup` struct: represents the name and default level (deny, warn, allow) of a lint.

<details>
  <summary>Old comment about an error I fixed</summary>

As of yet I'm unable to actually deny / allow a lint group. I've tried:

```rust
#![feature(register_tool)]
#![register_tool(bevy)]

#![deny(bevy::style)]

use bevy::prelude::*;

fn main() {
    App::new().run();
}
```

But I'm getting:

```
warning: unknown lint: `bevy::style`
 --> bevy_lint/examples/lint_test.rs:4:9
  |
4 | #![deny(bevy::style)]
  |         ^^^^^^^^^^^
  |
  = note: `#[warn(unknown_lints)]` on by default

warning: an entrypoint that calls `App::run()` does not return `AppExit`
 --> bevy_lint/examples/lint_test.rs:9:16
  |
8 | fn main() {
  |          - help: try: `-> AppExit`
9 |     App::new().run();
  |                ^^^^^
  |
  = note: `App::run()` returns `AppExit`, which can be used to determine whether the app exited successfully or not
  = note: `#[warn(bevy::main_return_without_appexit)]` on by default

warning: `bevy_lint` (example "lint_test") generated 2 warnings
```

`main_return_without_appexit` should have been denied as an error, but it was a warning instead. This requires a bit more testing before it can be merged.

</details>