### PR TITLE
Add a wrapper for cargo run

### DIFF
--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -6,6 +6,7 @@ use clap::{ArgAction, Args};
 use super::arg_builder::ArgBuilder;
 
 pub(crate) mod build;
+pub(crate) mod run;
 
 fn program() -> OsString {
     env::var_os("BEVY_CLI_CARGO").unwrap_or("cargo".into())

--- a/src/external_cli/cargo/run.rs
+++ b/src/external_cli/cargo/run.rs
@@ -1,0 +1,73 @@
+use std::process::Command;
+
+use clap::Args;
+
+use crate::external_cli::arg_builder::ArgBuilder;
+
+use super::{program, CargoCompilationArgs, CargoFeatureArgs, CargoManifestArgs};
+
+/// Create a command to run `cargo run`.
+pub(crate) fn command() -> Command {
+    let mut command = Command::new(program());
+    command.arg("run");
+    command
+}
+
+#[derive(Debug, Args)]
+pub struct CargoRunArgs {
+    #[clap(flatten)]
+    pub package_args: CargoPackageRunArgs,
+    #[clap(flatten)]
+    pub target_args: CargoTargetRunArgs,
+    #[clap(flatten)]
+    pub feature_args: CargoFeatureArgs,
+    #[clap(flatten)]
+    pub compilation_args: CargoCompilationArgs,
+    #[clap(flatten)]
+    pub manifest_args: CargoManifestArgs,
+}
+
+impl CargoRunArgs {
+    pub(crate) fn args_builder(&self, is_web: bool) -> ArgBuilder {
+        ArgBuilder::new()
+            .append(self.package_args.args_builder())
+            .append(self.target_args.args_builder())
+            .append(self.feature_args.args_builder())
+            .append(self.compilation_args.args_builder(is_web))
+            .append(self.manifest_args.args_builder())
+    }
+}
+
+#[derive(Debug, Args)]
+#[command(next_help_heading = "Package Selection")]
+pub struct CargoPackageRunArgs {
+    /// Package with the target to run
+    #[clap(short = 'p', long = "package", value_name = "SPEC")]
+    pub package: Option<String>,
+}
+
+impl CargoPackageRunArgs {
+    pub(crate) fn args_builder(&self) -> ArgBuilder {
+        ArgBuilder::new().add_opt_value("--package", &self.package)
+    }
+}
+
+#[derive(Debug, Args)]
+#[command(next_help_heading = "Target Selection")]
+pub struct CargoTargetRunArgs {
+    /// Build only the specified binary.
+    #[clap(long = "bin", value_name = "NAME")]
+    pub bin: Option<String>,
+
+    /// Build only the specified example.
+    #[clap(long = "example", value_name = "NAME")]
+    pub example: Option<String>,
+}
+
+impl CargoTargetRunArgs {
+    pub(crate) fn args_builder(&self) -> ArgBuilder {
+        ArgBuilder::new()
+            .add_opt_value("--bin", &self.bin)
+            .add_opt_value("--example", &self.example)
+    }
+}


### PR DESCRIPTION
Similar to #76, but for `cargo run`.
It gives us access to all the `cargo run` arguments and allows us to add them to our `bevy run` help command.

See #24 for context.

Usage: `cargo::run::command()`