### PR TITLE
Bug fixing and chores related to linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,36 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  # Keep this in sync with `rust-toolchain.toml`.
-  RUST_TOOLCHAIN: nightly-2024-08-21
-  RUST_COMPONENTS: rustc-dev, llvm-tools-preview
-
 jobs:
+  # Find the nightly Rust version and required components from `rust-toolchain.toml` using
+  # <https://taplo.tamasfe.dev>, so that we install can install them in later jobs.
+  extract-rust-version:
+    name: Extract Rust version
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.toolchain.outputs.toolchain }}
+      components: ${{ steps.toolchain.outputs.components }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Taplo
+        run: |
+          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz \
+            | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+
+      - name: Extract toolchain
+        id: toolchain
+        run: |
+          TOOLCHAIN=$(taplo get -f='rust-toolchain.toml' 'toolchain.channel')
+          COMPONENTS=$(taplo get -f='rust-toolchain.toml' --separator=', ' 'toolchain.components')
+
+          echo toolchain=$TOOLCHAIN >> $GITHUB_OUTPUT
+          echo components=$COMPONENTS >> $GITHUB_OUTPUT
+
   test:
     name: Run tests
+    needs: extract-rust-version
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -25,8 +47,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: ${{ env.RUST_COMPONENTS }}
+          toolchain: ${{ needs.extract-rust-version.outputs.channel }}
+          components: ${{ needs.extract-rust-version.outputs.components }}
 
       - name: Cache build artifacts
         uses: Leafwing-Studios/cargo-cache@v2
@@ -42,6 +64,7 @@ jobs:
 
   clippy:
     name: Check with Clippy
+    needs: extract-rust-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -50,8 +73,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: '${{ env.RUST_COMPONENTS }}, clippy'
+          toolchain: ${{ needs.extract-rust-version.outputs.channel }}
+          components: '${{ needs.extract-rust-version.outputs.components }}, clippy'
 
       - name: Cache build artifacts
         uses: Leafwing-Studios/cargo-cache@v2
@@ -63,6 +86,7 @@ jobs:
 
   rustfmt:
     name: Check with rustfmt
+    needs: extract-rust-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -71,14 +95,15 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: '${{ env.RUST_COMPONENTS }}, rustfmt'
+          toolchain: ${{ needs.extract-rust-version.outputs.channel }}
+          components: '${{ needs.extract-rust-version.outputs.components }}, rustfmt'
 
       - name: Run rustfmt
         run: cargo fmt --all --check
 
   docs:
     name: Build docs
+    needs: extract-rust-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -87,8 +112,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: ${{ env.RUST_COMPONENTS }}
+          toolchain: ${{ needs.extract-rust-version.outputs.channel }}
+          components: ${{ needs.extract-rust-version.outputs.components }}
 
       - name: Cache build artifacts
         uses: Leafwing-Studios/cargo-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -258,7 +258,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "toml_edit 0.22.21",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -394,6 +394,7 @@ dependencies = [
  "anyhow",
  "bevy",
  "clippy_utils",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -420,7 +421,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "toml_edit 0.22.21",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -583,7 +584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "serde",
 ]
 
@@ -655,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
 dependencies = [
  "jobserver",
  "libc",
@@ -678,9 +679,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -688,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -701,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1216,7 +1217,7 @@ dependencies = [
  "gix-utils",
  "itoa",
  "thiserror",
- "winnow 0.6.18",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -1237,7 +1238,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow 0.6.18",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -1340,7 +1341,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror",
- "winnow 0.6.18",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -1374,7 +1375,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror",
- "winnow 0.6.18",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -1448,8 +1449,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1604,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1617,7 +1618,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -1642,7 +1642,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1778,9 +1778,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libgit2-sys"
@@ -2057,9 +2057,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl"
@@ -2178,9 +2181,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2189,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2199,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2212,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -2232,26 +2235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,15 +2248,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -2352,9 +2335,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2378,8 +2361,8 @@ checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2393,13 +2376,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2410,22 +2393,22 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c914caef075f03e9d5c568e2e71b3d3cf17dc61a5481ff379bb744721be0a75a"
+checksum = "a694f9e0eb3104451127f6cc1e5de55f59d3b1fc8c5ddfaeb6f1e716479ceb4a"
 dependencies = [
  "cfg-if",
  "cvt",
  "fs_at",
  "libc",
  "normpath",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2559,19 +2542,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -2639,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2690,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -2824,9 +2806,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2903,18 +2885,18 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3057,7 +3039,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.21",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -3084,37 +3066,16 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow 0.6.20",
 ]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3214,9 +3175,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"
@@ -3253,9 +3214,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"
@@ -3639,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ A Bevy CLI tool.
 
 ## Nightly Rust
 
-The Bevy CLI includes a [custom linter](bevy_lint) that integrates directly with `rustc` through [`#![feature(rustc_private)]`](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html). Because of this, building this project requires nightly Rust with the `rustc-dev` component. If you use Rustup, a pinned version will be automatically installed when you compile this project based on the contents of [`rust-toolchain.toml`](rust-toolchain.toml).
+The Bevy CLI includes a [custom linter](bevy_lint) that integrates directly with `rustc` through [`#![feature(rustc_private)]`](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html). Because of this, building this project requires nightly Rust with the `rustc-dev` and `llvm-tools-preview` components. If you use Rustup, a pinned version will be automatically installed when you compile this project based on the contents of [`rust-toolchain.toml`](rust-toolchain.toml).
 
-However, some components may be still missing due to a [`rustup` bug](https://github.com/rust-lang/rustup/issues/3255). If you get `can't find crate` errors when trying to build, run the following commands to manually add the required components:
-
-```bash
-rustup component add --toolchain nightly-2024-08-21 rustc-dev llvm-tools-preview
-```
+> [!WARNING]
+>
+> Some components may still be missing due to a [`rustup` bug](https://github.com/rust-lang/rustup/issues/3255). If you get `can't find crate` errors when trying to build, ensure that you have the toolchain and components installed, based on [`rust-toolchain.toml`](rust-toolchain.toml).

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -1,15 +1,21 @@
 [package]
 name = "bevy_lint"
 version = "0.1.0-dev"
+authors = ["BD103"]
 edition = "2021"
+description = "A collection of lints for the Bevy game engine"
+repository = "https://github.com/TheBevyFlock/bevy_cli"
 license = "MIT OR Apache-2.0"
+# While there are two binaries available, only `bevy_lint` is intended to be called by users.
 default-run = "bevy_lint"
 
+# The main entrypoint for using Bevy lints. This program is intended to be called by users.
 [[bin]]
 name = "bevy_lint"
 path = "src/bin/main.rs"
 
-# Integrates custom lints with `rustc`.
+# The internal program called by `cargo` instead of `rustc`. While this is where the lints are
+# registered, it is not intended to be called by users.
 [[bin]]
 name = "bevy_lint_driver"
 path = "src/bin/driver.rs"

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -15,7 +15,7 @@ name = "bevy_lint_driver"
 path = "src/bin/driver.rs"
 
 [dependencies]
-# Easy error propagation and contexts
+# Easy error propagation and contexts.
 anyhow = "1.0.86"
 
 # Contains a series of useful utilities when writing lints. The version and commit were chosen to
@@ -25,6 +25,12 @@ anyhow = "1.0.86"
 version = "=0.1.82"
 git = "https://github.com/rust-lang/rust-clippy"
 rev = "e8ac4ea4187498052849531b86114a1eec5314a1"
+
+[build-dependencies]
+# Parse `rust-toolchain.toml` at build time.
+toml_edit = { version = "0.22.22", default-features = false, features = [
+    "parse",
+] }
 
 [dev-dependencies]
 # Used to test lints that need Bevy's types

--- a/bevy_lint/build.rs
+++ b/bevy_lint/build.rs
@@ -1,0 +1,16 @@
+use toml_edit::DocumentMut;
+
+const RUST_TOOLCHAIN: &str = include_str!("../rust-toolchain.toml");
+
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=../rust-toolchain.toml");
+
+    let rust_toolchain = RUST_TOOLCHAIN
+        .parse::<DocumentMut>()
+        .expect("Failed to parse `rust-toolchain.toml`.");
+
+    let channel = rust_toolchain["toolchain"]["channel"].as_str().unwrap();
+
+    println!("cargo::rustc-env=RUST_TOOLCHAIN_CHANNEL={channel}");
+}

--- a/bevy_lint/build.rs
+++ b/bevy_lint/build.rs
@@ -3,6 +3,7 @@ use toml_edit::DocumentMut;
 const RUST_TOOLCHAIN: &str = include_str!("../rust-toolchain.toml");
 
 fn main() {
+    // Only re-run this build script if its source or `rust-toolchain.toml` was modified.
     println!("cargo::rerun-if-changed=build.rs");
     println!("cargo::rerun-if-changed=../rust-toolchain.toml");
 
@@ -10,7 +11,11 @@ fn main() {
         .parse::<DocumentMut>()
         .expect("Failed to parse `rust-toolchain.toml`.");
 
-    let channel = rust_toolchain["toolchain"]["channel"].as_str().unwrap();
+    let channel = rust_toolchain["toolchain"]["channel"]
+        .as_str()
+        .expect("Could not find `toolchain.channel` key in `rust-toolchain.toml`.");
 
+    // Emit the toolchain channel as an environmental variable that the crate can access using the
+    // `env!()` macro.
     println!("cargo::rustc-env=RUST_TOOLCHAIN_CHANNEL={channel}");
 }

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -4,6 +4,7 @@ use std::{
     process::{Command, ExitCode},
 };
 
+// This is set by `build.rs`. It is the version specified in `rust-toolchain.toml`.
 const RUST_TOOLCHAIN_CHANNEL: &str = env!("RUST_TOOLCHAIN_CHANNEL");
 
 fn main() -> anyhow::Result<ExitCode> {

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -4,6 +4,8 @@ use std::{
     process::{Command, ExitCode},
 };
 
+const RUST_TOOLCHAIN: &str = "nightly-2024-08-21";
+
 fn main() -> anyhow::Result<ExitCode> {
     // The `bevy_lint` lives in the same folder as `bevy_lint_driver`, so we can easily find it
     // using the path of the current executable.
@@ -28,6 +30,7 @@ fn main() -> anyhow::Result<ExitCode> {
 
     // Run `cargo check`.
     let status = Command::new("cargo")
+        .arg(format!("+{RUST_TOOLCHAIN}"))
         .arg("check")
         // Forward all arguments to `cargo check` except for the first, which is the path to the
         // current executable.

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -38,6 +38,15 @@ fn main() -> anyhow::Result<ExitCode> {
         // This instructs `rustc` to call `bevy_lint_driver` instead of its default routine.
         // This lets us register custom lints.
         .env("RUSTC_WORKSPACE_WRAPPER", driver_path)
+        // Pass `--cfg bevy_lint` so that programs can conditionally configure lints. If
+        // `RUSTFLAGS` is already set, we append `--cfg bevy_lint` to the end.
+        .env(
+            "RUSTFLAGS",
+            env::var("RUSTFLAGS").map_or("--cfg bevy_lint".to_string(), |mut flags| {
+                flags.push_str(" --cfg bevy_lint");
+                flags
+            }),
+        )
         .status()
         .context("Failed to spawn `cargo check`.")?;
 

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Command, ExitCode},
 };
 
-const RUST_TOOLCHAIN: &str = "nightly-2024-08-21";
+const RUST_TOOLCHAIN_CHANNEL: &str = env!("RUST_TOOLCHAIN_CHANNEL");
 
 fn main() -> anyhow::Result<ExitCode> {
     // The `bevy_lint` lives in the same folder as `bevy_lint_driver`, so we can easily find it
@@ -30,7 +30,7 @@ fn main() -> anyhow::Result<ExitCode> {
 
     // Run `cargo check`.
     let status = Command::new("cargo")
-        .arg(format!("+{RUST_TOOLCHAIN}"))
+        .arg(format!("+{RUST_TOOLCHAIN_CHANNEL}"))
         .arg("check")
         // Forward all arguments to `cargo check` except for the first, which is the path to the
         // current executable.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 # If you modify this file, please also update `RUST_TOOLCHAIN` in `.github/workflows/ci.yml`, the
-# `clippy_utils` version in `bevy_lint/Cargo.toml`, and the toolchain in `README.md`.
+# `clippy_utils` version in `bevy_lint/Cargo.toml`, the toolchain in `README.md`, and
+# `RUST_TOOLCHAIN` in `bevy_lint/src/bin/main.rs`.
 
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
-# If you modify this file, please also update the `clippy_utils` version in `bevy_lint/Cargo.toml`,
-# and `RUST_TOOLCHAIN` in `bevy_lint/src/bin/main.rs`.
+# If you modify this file, please also update the `clippy_utils` version in `bevy_lint/Cargo.toml`.
 
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,5 @@
-# If you modify this file, please also update `RUST_TOOLCHAIN` in `.github/workflows/ci.yml`, the
-# `clippy_utils` version in `bevy_lint/Cargo.toml`, and `RUST_TOOLCHAIN` in
-# `bevy_lint/src/bin/main.rs`.
+# If you modify this file, please also update the `clippy_utils` version in `bevy_lint/Cargo.toml`,
+# and `RUST_TOOLCHAIN` in `bevy_lint/src/bin/main.rs`.
 
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # If you modify this file, please also update `RUST_TOOLCHAIN` in `.github/workflows/ci.yml`, the
-# `clippy_utils` version in `bevy_lint/Cargo.toml`, the toolchain in `README.md`, and
-# `RUST_TOOLCHAIN` in `bevy_lint/src/bin/main.rs`.
+# `clippy_utils` version in `bevy_lint/Cargo.toml`, and `RUST_TOOLCHAIN` in
+# `bevy_lint/src/bin/main.rs`.
 
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version

--- a/src/external_cli/cargo/run.rs
+++ b/src/external_cli/cargo/run.rs
@@ -1,3 +1,5 @@
+#![expect(dead_code, reason = "Temporarily unused until #120 is merged.")]
+
 use std::process::Command;
 
 use clap::Args;


### PR DESCRIPTION
This PR tackles a few issues with how `bevy_lint` functions.

First, it closes #117 by passing `--cfg bevy_lint` to `rustc` when `bevy_lint` is called. This allows code to conditionally configure lints (e.g. `#[cfg_attr(bevy_lint, allow(bevy::lint))]`).

Secondly, it fixes #118 by specifying the nightly version when calling `cargo check`. I originally hardcoded this version, but after a comment from @richchurcher I adjusted it to take the version from `rust-toolchain.toml`. (It specifically uses a build script to parse `rust-toolchain.toml` using `toml_edit`, then passes it to the code using an environmental variable.)

Thirdly, I removed other hard-coded references to the specifically nightly channel in `README.md` and `ci.yml`. (In CI I specifically used [Taplo](https://taplo.tamasfe.dev) to parse the version, similar to [`jq`](https://jqlang.github.io/jq/).)

Finally, I added a bit more metadata to `Cargo.toml` that will be used by <https://crates.io> once it is published.