### PR TITLE
Linter: Support Bevy 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "accesskit"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf780eb737f2d4a49ffbd512324d53ad089070f813f7be7f99dbd5123a7f448"
-
-[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,7 +31,7 @@ dependencies = [
  "actix-web",
  "bitflags",
  "bytes",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "http-range",
  "log",
@@ -64,7 +58,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "flate2",
  "futures-core",
@@ -180,7 +174,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -381,6 +375,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_type_match"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,30 +450,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043c9ad4b6fc4ca52d779873a8ca792a4e37842d07fce95363c9e17e36a1d8a0"
+checksum = "b6a01cd51a5cd310e4e7aa6e1560b1aabf29efc6a095a01e6daa8bf0a19f1fea"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
-name = "bevy_a11y"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a976cb539d6a5a3ff579cdb78187a6bcfbffa7e8224ea28f23d8b983d9389"
-dependencies = [
- "accesskit",
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
-]
-
-[[package]]
 name = "bevy_app"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5361d0f8a8677a5d0102cfe7321a7ecd2a8b9a4f887ce0dde1059311cf9cd42"
+checksum = "652574e4c10efcfa70f98036709dd5b67e5cb8d46c58087ef48c2ac6b62df9da"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -476,8 +469,9 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "console_error_panic_hook",
+ "ctrlc",
+ "derive_more 1.0.0",
  "downcast-rs",
- "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -502,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de706862871a1fe99ea619bff2f99d73e43ad82f19ef866a9e19a14c957c8537"
+checksum = "ecccf7be33330f58d4c7033b212a25c414d388e3a8d55b61331346da5dbabf22"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -516,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbfc33a4c6b80760bb8bf850a2cc65a1e031da62fd3ca8b552189104dc98514"
+checksum = "e141b7eda52a23bb88740b37a291e26394524cb9ee3b034c7014669671fc2bb5"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -527,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebb154e0cc78e3bbfbfdb42fb502b14c1cd47e72f16e6d4228dfe6233ba6cbd"
+checksum = "fa97748337405089edfb2857f7608f21bcc648a7ad272c9209808aad252ed542"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -542,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee4222406637f3c8e3991a99788cfcde76097bf997c311f1b6297364057483f"
+checksum = "cb4c4b60d2a712c6d5cbe610bac7ecf0838fc56a095fd5b15f30230873e84f15"
 dependencies = [
  "bevy_ecs_macros",
  "bevy_ptr",
@@ -553,18 +547,20 @@ dependencies = [
  "bevy_utils",
  "bitflags",
  "concurrent-queue",
+ "derive_more 1.0.0",
+ "disqualified",
  "fixedbitset 0.5.7",
  "nonmax",
  "petgraph",
  "serde",
- "thiserror 1.0.69",
+ "smallvec",
 ]
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b573430b67aff7bde8292257494f39343401379bfbda64035ba4918bba7b20"
+checksum = "cb4296b3254b8bd29769f6a4512731b2e6c4b163343ca18b72316927315b6096"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -574,40 +570,41 @@ dependencies = [
 
 [[package]]
 name = "bevy_hierarchy"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b912b37e1bc4dbb2aa40723199f74c8b06c4fbb6da0bb4585131df28ef66e"
+checksum = "6fe0b538beea7edbf30a6062242b99e67ff3bfa716566aacf91d5b5e027f02a2"
 dependencies = [
  "bevy_app",
  "bevy_core",
  "bevy_ecs",
  "bevy_reflect",
  "bevy_utils",
+ "disqualified",
  "smallvec",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd3a54e67cc3ba17971de7b1a7e64eda84493c1e7bb6bfa11c6cf8ac124377b"
+checksum = "46b4ea60095d1a1851e40cb12481ad3d5d234e14376d6b73142a85586c266b74"
 dependencies = [
  "bevy_app",
+ "bevy_core",
  "bevy_ecs",
  "bevy_math",
  "bevy_reflect",
  "bevy_utils",
+ "derive_more 1.0.0",
  "smol_str",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_internal"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d435cac77c568f3aef65f786a5fee0e53c81950c5258182dd2c1d6cd6c4fec"
+checksum = "d4237e6e9b03902321032f00f931f18a4a211093bd9a7cf81276a0228a2a4417"
 dependencies = [
- "bevy_a11y",
  "bevy_app",
  "bevy_core",
  "bevy_derive",
@@ -623,7 +620,6 @@ dependencies = [
  "bevy_time",
  "bevy_transform",
  "bevy_utils",
- "bevy_window",
 ]
 
 [[package]]
@@ -641,24 +637,25 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67240c7596c8f0653e50fce35a60196516817449235193246599facba9002e02"
+checksum = "1a0bdb42b00ac3752f0d6f531fbda8abf313603157a7b3163da8529412119a0a"
 dependencies = [
  "android_log-sys",
  "bevy_app",
  "bevy_ecs",
  "bevy_utils",
  "tracing-log",
+ "tracing-oslog",
  "tracing-subscriber",
  "tracing-wasm",
 ]
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc65e570012e64a21f3546df68591aaede8349e6174fb500071677f54f06630"
+checksum = "3954dbb56a66a6c09c783e767f6ceca0dc0492c22e536e2aeaefb5545eac33c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -668,47 +665,51 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5421792749dda753ab3718e77d27bfce38443daf1850b836b97530b6245a4581"
+checksum = "9ae26f952598e293acac783d947b21af1809673cbeba25d76b969a56f287160b"
 dependencies = [
  "bevy_reflect",
+ "derive_more 1.0.0",
  "glam",
+ "itertools 0.13.0",
  "rand",
+ "rand_distr",
  "serde",
  "smallvec",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_ptr"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61baa1bdc1f4a7ac2c18217570a7cc04e1cd54d38456e91782f0371c79afe0a8"
+checksum = "2af9e30b40fb3f0a80a658419f670f2de1e743efcaca1952c43cdcc923287944"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2508785a4a5809f25a237eec4fee2c91a4dbcf81324b2bbc2d6c52629e603781"
+checksum = "52a37e2ae5ed62df4a0e3f958076effe280b39bc81fe878587350897a89332a2"
 dependencies = [
+ "assert_type_match",
  "bevy_ptr",
  "bevy_reflect_derive",
  "bevy_utils",
+ "derive_more 1.0.0",
+ "disqualified",
  "downcast-rs",
  "erased-serde",
  "glam",
  "serde",
  "smallvec",
  "smol_str",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967d5da1882ec3bb3675353915d3da909cafac033cbf31e58727824a1ad2a288"
+checksum = "94c683fc68c75fc26f90bb1e529590095380d7cec66f6610dbe6b93d9fd26f94"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -719,48 +720,49 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77865f310b1fc48fb05b7c4adbe76607ec01d0c14f8ab4caba4d714c86439946"
+checksum = "5171c605b462b4e3249e01986505e62e3933aa27642a9f793c841814fcbbfb4f"
 dependencies = [
  "async-executor",
+ "futures-channel",
  "futures-lite",
+ "pin-project",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_time"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e4d53ec32a1b16492396951d04de0d2d90e924bf9adcb8d1adacab5ab6c17c"
+checksum = "291b6993b899c04554fc034ebb9e0d7fde9cb9b2fb58dcd912bfa6247abdedbb"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_reflect",
  "bevy_utils",
  "crossbeam-channel",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_transform"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5493dce84427d00a9266e8e4386d738a72ee8640423b62dfcecb6dfccbfe0d2"
+checksum = "dc35665624d0c728107ab0920d5ad2d352362b906a8c376eaf375ec9c751faf4"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
- "thiserror 1.0.69",
+ "derive_more 1.0.0",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb0ec333b5965771153bd746f92ffd8aeeb9d008a8620ffd9ed474859381a5e"
+checksum = "a0a48bad33c385a7818b7683a16c8b5c6930eded05cd3f176264fc1f5acea473"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
@@ -773,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils_proc_macros"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f1ab8f2f6f58439d260081d89a42b02690e5fdd64f814edc9417d33fcf2857"
+checksum = "3dfd8d4a525b8f04f85863e45ccad3e922d4c11ed4a8d54f7f62a40bf83fb90f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -783,19 +785,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_window"
-version = "0.14.2"
+name = "bindgen"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e88a20db64ea8204540afb4699295947c454738fd50293f7b32ab8be857a6"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bevy_a11y",
- "bevy_app",
- "bevy_ecs",
- "bevy_math",
- "bevy_reflect",
- "bevy_utils",
- "raw-window-handle",
- "smol_str",
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -979,6 +985,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1004,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -1272,6 +1298,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cvt"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1336,27 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1356,6 +1413,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "disqualified"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c272297e804878a2a4b707cfcfc6d2328b5bb936944613b4fdf2b9269afdfd"
 
 [[package]]
 name = "doc-comment"
@@ -1868,14 +1931,20 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.27.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+checksum = "dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677"
 dependencies = [
  "bytemuck",
  "rand",
  "serde",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -2457,6 +2526,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,6 +2720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2801,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,6 +2848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2990,6 +3092,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,6 +3158,16 @@ checksum = "abec3fb083c10660b3854367697da94c674e9e82aa7511014dc958beeb7215e9"
 dependencies = [
  "owo-colors",
  "pad",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -3093,10 +3225,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-window-handle"
-version = "0.6.2"
+name = "rand_distr"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3274,6 +3410,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_apfloat"
@@ -3978,6 +4120,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cfg-if",
+ "once_cell",
+ "parking_lot",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,6 +4257,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -41,7 +41,7 @@ toml_edit = { version = "0.22.22", default-features = false, features = [
 
 [dev-dependencies]
 # Used when running UI tests.
-bevy = { version = "0.14.2", default-features = false }
+bevy = { version = "0.15.0", default-features = false }
 
 # Used to deserialize `--message-format=json` messages from Cargo.
 serde = { version = "1.0.210", features = ["derive"] }

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -154,7 +154,7 @@ There are several other ways to toggle lints, but they have varying levels of su
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
-|0.2.0-dev|1.84.0|`nightly-2024-11-28`|0.14|
+|0.2.0-dev|1.84.0|`nightly-2024-11-28`|0.15|
 |0.1.0|1.84.0|`nightly-2024-11-14`|0.14|
 
 The Rust version in the above table specifies what [version of the Rust language](https://github.com/rust-lang/rust/releases) can be compiled with `bevy_lint`. Code written for a later version of Rust may not compile. (This is not usually an issue, though, because `bevy_lint`'s Rust version is kept 1 to 2 releases ahead of stable Rust.)

--- a/bevy_lint/src/paths.rs
+++ b/bevy_lint/src/paths.rs
@@ -8,9 +8,8 @@
 
 pub const APP: [&str; 3] = ["bevy_app", "app", "App"];
 pub const COMPONENT: [&str; 3] = ["bevy_ecs", "component", "Component"];
-// Note that this moves to `bevy_ecs::event::base::Event` in 0.15.
-pub const EVENT: [&str; 3] = ["bevy_ecs", "event", "Event"];
-pub const EVENTS: [&str; 3] = ["bevy_ecs", "event", "Events"];
+pub const EVENT: [&str; 4] = ["bevy_ecs", "event", "base", "Event"];
+pub const EVENTS: [&str; 4] = ["bevy_ecs", "event", "collections", "Events"];
 pub const PLUGIN: [&str; 3] = ["bevy_app", "plugin", "Plugin"];
 pub const QUERY: [&str; 4] = ["bevy_ecs", "system", "query", "Query"];
 pub const QUERY_STATE: [&str; 4] = ["bevy_ecs", "query", "state", "QueryState"];

--- a/bevy_lint/tests/ui/missing_reflect/impl.rs
+++ b/bevy_lint/tests/ui/missing_reflect/impl.rs
@@ -37,4 +37,6 @@ impl Component for MyEvent {
 }
 
 //~v NOTE: `Event` implemented here
-impl Event for MyEvent {}
+impl Event for MyEvent {
+    type Traversal = ();
+}

--- a/bevy_lint/tests/ui/missing_reflect/impl.stderr
+++ b/bevy_lint/tests/ui/missing_reflect/impl.stderr
@@ -7,8 +7,10 @@ error: defined an event without a `Reflect` implementation
 note: `Event` implemented here
   --> tests/ui/missing_reflect/impl.rs:40:1
    |
-40 | impl Event for MyEvent {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+40 | / impl Event for MyEvent {
+41 | |     type Traversal = ();
+42 | | }
+   | |_^
 note: the lint level is defined here
   --> tests/ui/missing_reflect/impl.rs:8:9
    |

--- a/bevy_lint/tests/ui/missing_reflect/impl_ref.rs
+++ b/bevy_lint/tests/ui/missing_reflect/impl_ref.rs
@@ -42,4 +42,6 @@ impl Component for &'static &'static &'static MyEvent {
 }
 
 //~v NOTE: `Event` implemented here
-impl Event for &'static &'static &'static MyEvent {}
+impl Event for &'static &'static &'static MyEvent {
+    type Traversal = ();
+}

--- a/bevy_lint/tests/ui/missing_reflect/impl_ref.stderr
+++ b/bevy_lint/tests/ui/missing_reflect/impl_ref.stderr
@@ -7,8 +7,10 @@ error: defined an event without a `Reflect` implementation
 note: `Event` implemented here
   --> tests/ui/missing_reflect/impl_ref.rs:45:1
    |
-45 | impl Event for &'static &'static &'static MyEvent {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+45 | / impl Event for &'static &'static &'static MyEvent {
+46 | |     type Traversal = ();
+47 | | }
+   | |_^
 note: the lint level is defined here
   --> tests/ui/missing_reflect/impl_ref.rs:13:9
    |

--- a/bevy_lint/tests/ui/panicking_methods/world.rs
+++ b/bevy_lint/tests/ui/panicking_methods/world.rs
@@ -28,10 +28,12 @@ fn main() {
     //~^ ERROR: called a `World` method that can panic when a non-panicking alternative exists
     //~| HELP: use `world.get_entity_mut(bob)`
 
+    #[expect(deprecated, reason = "While this method is deprecated, we should still check for it while it exists.")]
     world.many_entities([bob]);
     //~^ ERROR: called a `World` method that can panic when a non-panicking alternative exists
     //~| HELP: use `world.get_many_entities([bob])`
 
+    #[expect(deprecated, reason = "While this method is deprecated, we should still check for it while it exists.")]
     world.many_entities_mut([bob]);
     //~^ ERROR: called a `World` method that can panic when a non-panicking alternative exists
     //~| HELP: use `world.get_many_entities_mut([bob])`

--- a/bevy_lint/tests/ui/panicking_methods/world.stderr
+++ b/bevy_lint/tests/ui/panicking_methods/world.stderr
@@ -20,73 +20,73 @@ error: called a `World` method that can panic when a non-panicking alternative e
    = help: use `world.get_entity_mut(bob)` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:31:11
+  --> tests/ui/panicking_methods/world.rs:32:11
    |
-31 |     world.many_entities([bob]);
+32 |     world.many_entities([bob]);
    |           ^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.get_many_entities([bob])` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:35:11
+  --> tests/ui/panicking_methods/world.rs:37:11
    |
-35 |     world.many_entities_mut([bob]);
+37 |     world.many_entities_mut([bob]);
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.get_many_entities_mut([bob])` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:39:11
+  --> tests/ui/panicking_methods/world.rs:41:11
    |
-39 |     world.resource::<Jeffrey>();
+41 |     world.resource::<Jeffrey>();
    |           ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.get_resource::<Jeffrey>()` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:43:11
+  --> tests/ui/panicking_methods/world.rs:45:11
    |
-43 |     world.resource_mut::<Jeffrey>();
+45 |     world.resource_mut::<Jeffrey>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.get_resource_mut::<Jeffrey>()` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:47:11
+  --> tests/ui/panicking_methods/world.rs:49:11
    |
-47 |     world.resource_ref::<Jeffrey>();
+49 |     world.resource_ref::<Jeffrey>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.get_resource_ref::<Jeffrey>()` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:51:11
+  --> tests/ui/panicking_methods/world.rs:53:11
    |
-51 |     world.non_send_resource::<Patrick>();
+53 |     world.non_send_resource::<Patrick>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.get_non_send_resource::<Patrick>()` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:55:11
+  --> tests/ui/panicking_methods/world.rs:57:11
    |
-55 |     world.non_send_resource_mut::<Patrick>();
+57 |     world.non_send_resource_mut::<Patrick>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.get_non_send_resource_mut::<Patrick>()` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:59:11
+  --> tests/ui/panicking_methods/world.rs:61:11
    |
-59 |     world.run_schedule(Update);
+61 |     world.run_schedule(Update);
    |           ^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.try_run_schedule(Update)` and handle the `Option` or `Result`
 
 error: called a `World` method that can panic when a non-panicking alternative exists
-  --> tests/ui/panicking_methods/world.rs:63:11
+  --> tests/ui/panicking_methods/world.rs:65:11
    |
-63 |     world.schedule_scope(Update, |_world, _schedule| {});
+65 |     world.schedule_scope(Update, |_world, _schedule| {});
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `world.try_schedule_scope(Update, |_world, _schedule| {})` and handle the `Option` or `Result`


### PR DESCRIPTION
This updates the linter to support Bevy 0.15. As #138 has not yet been implemented, Bevy 0.14 support is being dropped.[^0]

Overall, it was surprisingly simple. I bumped the version of Bevy we use in testing, then fixed any errors. The UI tests are so rigid that even the slightest quiver could cause them to fail, which in this case is a good thing!

The one thing of note is that I'm keeping support for `World::many_entities()` and `many_entities_mut()` in `bevy::panicking_world_methods` even though they are deprecated. Since `panicking_methods` is likely a lint that would be denied in projects, I don't want panicking methods to slip by just because someone added `#[allow(deprecated)]` while migration their project. Once these methods are completely removed from Bevy, we'll remove them from the linter.

[^0]: I hope this won't be permanent, though. If all goes to plan, support for 0.14 will be re-added before the next release of `bevy_lint`!