### PR TITLE
Setup Typos in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,3 +122,21 @@ jobs:
 
       - name: Build documentation
         run: cargo doc --workspace --all-features --document-private-items --no-deps
+
+  typos:
+    name: Check for typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for typos
+        id: typos
+        uses: crate-ci/typos@v1.26.0
+
+      - name: Print help on failure
+        if: ${{ failure() && steps.typos.conclusion == 'failure' }}
+        run: |
+          echo 'To fix typos, please run `typos -w`.'
+          echo 'To check for a diff, run `typos`.'
+          echo 'You can install `typos` at <https://crates.io/crates/typos>.'

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -14,12 +14,12 @@ pub(crate) fn command() -> Command {
     command
 }
 
-/// Try to obtain the Cargo metadata of this pacakge.
+/// Try to obtain the Cargo metadata of this package.
 pub(crate) fn metadata() -> anyhow::Result<Metadata> {
     metadata_with_args::<[&str; 0], &str>([])
 }
 
-/// Try to obtain the Cargo metadata of this pacakge.
+/// Try to obtain the Cargo metadata of this package.
 ///
 /// To see which additional args are available, [consult the `cargo metadata` documentation](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html)
 /// or use `cargo metadata --help`.


### PR DESCRIPTION
[Typos](https://github.com/crate-ci/typos) is a spell checker that is used in both Bevy's engine and website CI. This PR sets up Typos to be run during CI, checking commits and pull requests, since @TimJentzsch may not always be there to catch my spelling mistakes!