### PR TITLE
v0.1.0 post-release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_lint"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "bevy",

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+**All Changes**: [`lint-v0.1.0...main`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.1.0...main)
+
 ## 0.1.0 - 2024-11-17
 
 **All Changes**: [`17834eb...lint-v0.1.0`](https://github.com/TheBevyFlock/bevy_cli/compare/17834eb...lint-v0.1.0)

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_lint"
-version = "0.1.0"
+version = "0.2.0-dev"
 authors = ["BD103"]
 edition = "2021"
 description = "A collection of lints for the Bevy game engine"

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -154,6 +154,7 @@ There are several other ways to toggle lints, but they have varying levels of su
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
+|0.2.0-dev|1.84.0|`nightly-2024-11-14`|0.14|
 |0.1.0|1.84.0|`nightly-2024-11-14`|0.14|
 
 The Rust version in the above table specifies what [version of the Rust language](https://github.com/rust-lang/rust/releases) can be compiled with `bevy_lint`. Code written for a later version of Rust may not compile. (This is not usually an issue, though, because `bevy_lint`'s Rust version is kept 1 to 2 releases ahead of stable Rust.)

--- a/bevy_lint/docs/release.md
+++ b/bevy_lint/docs/release.md
@@ -21,6 +21,12 @@
 ````markdown
 <!-- One-sentence summary of changes. What awesome features can we spotlight? What critical bugs were fixed? -->
 
+You can find the live documentation for this release [here](https://thebevyflock.github.io/bevy_cli/bevy_lint/).
+
+> [!WARNING]
+>
+> This is an unofficial community project, hacked upon by the Bevy CLI working group until it is eventually upstreamed into the main [Bevy Engine organization](https://github.com/bevyengine). Pardon our rough edges, and please consider [submitting an issue](https://github.com/TheBevyFlock/bevy_cli/issues) if you run into trouble!
+
 <!-- You can refer to the compatibility table in `bevy_lint/README.md` for the following two values. -->
 
 This release uses the <!-- `nightly-YYYY-MM-DD` --> toolchain, based on Rust <!-- 1.XX.Y -->. You can install it from Git with the following commands:
@@ -39,7 +45,7 @@ rustup run nightly-YYYY-MM-DD cargo install \
     bevy_lint
 ```
 
-<!-- Paste the changelog for this release here. -->
+<!-- Paste the changelog for this release here. Make sure to include the "All Changes" link. :) -->
 ````
 
 5. Check the pre-release box if this is an alpha release, then click "Publish release"!
@@ -58,5 +64,6 @@ rustup run nightly-YYYY-MM-DD cargo install \
 ```
 
 2. Bump the version in [`Cargo.toml`](../Cargo.toml) to the next `-dev` version, and ensure [`Cargo.lock`](../../Cargo.lock) also updates.
-3. Commit all of these changes and open a pull request.
-4. Merge the PR after it has been approved, unblocking frozen pull requests.
+3. Add a new row to the compatibility table for the new `-dev` version in [`README.md`](../README.md).
+4. Commit all of these changes and open a pull request.
+5. Merge the PR after it has been approved, unblocking frozen pull requests.


### PR DESCRIPTION
This, following the [release checklist](https://github.com/TheBevyFlock/bevy_cli/blob/663298e1e24a6422abd001b6142dc53f371c3bcd/bevy_lint/docs/release.md), updates `bevy_lint` to v0.2.0-dev. I also added some missing information to the release checklist, based off of my experience releasing v0.1.0.

Once this is merged, the feature freeze will be lifted, letting #164 and #173 be merged.