### PR TITLE
Improve lint driver entrypoint

### DIFF
--- a/bevy_lint/src/bin/driver.rs
+++ b/bevy_lint/src/bin/driver.rs
@@ -2,16 +2,51 @@
 #![feature(rustc_private)]
 
 extern crate rustc_driver;
+extern crate rustc_session;
 extern crate rustc_span;
 
+use std::process::ExitCode;
+
 use bevy_lint::BevyLintCallback;
-use rustc_span::ErrorGuaranteed;
+use rustc_driver::{catch_with_exit_code, init_rustc_env_logger, install_ice_hook, RunCompiler};
+use rustc_session::{config::ErrorOutputType, EarlyDiagCtxt};
 
-fn main() -> Result<(), ErrorGuaranteed> {
-    // The arguments are formatted as `[DRIVER_PATH, RUSTC_PATH, ARGS...]`. We skip the driver path
-    // so that `RunCompiler` just sees `rustc`'s path.
-    let args: Vec<String> = std::env::args().skip(1).collect();
+const BUG_REPORT_URL: &str = "https://github.com/TheBevyFlock/bevy_cli/issues";
 
-    // Call the compiler with our custom callback.
-    rustc_driver::RunCompiler::new(&args, &mut BevyLintCallback).run()
+fn main() -> ExitCode {
+    // Setup a diagnostic context that can be used for error messages.
+    let early_dcx = EarlyDiagCtxt::new(ErrorOutputType::default());
+
+    // Setup `rustc`'s builtin `tracing` logger.
+    init_rustc_env_logger(&early_dcx);
+
+    // "ICE" stands for Internal Compiler Error. An ICE hook is a special type of panic handler
+    // that dumps an absurd amount of data when the driver panics. We take advantage of this, but
+    // override the default bug report URL so that users bother us, not Rust compiler devs. :)
+    install_ice_hook(BUG_REPORT_URL, |dcx| {
+        dcx.handle()
+            .note("This is likely a bug with `bevy_lint`, not `rustc` or `cargo`.");
+    });
+
+    // Run the passed closure, but catch any panics and return the respective exit code.
+    let exit_code = catch_with_exit_code(move || {
+        // Get the arguments passed through the CLI. This is equivalent to `std::env::args()`, but
+        // it returns a `Result` instead of panicking.
+        let mut args = rustc_driver::args::raw_args(&early_dcx)?;
+
+        // The arguments are formatted as `[DRIVER_PATH, RUSTC_PATH, ARGS...]`. We skip the driver
+        // path so that `RunCompiler` just sees `rustc`'s path.
+        args.remove(0);
+
+        println!("{:?}", args);
+
+        // Call the compiler with our custom callback.
+        RunCompiler::new(&args, &mut BevyLintCallback).run()
+    });
+
+    // We truncate the `i32` to a `u8`. `catch_with_exit_code()` currently only returns 1 or 0, so
+    // this should does not discard any data. We prefer returning an `ExitCode` instead of calling
+    // `std::process::exit()` because this calls `Drop` implementations, in case we need them in
+    // the future.
+    ExitCode::from(exit_code as u8)
 }

--- a/bevy_lint/src/bin/driver.rs
+++ b/bevy_lint/src/bin/driver.rs
@@ -38,8 +38,6 @@ fn main() -> ExitCode {
         // path so that `RunCompiler` just sees `rustc`'s path.
         args.remove(0);
 
-        println!("{:?}", args);
-
         // Call the compiler with our custom callback.
         RunCompiler::new(&args, &mut BevyLintCallback).run()
     });


### PR DESCRIPTION
This makes the `bevy_lint_driver` binary behave a bit more like `clippy-driver`, which means it also behaves a bit more like `rustc`. Some changes include:

- Panicking will now result in an ICE, which can be used to debug issues.
- Logging is now setup, so you can set the `RUSTC_LOG` variable to configure logging levels and scope. (It uses `tracing` internally!)
- Exit code logic now mirrors the functionality recommended for `rustc` drivers: specifically using `catch_with_exit_code()`.

~~I'm currently debugging an issue with this where `serde_derive` fails to compile (I believe it's the `rustc_driver::args::raw_args()` call), so I'll update this when I fix it. :)~~