### PR TITLE
Replace `lower_ty()` with `typeck_results.node_type()`

### DIFF
--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -8,7 +8,6 @@
 extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_hir;
-extern crate rustc_hir_analysis;
 extern crate rustc_interface;
 extern crate rustc_lint;
 extern crate rustc_middle;

--- a/bevy_lint/src/lints/insert_event_resource.rs
+++ b/bevy_lint/src/lints/insert_event_resource.rs
@@ -41,7 +41,6 @@ use clippy_utils::{
 };
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, GenericArg, GenericArgs, Path, PathSegment, QPath};
-use rustc_hir_analysis::lower_ty;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{Ty, TyKind};
 use rustc_session::declare_lint_pass;
@@ -153,9 +152,7 @@ fn check_init_resource<'tcx>(cx: &LateContext<'tcx>, path: &PathSegment<'tcx>, m
     {
         // Lower `rustc_hir::Ty` to `ty::Ty`, so we can inspect type information. For more
         // information, see <https://rustc-dev-guide.rust-lang.org/ty.html#rustc_hirty-vs-tyty>.
-        // Note that `lower_ty()` is quasi-deprecated, and should be removed if a adequate
-        // replacement is found.
-        let resource_ty = lower_ty(cx.tcx, resource_hir_ty);
+        let resource_ty = cx.typeck_results().node_type(resource_hir_ty.hir_id);
 
         // If the resource type is `Events<T>`, emit the lint.
         if match_type(cx, resource_ty, &crate::paths::EVENTS) {


### PR DESCRIPTION
Fixes #114!

The migrates `bevy::insert_event_resource` from using the quasi-deprecated [`lower_ty()`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/fn.lower_ty.html) function to [`TypeckResults::node_type()`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/typeck_results/struct.TypeckResults.html#method.node_type). The behavior of the lint should not change, though this PR may fix a few hidden crashes.