### PR TITLE
Improve binary package detection for `bevy run`

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -13,7 +13,7 @@ pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
     if args.is_web() {
         ensure_web_setup()?;
 
-        println!("Compile to WebAssembly...");
+        println!("Compiling to WebAssembly...");
         cargo::build::command().args(cargo_args).ensure_status()?;
 
         println!("Bundling JavaScript bindings...");

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -13,12 +13,11 @@ pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
     if args.is_web() {
         ensure_web_setup()?;
 
-        println!("Building for WASM...");
+        println!("Compile to WebAssembly...");
         cargo::build::command().args(cargo_args).ensure_status()?;
 
-        println!("Bundling for the web...");
-        wasm_bindgen::bundle(&package_name()?, args.profile())
-            .expect("Failed to bundle for the web");
+        println!("Bundling JavaScript bindings...");
+        wasm_bindgen::bundle(&package_name()?, args.profile())?;
     } else {
         cargo::build::command().args(cargo_args).ensure_status()?;
     }

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -73,6 +73,18 @@ pub struct Package {
     pub default_run: Option<String>,
 }
 
+impl Package {
+    /// Check if the package has an executable binary.
+    pub fn has_bin(&self) -> bool {
+        self.targets.iter().any(|target| {
+            target
+                .kind
+                .iter()
+                .any(|target_kind| *target_kind == TargetKind::Bin)
+        })
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Dependency {
     /// The name of the dependency.
@@ -93,7 +105,7 @@ pub struct Dependency {
     pub path: Option<PathBuf>,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DependencyKind {
     #[default]
@@ -113,7 +125,7 @@ pub struct Target {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum TargetKind {
     Lib,

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -41,56 +41,56 @@ pub struct Metadata {
     /// List of all packages in the workspace.
     ///
     /// It also includes all feature-enabled dependencies unless `--no-deps` is used.
-    packages: Vec<Package>,
+    pub packages: Vec<Package>,
     /// List of members of the workspace.
     ///
     /// Each entry is the Package ID for the package.
-    workspace_members: Option<Vec<String>>,
+    pub workspace_members: Option<Vec<String>>,
     /// List of default members of the workspace.
     ///
     /// Each entry is the Package ID for the package.
-    workspace_default_members: Option<Vec<String>>,
+    pub workspace_default_members: Option<Vec<String>>,
     /// The absolute path to the build directory where Cargo places its output.
-    target_directory: PathBuf,
+    pub target_directory: PathBuf,
     /// The absolute path to the root of the workspace.
-    workspace_root: Option<PathBuf>,
+    pub workspace_root: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Package {
     /// The name of the package.
-    name: String,
+    pub name: String,
     /// The version of the package.
-    version: Version,
+    pub version: Version,
     /// The Package ID for referring to the package within the document and as the `--package`
     /// argument to many commands.
-    id: String,
+    pub id: String,
     /// List of Cargo targets.
-    targets: Vec<Target>,
+    pub targets: Vec<Target>,
     /// Absolute path to this package's manifest.
-    manifest_path: PathBuf,
+    pub manifest_path: PathBuf,
     /// Optional string that is the default binary picked by cargo run.
-    default_run: Option<String>,
+    pub default_run: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Dependency {
     /// The name of the dependency.
-    name: String,
+    pub name: String,
     /// The version requirement for the dependency.
     ///
     /// Dependencies without a version requirement have a value of `*`.
     #[serde(default)]
-    req: VersionReq,
+    pub req: VersionReq,
     /// The dependency kind.
     ///
     /// `"dev"`, `"build"`, or `null` for a normal dependency.
     #[serde(default)]
-    kind: DependencyKind,
+    pub kind: DependencyKind,
     /// The file system path for a local path dependency.
     ///
     /// Not present if not a path dependency.
-    path: Option<PathBuf>,
+    pub path: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -106,11 +106,11 @@ pub enum DependencyKind {
 
 #[derive(Debug, Deserialize)]
 pub struct Target {
-    kind: Vec<TargetKind>,
+    pub kind: Vec<TargetKind>,
     /// The name of the target.
     ///
     /// For lib targets, dashes will be replaced with underscores.
-    name: String,
+    pub name: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -14,12 +14,12 @@ pub(crate) fn command() -> Command {
     command
 }
 
-/// Try to obtain the Cargo metadata of this pacakge.
+/// Try to obtain the Cargo metadata of this package.
 pub(crate) fn metadata() -> anyhow::Result<Metadata> {
     metadata_with_args::<[&str; 0], &str>([])
 }
 
-/// Try to obtain the Cargo metadata of this pacakge.
+/// Try to obtain the Cargo metadata of this package.
 ///
 /// To see which additional args are available, [consult the `cargo metadata` documentation](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html)
 /// or use `cargo metadata --help`.

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -26,7 +26,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
 
         // If targeting the web, run a web server with the WASM build
-        println!("Compile to WebAssembly...");
+        println!("Compiling to WebAssembly...");
         cargo::build::command().args(cargo_args).ensure_status()?;
 
         println!("Bundling JavaScript bindings...");

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -26,10 +26,10 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
 
         // If targeting the web, run a web server with the WASM build
-        println!("Building for WASM...");
+        println!("Compile to WebAssembly...");
         cargo::build::command().args(cargo_args).ensure_status()?;
 
-        println!("Bundling for the web...");
+        println!("Bundling JavaScript bindings...");
         let package_name = select_run_package(&metadata, &args.cargo_args)?
             .name
             .clone();

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,8 +2,14 @@ use args::RunSubcommands;
 
 use crate::{
     build::ensure_web_setup,
-    external_cli::{cargo, wasm_bindgen, CommandHelpers},
-    manifest::package_name,
+    external_cli::{
+        cargo::{
+            self,
+            metadata::{Metadata, Package},
+            run::CargoRunArgs,
+        },
+        wasm_bindgen, CommandHelpers,
+    },
 };
 
 pub use self::args::RunArgs;
@@ -17,12 +23,17 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     if let Some(RunSubcommands::Web(web_args)) = &args.subcommand {
         ensure_web_setup()?;
 
+        let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
+
         // If targeting the web, run a web server with the WASM build
         println!("Building for WASM...");
         cargo::build::command().args(cargo_args).ensure_status()?;
 
         println!("Bundling for the web...");
-        wasm_bindgen::bundle(&package_name()?, args.profile())?;
+        let package_name = select_run_package(&metadata, &args.cargo_args)?
+            .name
+            .clone();
+        wasm_bindgen::bundle(&package_name, args.profile())?;
 
         let port = web_args.port;
         let url = format!("http://localhost:{port}");
@@ -46,4 +57,56 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Determine which package should be run.
+fn select_run_package<'a>(
+    metadata: &'a Metadata,
+    args: &CargoRunArgs,
+) -> anyhow::Result<&'a Package> {
+    let package_name = if let Some(bin) = &args.target_args.bin {
+        bin.clone()
+    } else if let Some(package) = &args.package_args.package {
+        package.clone()
+    } else {
+        // Try to determine the run package automatically
+        let default_runs: Vec<_> = metadata
+            .packages
+            .iter()
+            .filter_map(|package| package.default_run.clone())
+            .collect();
+        anyhow::ensure!(default_runs.len() <= 1, "More than one default run target");
+
+        if let Some(default_run) = default_runs.into_iter().next() {
+            default_run
+        } else {
+            // If there is only one package with binary target, use that
+            let bin_packages: Vec<_> = metadata
+                .packages
+                .iter()
+                .filter(|package| package.has_bin())
+                .collect();
+            anyhow::ensure!(
+                bin_packages.len() <= 1,
+                "Multiple binary targets found: {}\nPlease select one with the `--bin` argument",
+                bin_packages
+                    .iter()
+                    .map(|package| package.name.clone())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            );
+
+            anyhow::ensure!(bin_packages.len() == 1, "No binary target found");
+            bin_packages[0].name.clone()
+        }
+    };
+
+    match metadata
+        .packages
+        .iter()
+        .find(|package| package.name == package_name)
+    {
+        Some(package) => Ok(package),
+        None => Err(anyhow::anyhow!("Didn't find package {package_name}")),
+    }
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -60,6 +60,12 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
 }
 
 /// Determine which package should be run.
+///
+/// We first take a look at the `--bin` and `--package` args.
+/// If they are not defined, we try to determine the package automatically with the information
+/// provided by cargo metadata.
+/// We first look for the `default_run` definition and otherwise check if there is only a single
+/// binary package that could be run.
 fn select_run_package<'a>(
     metadata: &'a Metadata,
     args: &CargoRunArgs,


### PR DESCRIPTION
`bevy run web` quickly stopped working for more complex repository setups, because it couldn't figure out which package it had to run.

This PR adds a more sophisticated detection of the binary package detection.
We first take a look at the `--bin` and `--package` args.
If they are not defined, we try to determine the package automatically with the information provided by `cargo metadata`. We first look for the `default_run` definition and otherwise check if there is only a single binary package that could be run.

You can test this with the setup in <https://github.com/TimJentzsch/bevy_complex_repo>.
To do that, first install the Bevy CLI on this branch with `cargo install --path .`, then use `bevy run web` or `bevy run web -p cplx_demo` on that repository in the `app` folder.