### PR TITLE
Support `run_schedule()` in `panicking_world_methods` lint

### DIFF
--- a/bevy_lint/src/lints/panicking_methods.rs
+++ b/bevy_lint/src/lints/panicking_methods.rs
@@ -232,6 +232,7 @@ impl PanickingType {
                 ("resource_ref", "get_resource_ref"),
                 ("non_send_resource", "get_non_send_resource"),
                 ("non_send_resource_mut", "get_non_send_resource_mut"),
+                ("run_schedule", "try_run_schedule"),
                 ("schedule_scope", "try_schedule_scope"),
             ],
         }

--- a/bevy_lint/tests/ui/panicking_methods/world.rs
+++ b/bevy_lint/tests/ui/panicking_methods/world.rs
@@ -56,6 +56,10 @@ fn main() {
     //~^ ERROR: called a `World` method that can panic when a non-panicking alternative exists
     //~| HELP: use `world.get_non_send_resource_mut::<Patrick>()`
 
+    world.run_schedule(Update);
+    //~^ ERROR: called a `World` method that can panic when a non-panicking alternative exists
+    //~| HELP: use `world.try_run_schedule(Update)`
+
     world.schedule_scope(Update, |_world, _schedule| {});
     //~^ ERROR: called a `World` method that can panic when a non-panicking alternative exists
     //~| HELP: use `world.try_schedule_scope(Update, |_world, _schedule| {})`

--- a/bevy_lint/tests/ui/panicking_methods/world.stderr
+++ b/bevy_lint/tests/ui/panicking_methods/world.stderr
@@ -78,10 +78,18 @@ error: called a `World` method that can panic when a non-panicking alternative e
 error: called a `World` method that can panic when a non-panicking alternative exists
   --> tests/ui/panicking_methods/world.rs:59:11
    |
-59 |     world.schedule_scope(Update, |_world, _schedule| {});
+59 |     world.run_schedule(Update);
+   |           ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `world.try_run_schedule(Update)` and handle the `Option` or `Result`
+
+error: called a `World` method that can panic when a non-panicking alternative exists
+  --> tests/ui/panicking_methods/world.rs:63:11
+   |
+63 |     world.schedule_scope(Update, |_world, _schedule| {});
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.try_schedule_scope(Update, |_world, _schedule| {})` and handle the `Option` or `Result`
 
-error: aborting due to 10 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Closes #129.

I missed [`World::run_schedule()`](https://docs.rs/bevy_ecs/0.14.2/bevy_ecs/world/struct.World.html#method.run_schedule) in my first pass over all panicking `World` methods. This fixes that, and suggests `try_run_schedule()` instead.