### PR TITLE
Warn on `rustc::internal` lints

### DIFF
--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(rustc_private)]
 // Allows chaining `if let` multiple times using `&&`.
 #![feature(let_chains)]
+// Warn on internal `rustc` lints that check for poor usage of internal compiler APIs.
+#![warn(rustc::internal)]
 
 // This is a list of every single `rustc` crate used within this library. If you need another, add
 // it here!


### PR DESCRIPTION
`rustc` has a series of [internal lints](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/internal/index.html) that checks that its own APIs are being used correctly. Since we are using private `rustc` crates, we should enable these lints to avoid footguns.

I first learned about this lint group when browsing Clippy's source code. Funnily enough, `rustc -W help` doesn't print `internal` as a possible group, which is why I didn't know about it earlier.