### PR TITLE
Add `missing_reflect` lint (attempt 2)

### DIFF
--- a/bevy_lint/src/lints/missing_reflect.rs
+++ b/bevy_lint/src/lints/missing_reflect.rs
@@ -1,9 +1,15 @@
 //! TODO
 
-use rustc_lint::{LateContext, LateLintPass};
-use rustc_session::declare_lint_pass;
-
 use crate::declare_bevy_lint;
+use clippy_utils::{def_path_res, diagnostics::span_lint_hir};
+use rustc_hir::{
+    def::{DefKind, Res},
+    HirId, Item, ItemKind, Node, OwnerId, QPath, TyKind,
+};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TyCtxt;
+use rustc_session::declare_lint_pass;
+use rustc_span::symbol::Ident;
 
 declare_bevy_lint! {
     pub MISSING_REFLECT,
@@ -16,5 +22,130 @@ declare_lint_pass! {
 }
 
 impl<'tcx> LateLintPass<'tcx> for MissingReflect {
-    fn check_crate(&mut self, cx: &LateContext<'tcx>) {}
+    fn check_crate(&mut self, cx: &LateContext<'tcx>) {
+        // Finds all types that implement `Reflect` in this crate.
+        let reflected: Vec<TraitType> =
+            TraitType::from_local_crate(cx.tcx, &crate::paths::REFLECT).collect();
+
+        // Finds all non-`Reflect` types that implement `Event` in this crate.
+        let events: Vec<TraitType> = TraitType::from_local_crate(cx.tcx, &crate::paths::EVENT)
+            .filter(|trait_type| !reflected.contains(trait_type))
+            .collect();
+
+        // Finds all non-`Reflect` types that implement `Component` and *not* `Event` in this
+        // crate. Because events are also components, we need to deduplicate the two to avoid
+        // emitting multiple diagnostics for the same type.
+        let components: Vec<TraitType> =
+            TraitType::from_local_crate(cx.tcx, &crate::paths::COMPONENT)
+                .filter(|trait_type| {
+                    !(reflected.contains(trait_type) || events.contains(trait_type))
+                })
+                .collect();
+
+        // Finds all non-`Reflect` types that implement `Resource` in this crate.
+        let resources: Vec<TraitType> =
+            TraitType::from_local_crate(cx.tcx, &crate::paths::RESOURCE)
+                .filter(|trait_type| !reflected.contains(trait_type))
+                .collect();
+
+        for checked_trait in [events, components, resources] {
+            for without_reflect in checked_trait {
+                span_lint_hir(
+                    cx,
+                    MISSING_REFLECT.lint,
+                    without_reflect.hir_id,
+                    without_reflect.ident.span,
+                    MISSING_REFLECT.lint.desc,
+                );
+            }
+        }
+    }
+}
+
+/// Represents a type that implements a specific trait.
+#[derive(Debug)]
+struct TraitType {
+    hir_id: HirId,
+    ident: Ident,
+}
+
+impl TraitType {
+    fn from_local_crate<'tcx>(
+        tcx: TyCtxt<'tcx>,
+        trait_path: &[&str],
+    ) -> impl Iterator<Item = Self> + 'tcx {
+        // Find the `DefId` of the trait. There may be multiple if there are multiple versions of
+        // the same crate.
+        let trait_def_ids = def_path_res(tcx, trait_path)
+            .into_iter()
+            .filter_map(|res| match res {
+                Res::Def(DefKind::Trait, def_id) => Some(def_id),
+                _ => None,
+            });
+
+        // if trait_def_ids.len() > 1 {
+        //     tcx.dcx().warn(format!(
+        //         "Multiple versions of trait {} found. Are there multiple versions of the same
+        // crate?",         crate::utils::path_to_string(trait_path),
+        //     ));
+        // }
+
+        // Find a map of all trait `impl` items within the current crate. The key is the `DefId` of
+        // the trait, and the value is a `Vec<LocalDefId>` for all `impl` items.
+        let all_trait_impls = tcx.all_local_trait_impls(());
+
+        // Find all `impl` items for the specific trait.
+        let trait_impls = trait_def_ids
+            .filter_map(|def_id| all_trait_impls.get(&def_id))
+            .flatten()
+            .copied();
+
+        // Map the `DefId`s of `impl` items to `TraitType`s. Sometimes this conversion can fail, so
+        // we use `filter_map()` to skip errors.
+        trait_impls.filter_map(move |local_def_id| {
+            // Retrieve the node of the `impl` item from its `DefId`.
+            let node = tcx.hir_node_by_def_id(local_def_id);
+
+            // Verify that it's an `impl` item and not something else.
+            let Node::Item(Item {
+                kind: ItemKind::Impl(impl_),
+                ..
+            }) = node
+            else {
+                return None;
+            };
+
+            // Find where `T` in `impl T` was originally defined, after peeling away all references
+            // `&`. This was adapted from `clippy_utils::path_res()` in order to avoid passing
+            // `LateContext` to this function.
+            let def_id = match impl_.self_ty.peel_refs().kind {
+                TyKind::Path(QPath::Resolved(_, path)) => path.res.opt_def_id()?,
+                _ => return None,
+            };
+
+            let hir_id = OwnerId {
+                // This is guaranteed to be a `LocalDefId` due to Rust's orphan rule. The traits
+                // (`Reflect`, `Component`, etc.) are from an external crate, so the type
+                // definition _must_ be local. The only case this may not be upheld is within
+                // Bevy's own crates.
+                def_id: def_id.expect_local(),
+            }
+            .into();
+
+            let ident = tcx.opt_item_ident(def_id).unwrap();
+
+            Some(TraitType { hir_id, ident })
+        })
+    }
+}
+
+/// A custom equality implementation that just checks the [`DefId`] of the [`TraitType`], and skips
+/// the other values.
+///
+/// [`TraitType`]s with equal [`DefId`]s are guaranteed to be equal in all other fields, so this
+/// takes advantage of that fact.
+impl PartialEq for TraitType {
+    fn eq(&self, other: &Self) -> bool {
+        self.hir_id == other.hir_id
+    }
 }

--- a/bevy_lint/src/lints/missing_reflect.rs
+++ b/bevy_lint/src/lints/missing_reflect.rs
@@ -1,0 +1,20 @@
+//! TODO
+
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+use crate::declare_bevy_lint;
+
+declare_bevy_lint! {
+    pub MISSING_REFLECT,
+    RESTRICTION,
+    "defined a component, resource, or event without a `Reflect` implementation",
+}
+
+declare_lint_pass! {
+    MissingReflect => [MISSING_REFLECT.lint]
+}
+
+impl<'tcx> LateLintPass<'tcx> for MissingReflect {
+    fn check_crate(&mut self, cx: &LateContext<'tcx>) {}
+}

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -3,6 +3,7 @@ use rustc_lint::{Lint, LintStore};
 
 pub mod insert_event_resource;
 pub mod main_return_without_appexit;
+pub mod missing_reflect;
 pub mod panicking_methods;
 pub mod plugin_not_ending_in_plugin;
 
@@ -10,6 +11,7 @@ pub(crate) static LINTS: &[&BevyLint] = &[
     insert_event_resource::INSERT_EVENT_RESOURCE,
     main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT,
     panicking_methods::PANICKING_QUERY_METHODS,
+    missing_reflect::MISSING_REFLECT,
     panicking_methods::PANICKING_WORLD_METHODS,
     plugin_not_ending_in_plugin::PLUGIN_NOT_ENDING_IN_PLUGIN,
 ];
@@ -22,6 +24,7 @@ pub(crate) fn register_lints(store: &mut LintStore) {
 pub(crate) fn register_passes(store: &mut LintStore) {
     store.register_late_pass(|_| Box::new(insert_event_resource::InsertEventResource));
     store.register_late_pass(|_| Box::new(main_return_without_appexit::MainReturnWithoutAppExit));
+    store.register_late_pass(|_| Box::new(missing_reflect::MissingReflect));
     store.register_late_pass(|_| Box::new(panicking_methods::PanickingMethods));
     store.register_late_pass(|_| Box::new(plugin_not_ending_in_plugin::PluginNotEndingInPlugin));
 }

--- a/bevy_lint/src/paths.rs
+++ b/bevy_lint/src/paths.rs
@@ -7,8 +7,13 @@
 //! [`match_def_path()`](clippy_utils::match_def_path).
 
 pub const APP: [&str; 3] = ["bevy_app", "app", "App"];
+pub const COMPONENT: [&str; 3] = ["bevy_ecs", "component", "Component"];
+// Note that this moves to `bevy_ecs::event::base::Event` in 0.15.
+pub const EVENT: [&str; 3] = ["bevy_ecs", "event", "Event"];
 pub const EVENTS: [&str; 3] = ["bevy_ecs", "event", "Events"];
 pub const PLUGIN: [&str; 3] = ["bevy_app", "plugin", "Plugin"];
 pub const QUERY: [&str; 4] = ["bevy_ecs", "system", "query", "Query"];
 pub const QUERY_STATE: [&str; 4] = ["bevy_ecs", "query", "state", "QueryState"];
+pub const REFLECT: [&str; 3] = ["bevy_reflect", "reflect", "Reflect"];
+pub const RESOURCE: [&str; 4] = ["bevy_ecs", "system", "system_param", "Resource"];
 pub const WORLD: [&str; 3] = ["bevy_ecs", "world", "World"];


### PR DESCRIPTION
Closes #54. See #137 for past attempt.

This adds a lint that lets users require all components, resources, and events derive `Reflect`. `Reflect` is often used by tools such as `bevy-inspector-egui` to view the state of the world while the game is running, but these tools are far less useful if they do not have access to reflection data.

This lint is off by default, and intended to be used to require `Reflect` for types within specific modules. For example:

```rust
#[deny(bevy::missing_reflect)]
mod components {
    use bevy::prelude::*;

    #[derive(Component)]
    struct MyComponent;
}
```

Developers are free to require it throughout the entire crate, however.

```rust
#![deny(bevy::missing_reflect)]
```

This lint gives lots of information when it is raised, such as where the offending trait was implemented and how to fix it:

![image](https://github.com/user-attachments/assets/e0c33639-d81d-44e6-b7da-433b9f61a61d)

Thanks to `clippy_utils`'s [`suggest_item_with_attr()`](https://doc.rust-lang.org/nightly/nightly-rustc/clippy_utils/sugg/trait.DiagExt.html#tymethod.suggest_item_with_attr), the suggestion is machine applicable. This means that `cargo fix` can automatically fix this lint, making migrating a code base super easy.