### PR TITLE
`bevy patch` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,11 @@ cargo-generate = "0.22"
 # Better CLI user input
 dialoguer = { version = "0.11.0", default-features = false }
 
-# API interaction
+# JSON serialization.
 serde = { features = ["derive"], version = "1.0.210" }
 serde_json = "1.0.128"
+
+# API interaction
 reqwest = { features = ["blocking", "json"], version = "0.12.7" }
 regex = "1.10.6"
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -39,6 +39,15 @@ pub enum Subcommands {
     Build(BuildArgs),
     /// Run your Bevy app.
     Run(RunArgs),
+    /// Generates the `[patch.crates-io]` table when overriding Bevy's source.
+    /// 
+    /// This command is useful when you want to migrate an existing project to an unstable version
+    /// of Bevy or a custom fork. It outputs a `[patch.crates-io]` table to override all official
+    /// Bevy crates in a workspace, meant to be appended to the root `Cargo.toml` file of your
+    /// project.
+    /// 
+    /// Please note that the version in the patched Bevy's repository must correspond to the
+    /// version in your `Cargo.toml`, or it will resolve to <https://crates.io> instead.
     Patch(PatchArgs),
     /// Check the current project using Bevy-specific lints.
     ///

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use bevy_cli::{build::BuildArgs, run::RunArgs};
+use bevy_cli::{build::BuildArgs, patch::PatchArgs, run::RunArgs};
 use clap::{Args, Parser, Subcommand};
 
 fn main() -> Result<()> {
@@ -9,9 +9,10 @@ fn main() -> Result<()> {
         Subcommands::New(new) => {
             bevy_cli::template::generate_template(&new.name, &new.template, &new.branch)?;
         }
-        Subcommands::Lint { args } => bevy_cli::lint::lint(args)?,
         Subcommands::Build(args) => bevy_cli::build::build(&args)?,
         Subcommands::Run(args) => bevy_cli::run::run(&args)?,
+        Subcommands::Patch(args) => bevy_cli::patch::patch(&args)?,
+        Subcommands::Lint { args } => bevy_cli::lint::lint(args)?,
     }
 
     Ok(())
@@ -38,6 +39,7 @@ pub enum Subcommands {
     Build(BuildArgs),
     /// Run your Bevy app.
     Run(RunArgs),
+    Patch(PatchArgs),
     /// Check the current project using Bevy-specific lints.
     ///
     /// This command requires `bevy_lint` to be installed, and will fail if it is not. Please see

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -71,6 +71,8 @@ pub struct Package {
     pub manifest_path: PathBuf,
     /// Optional string that is the default binary picked by cargo run.
     pub default_run: Option<String>,
+    /// A list of direct dependencies for this package.
+    pub dependencies: Vec<Dependency>,
 }
 
 impl Package {
@@ -108,12 +110,13 @@ pub struct Dependency {
 #[derive(Debug, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DependencyKind {
-    #[default]
-    Normal,
     Dev,
     Build,
+    // While `Dev` and `Build` are represented in their string forms, `Null` is represented as
+    // `null` instead of `"null"` in JSON.
+    #[default]
     #[serde(untagged)]
-    Unknown(String),
+    Null,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@ pub mod build;
 pub mod external_cli;
 pub mod lint;
 pub mod manifest;
+pub mod patch;
 pub mod run;
 pub mod template;

--- a/src/patch/args.rs
+++ b/src/patch/args.rs
@@ -1,0 +1,4 @@
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct PatchArgs {}

--- a/src/patch/args.rs
+++ b/src/patch/args.rs
@@ -1,4 +1,27 @@
 use clap::Args;
 
-#[derive(Debug, Args)]
-pub struct PatchArgs {}
+#[derive(Args, Debug)]
+pub struct PatchArgs {
+    /// The URL to the Git repository.
+    #[arg(long)]
+    pub git: String,
+    
+    #[clap(flatten)]
+    pub git_revision_args: GitRevisionArgs,
+}
+
+#[derive(Args, Debug)]
+#[group(multiple = false)]
+pub struct GitRevisionArgs {
+    /// The branch of the Git repository to use.
+    #[clap(long)]
+    pub branch: Option<String>,
+
+    /// The tag of the Git repository to use.
+    #[clap(long)]
+    pub tag: Option<String>,
+
+    /// The revision (commit or reference) of the Git repository to use.
+    #[clap(long)]
+    pub rev: Option<String>,
+}

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -1,0 +1,13 @@
+mod args;
+
+use crate::external_cli::cargo;
+
+pub use self::args::PatchArgs;
+
+pub fn patch(args: &PatchArgs) -> anyhow::Result<()> {
+    let metadata = cargo::metadata::metadata()?;
+
+    todo!();
+
+    Ok(())
+}

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -1,13 +1,84 @@
 mod args;
 
-use crate::external_cli::cargo;
-
 pub use self::args::PatchArgs;
+
+use crate::external_cli::cargo::{self, metadata::DependencyKind};
+use anyhow::bail;
+use args::GitRevisionArgs;
 
 pub fn patch(args: &PatchArgs) -> anyhow::Result<()> {
     let metadata = cargo::metadata::metadata()?;
 
-    todo!();
+    // Find `bevy_internal` within this workspace's list of packages. (This list contains
+    // dependencies of crates, since we didn't specify `--no-deps`.) `bevy_internal` depends on
+    // almost all official Bevy crates, excluding `bevy`, `bevy_dylib`, and `bevy_internal` itself.
+    let Some(bevy_internal) = metadata
+        .packages
+        .into_iter()
+        .find(|p| p.name == "bevy_internal")
+    else {
+        bail!(
+            "`bevy_internal` cannot be found in dependencies. Is Bevy installed as a dependency?"
+        );
+    };
+
+    // Generate a (potentially empty) string containing the Git repository revision specification.
+    // For example, if `--branch patch-1` was specified, this would be `, branch = "patch-1"`.
+    let revision_fragment = git_revision_fragment(&args.git_revision_args);
+
+    println!("[patch.crates-io]");
+
+    // These 3 are not dependencies of `bevy_internal`, so they need to be emitted manually.
+    println!("bevy = {{ git = \"{}\"{} }}", args.git, revision_fragment);
+    println!(
+        "bevy_internal = {{ git = \"{}\"{} }}",
+        args.git, revision_fragment
+    );
+    println!(
+        "bevy_dylib = {{ git = \"{}\"{} }}",
+        args.git, revision_fragment
+    );
+
+    for d in bevy_internal
+        .dependencies
+        .into_iter()
+        // Skip dev-dependencies and build-dependencies.
+        .filter(|d| matches!(d.kind, DependencyKind::Null))
+        // While `bevy_internal` doesn't directly depend on any non-Bevy crates currently, that may
+        // change in the future. This is a future-proof, in case a crate like `cfg_if` is added.
+        .filter(|d| d.name.starts_with("bevy_"))
+    {
+        println!(
+            "{} = {{ git = \"{}\"{} }}",
+            d.name, args.git, revision_fragment
+        );
+    }
 
     Ok(())
+}
+
+/// Returns a string fragment leading after `git = "<git>"` in a dependency patch specification.
+fn git_revision_fragment(revision_args: &GitRevisionArgs) -> String {
+    // `branch`, `tag`, and `rev` are exclusive to each other in the CLI. If we find `Some` for
+    // one, we can assume that the other two are `None`.
+    match revision_args {
+        // If no revision is specified, use the default `{ git = "<git>" }`.
+        GitRevisionArgs {
+            branch: None,
+            tag: None,
+            rev: None,
+        } => String::new(),
+
+        // If `--branch` is specified, use `{ git = "<git>", branch = "<branch>" }`.
+        GitRevisionArgs {
+            branch: Some(branch),
+            ..
+        } => format!(", branch = \"{branch}\""),
+
+        // If `--tag` is specified, use `{ git = "<git>", tag = "<tag>" }`.
+        GitRevisionArgs { tag: Some(tag), .. } => format!(", tag = \"{tag}\""),
+
+        // If `--rev` is specified, use `{ git = "<git>", rev = "<rev>" }`.
+        GitRevisionArgs { rev: Some(rev), .. } => format!(", rev = \"{rev}\""),
+    }
 }


### PR DESCRIPTION
Closes #79.

This is my first working draft of the `bevy patch` command, which can generate a `[patch.crates-io]` for the current workspace. It still needs a bit of work, so I'm putting it on hold until v0.1.0 of the linter is released.