### PR TITLE
Use `cargo doc-lints` when building Github Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,10 +37,9 @@ jobs:
           sweep-cache: true
 
       - name: Build with `rustdoc`
-        # We don't need to document dependencies since this is not intended to be consumed as a
-        # library. Furthermore, we pass `--lib` to prevent it from documenting binaries
-        # automatically.
-        run: cargo doc --package bevy_lint --no-deps --lib
+        # This alias calls `cargo rustdoc` with additional arguments, as specified by
+        # `.cargo/config.toml`.
+        run: cargo doc-lints
 
       - name: Finalize documentation
         run: |


### PR DESCRIPTION
This is a change I forgot to add in #161. It fixes the alerts so instead of looking like:

![image](https://github.com/user-attachments/assets/fcb68295-07b6-4173-94fc-dea13be18d1e)

They look like:

![image](https://github.com/user-attachments/assets/04983c8c-5284-4b14-8b68-af81fba813e5)

While this fix is not necessary for v0.1.0's release, I would like to get it in sooner rather than later! :)