### PR TITLE
Enable fuzzy-searching for dependency crates in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
     // Enables Rust-Analyzer support for `rustc` crates.
     "rust-analyzer.rustc.source": "discover",
+    // Show dependency types while fuzzy searching, including types from `rustc` crates.
+    "rust-analyzer.workspace.symbol.search.scope": "workspace_and_dependencies",
 }


### PR DESCRIPTION
This change lets contributors using VSCode to press `Ctrl + T` to search for dependency types (including `rustc`!), not just local crate types. (For example, try searching for `TyCtxt`!)

I believe this is an ergonomic improvement, but it can clutter up and slow down the search results. Let me know if you don't think this is an improvement!

Originally found while browsing [Kani's section on working with `rustc`](https://model-checking.github.io/kani/rustc-hacks.html#vscode).