### PR TITLE
feat: add neovim section to the editor tutorial

### DIFF
--- a/bevy_lint/docs/tutorials/editor.md
+++ b/bevy_lint/docs/tutorials/editor.md
@@ -18,4 +18,10 @@ There can be a few extra steps required to get code-completion and syntax highli
 
 ## Neovim
 
-TODO :)
+> [!NOTE]
+> 
+> This requires rust-analyzer to be already set up and configure with Neovim
+
+For Neovim the easiest way to configure rust-analyzer for rustc types is to use [neoconf.nvim], which allows importing settings from [`.vscode/settings.json`].
+
+[neoconf.nvim]: https://github.com/folke/neoconf.nvim/


### PR DESCRIPTION
The neovim part is a bit flexible for a tutorial maybe better as a howto (bikeshedding) regardless I think this should be enough to get people started and not wondering why they don't get LSP hints