### PR TITLE
Bevy build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "toml_edit 0.22.21",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ dialoguer = { version = "0.11.0", default-features = false }
 serde = { features = ["derive"], version = "1.0.210" }
 reqwest = { features = ["blocking", "json"], version = "0.12.7" }
 regex = "1.10.6"
+toml_edit = { version = "0.22.21", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,6 @@ dialoguer = { version = "0.11.0", default-features = false }
 serde = { features = ["derive"], version = "1.0.210" }
 reqwest = { features = ["blocking", "json"], version = "0.12.7" }
 regex = "1.10.6"
-toml_edit = { version = "0.22.21", default-features = false }
+toml_edit = { version = "0.22.21", default-features = false, features = [
+  "parse",
+] }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bevy_cli::build::{build, BuildArgs};
 use clap::{Args, Parser, Subcommand};
 
 fn main() -> Result<()> {
@@ -9,6 +10,7 @@ fn main() -> Result<()> {
             bevy_cli::template::generate_template(&new.name, &new.template, &new.branch)?;
         }
         Subcommands::Lint { args } => bevy_cli::lint::lint(args)?,
+        Subcommands::Build(args) => build(&args)?,
     }
 
     Ok(())
@@ -27,10 +29,16 @@ pub struct Cli {
 }
 
 /// Available subcommands for `bevy`.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Only constructed once, not expected to have a performance impact."
+)]
 #[derive(Subcommand)]
 pub enum Subcommands {
     /// Create a new Bevy project from a specified template.
     New(NewArgs),
+    /// Build your Bevy app.
+    Build(BuildArgs),
     /// Check the current project using Bevy-specific lints.
     ///
     /// This command requires `bevy_lint` to be installed, and will fail if it is not. Please see

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use bevy_cli::build::{build, BuildArgs};
+use bevy_cli::build::BuildArgs;
 use clap::{Args, Parser, Subcommand};
 
 fn main() -> Result<()> {
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
             bevy_cli::template::generate_template(&new.name, &new.template, &new.branch)?;
         }
         Subcommands::Lint { args } => bevy_cli::lint::lint(args)?,
-        Subcommands::Build(args) => build(&args)?,
+        Subcommands::Build(args) => bevy_cli::build::build(&args)?,
     }
 
     Ok(())

--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -1,0 +1,37 @@
+use clap::{Args, Subcommand};
+
+use crate::external_cli::{arg_builder::ArgBuilder, cargo::build::CargoBuildArgs};
+
+#[derive(Debug, Args)]
+pub struct BuildArgs {
+    /// The subcommands available for the build command.
+    #[clap(subcommand)]
+    pub subcommand: Option<BuildSubcommands>,
+
+    /// Arguments to forward to `cargo build`.
+    #[clap(flatten)]
+    pub cargo_args: CargoBuildArgs,
+}
+
+impl BuildArgs {
+    /// Determine if the app is being built for the web.
+    pub(crate) fn is_web(&self) -> bool {
+        matches!(self.subcommand, Some(BuildSubcommands::Web))
+    }
+
+    /// The profile used to compile the app.
+    pub(crate) fn profile(&self) -> &str {
+        self.cargo_args.compilation_args.profile()
+    }
+
+    /// Generate arguments to forward to `cargo build`.
+    pub(crate) fn cargo_args_builder(&self) -> ArgBuilder {
+        self.cargo_args.args_builder(self.is_web())
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum BuildSubcommands {
+    /// Build your app for the browser.
+    Web,
+}

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    external_cli::{cargo, rustup, wasm_bindgen},
+    external_cli::{cargo, rustup, wasm_bindgen, CommandHelpers},
     manifest::package_name,
 };
 
@@ -8,21 +8,19 @@ pub use self::args::BuildArgs;
 mod args;
 
 pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
-    if args.is_web() {
-        ensure_web_setup()?;
-    }
-
     let cargo_args = args.cargo_args_builder();
 
     if args.is_web() {
+        ensure_web_setup()?;
+
         println!("Building for WASM...");
-        cargo::build::command().args(cargo_args).status()?;
+        cargo::build::command().args(cargo_args).ensure_status()?;
 
         println!("Bundling for the web...");
         wasm_bindgen::bundle(&package_name()?, args.profile())
             .expect("Failed to bundle for the web");
     } else {
-        cargo::build::command().args(cargo_args).status()?;
+        cargo::build::command().args(cargo_args).ensure_status()?;
     }
 
     Ok(())

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,0 +1,38 @@
+use crate::{
+    external_cli::{cargo, rustup, wasm_bindgen},
+    manifest::package_name,
+};
+
+pub use self::args::BuildArgs;
+
+mod args;
+
+pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
+    if args.is_web() {
+        ensure_web_setup()?;
+    }
+
+    let cargo_args = args.cargo_args_builder();
+
+    if args.is_web() {
+        println!("Building for WASM...");
+        cargo::build::command().args(cargo_args).status()?;
+
+        println!("Bundling for the web...");
+        wasm_bindgen::bundle(&package_name()?, args.profile())
+            .expect("Failed to bundle for the web");
+    } else {
+        cargo::build::command().args(cargo_args).status()?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn ensure_web_setup() -> anyhow::Result<()> {
+    // `wasm32-unknown-unknown` compilation target
+    rustup::install_target_if_needed("wasm32-unknown-unknown")?;
+    // `wasm-bindgen-cli` for bundling
+    cargo::install::if_needed(wasm_bindgen::PROGRAM, wasm_bindgen::PACKAGE, true, false)?;
+
+    Ok(())
+}

--- a/src/external_cli/cargo/install.rs
+++ b/src/external_cli/cargo/install.rs
@@ -1,0 +1,56 @@
+use std::process::{exit, Command};
+
+use dialoguer::Confirm;
+
+/// Check if the given program is installed on the system.
+///
+/// This assumes that the program offers a `--version` flag.
+fn is_installed(program: &str) -> bool {
+    let output = Command::new(program).arg("--version").output();
+
+    if let Ok(output) = output {
+        output.status.success()
+    } else {
+        false
+    }
+}
+
+/// Checks if the program is installed and installs it if it isn't.
+///
+/// Returns `true` if the program needed to be installed.
+pub(crate) fn if_needed(
+    program: &str,
+    package: &str,
+    ask_user: bool,
+    hidden: bool,
+) -> anyhow::Result<bool> {
+    if is_installed(program) {
+        return Ok(false);
+    }
+
+    // Abort if the user doesn't want to install it
+    if ask_user
+        && !Confirm::new()
+            .with_prompt(format!(
+                "`{program}` is missing, should I install it for you?"
+            ))
+            .interact()?
+    {
+        exit(1);
+    }
+
+    let mut cmd = Command::new(super::program());
+    cmd.arg("install").arg(package);
+
+    let status = if hidden {
+        cmd.output()?.status
+    } else {
+        cmd.status()?
+    };
+
+    if !status.success() {
+        Err(anyhow::anyhow!("Failed to install `{program}`."))
+    } else {
+        Ok(true)
+    }
+}

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -1,3 +1,4 @@
+#![expect(dead_code, reason = "Will be used for bevy bump and perhaps bevy run")]
 use std::{ffi::OsStr, path::PathBuf, process::Command};
 
 use semver::{Version, VersionReq};

--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -1,4 +1,3 @@
-#![expect(dead_code, reason = "Will be used for `bevy build` and `bevy run`")]
 use std::{env, ffi::OsString};
 
 use clap::{ArgAction, Args};
@@ -6,6 +5,7 @@ use clap::{ArgAction, Args};
 use super::arg_builder::ArgBuilder;
 
 pub(crate) mod build;
+pub(crate) mod install;
 
 fn program() -> OsString {
     env::var_os("BEVY_CLI_CARGO").unwrap_or("cargo".into())
@@ -65,6 +65,19 @@ pub struct CargoCompilationArgs {
 }
 
 impl CargoCompilationArgs {
+    /// The profile used to compile the app.
+    ///
+    /// This is determined by the `--release` and `--profile` arguments.
+    pub(crate) fn profile(&self) -> &str {
+        if self.is_release {
+            "release"
+        } else if let Some(profile) = &self.profile {
+            profile
+        } else {
+            "debug"
+        }
+    }
+
     pub(crate) fn args_builder(&self, is_web: bool) -> ArgBuilder {
         // web takes precedence over --target <TRIPLE>
         let target = if is_web {

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -1,6 +1,26 @@
 //! Wrappers and utilities to deal with external CLI applications, like `cargo`.
 
+use std::process::{Command, ExitStatus};
+
 pub mod arg_builder;
 pub(crate) mod cargo;
 pub(crate) mod rustup;
 pub(crate) mod wasm_bindgen;
+
+pub trait CommandHelpers {
+    fn ensure_status(&mut self) -> anyhow::Result<ExitStatus>;
+}
+
+impl CommandHelpers for Command {
+    /// Ensure that the command exits with a successful status code.
+    fn ensure_status(&mut self) -> anyhow::Result<ExitStatus> {
+        let status = self.status()?;
+        anyhow::ensure!(
+            status.success(),
+            "Command {} exited with status code {}",
+            self.get_program().to_str().unwrap_or_default(),
+            status
+        );
+        Ok(status)
+    }
+}

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -1,7 +1,5 @@
 //! Utilities for the `rustup` CLI tool.
 
-#![expect(dead_code, reason = "Will be used for build/run commands")]
-
 use std::{env, ffi::OsString, process::Command};
 
 use dialoguer::Confirm;

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -1,5 +1,3 @@
-#![expect(dead_code, reason = "Will be used for the build/run commands")]
-
 use std::process::Command;
 
 use super::arg_builder::ArgBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 //! The library backend for the Bevy CLI.
 
+pub mod build;
 pub mod external_cli;
 pub mod lint;
+pub mod manifest;
 pub mod template;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,24 @@
+use std::{fs::File, io::Read as _};
+
+use toml_edit::{DocumentMut, Item, Value};
+
+/// Get the contents of the manifest file.
+fn get_cargo_toml(folder_name: &str) -> anyhow::Result<DocumentMut> {
+    let mut file = File::open(format!("{folder_name}/Cargo.toml"))?;
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+
+    Ok(content.parse()?)
+}
+
+/// Determine the name of the cargo package.
+pub(crate) fn package_name() -> anyhow::Result<String> {
+    let cargo_toml = get_cargo_toml("./")?;
+
+    if let Item::Value(Value::String(name)) = &cargo_toml["package"]["name"] {
+        Ok(name.value().clone())
+    } else {
+        Err(anyhow::anyhow!("No package name defined in Cargo.toml"))
+    }
+}


### PR DESCRIPTION
This PR adds the remaining pieces needed for the `bevy build` command.

The command is a wrapper around `cargo build`, but with an additional `web` sub command which makes it a lot easier to build an app for the browser.
I also plan to add additional features in the feature, like #68.

The PR contains the following changes:

- Added `cargo install` wrapper to install a program if it's missing (prompting the user).
- Added helper to obtain the current package name via `Cargo.toml`. There are likely better ways to do this (perhaps via `cargo metadata`), but I already had this implemented and we can improve it in a follow-up if needed.
- Added helper to determine the active compilation profile, which is needed to determine the path to the build artifact.
- Implemented the build command itself.

If you'd prefer smaller PRs let me know and I will split this up further.