### PR TITLE
Add --yes argument to confirm all prompts automatically

### DIFF
--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -10,7 +10,7 @@ pub struct BuildArgs {
 
     /// Confirm all prompts automatically.
     #[arg(long = "yes", default_value_t = false)]
-    pub silent: bool,
+    pub skip_prompts: bool,
 
     /// Arguments to forward to `cargo build`.
     #[clap(flatten)]

--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -8,6 +8,10 @@ pub struct BuildArgs {
     #[clap(subcommand)]
     pub subcommand: Option<BuildSubcommands>,
 
+    /// Confirm all prompts automatically.
+    #[arg(long = "yes", default_value_t = false)]
+    pub silent: bool,
+
     /// Arguments to forward to `cargo build`.
     #[clap(flatten)]
     pub cargo_args: CargoBuildArgs,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -11,7 +11,7 @@ pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
     let cargo_args = args.cargo_args_builder();
 
     if args.is_web() {
-        ensure_web_setup()?;
+        ensure_web_setup(args.silent)?;
 
         let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
 
@@ -35,11 +35,11 @@ pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(crate) fn ensure_web_setup() -> anyhow::Result<()> {
+pub(crate) fn ensure_web_setup(silent: bool) -> anyhow::Result<()> {
     // `wasm32-unknown-unknown` compilation target
-    rustup::install_target_if_needed("wasm32-unknown-unknown")?;
+    rustup::install_target_if_needed("wasm32-unknown-unknown", silent)?;
     // `wasm-bindgen-cli` for bundling
-    cargo::install::if_needed(wasm_bindgen::PROGRAM, wasm_bindgen::PACKAGE, true, false)?;
+    cargo::install::if_needed(wasm_bindgen::PROGRAM, wasm_bindgen::PACKAGE, !silent, false)?;
 
     Ok(())
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -11,7 +11,7 @@ pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
     let cargo_args = args.cargo_args_builder();
 
     if args.is_web() {
-        ensure_web_setup(args.silent)?;
+        ensure_web_setup(args.skip_prompts)?;
 
         let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
 
@@ -35,11 +35,16 @@ pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(crate) fn ensure_web_setup(silent: bool) -> anyhow::Result<()> {
+pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {
     // `wasm32-unknown-unknown` compilation target
-    rustup::install_target_if_needed("wasm32-unknown-unknown", silent)?;
+    rustup::install_target_if_needed("wasm32-unknown-unknown", skip_prompts)?;
     // `wasm-bindgen-cli` for bundling
-    cargo::install::if_needed(wasm_bindgen::PROGRAM, wasm_bindgen::PACKAGE, !silent, false)?;
+    cargo::install::if_needed(
+        wasm_bindgen::PROGRAM,
+        wasm_bindgen::PACKAGE,
+        skip_prompts,
+        false,
+    )?;
 
     Ok(())
 }

--- a/src/external_cli/cargo/install.rs
+++ b/src/external_cli/cargo/install.rs
@@ -21,7 +21,7 @@ fn is_installed(program: &str) -> bool {
 pub(crate) fn if_needed(
     program: &str,
     package: &str,
-    ask_user: bool,
+    skip_prompts: bool,
     hidden: bool,
 ) -> anyhow::Result<bool> {
     if is_installed(program) {
@@ -29,7 +29,7 @@ pub(crate) fn if_needed(
     }
 
     // Abort if the user doesn't want to install it
-    if ask_user
+    if !skip_prompts
         && !Confirm::new()
             .with_prompt(format!(
                 "`{program}` is missing, should I install it for you?"

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -22,20 +22,24 @@ fn is_target_installed(target: &str) -> bool {
 }
 
 /// Install a compilation target, if it is not already installed.
-pub(crate) fn install_target_if_needed(target: &str) -> anyhow::Result<()> {
+pub(crate) fn install_target_if_needed(target: &str, silent: bool) -> anyhow::Result<()> {
     if is_target_installed(target) {
         return Ok(());
     }
 
-    // Abort if the user doesn't want to install it
-    if !Confirm::new()
-        .with_prompt(format!(
-            "Compilation target `{target}` is missing, should I install it for you?",
-        ))
-        .interact()?
-    {
-        anyhow::bail!("User does not want to install target `{target}`.");
+    if !silent {
+        // Abort if the user doesn't want to install it
+        if !Confirm::new()
+            .with_prompt(format!(
+                "Compilation target `{target}` is missing, should I install it for you?",
+            ))
+            .interact()?
+        {
+            anyhow::bail!("User does not want to install target `{target}`.");
+        }
     }
+
+    println!("Installing missing target: `{target}`");
 
     let mut cmd = Command::new(program());
     cmd.arg("target").arg("add").arg(target);

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -10,7 +10,7 @@ pub struct RunArgs {
 
     /// Confirm all prompts automatically.
     #[arg(long = "yes", default_value_t = false)]
-    pub silent: bool,
+    pub skip_prompts: bool,
 
     /// Commands to forward to `cargo run`.
     #[clap(flatten)]

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -8,6 +8,10 @@ pub struct RunArgs {
     #[command(subcommand)]
     pub subcommand: Option<RunSubcommands>,
 
+    /// Confirm all prompts automatically.
+    #[arg(long = "yes", default_value_t = false)]
+    pub silent: bool,
+
     /// Commands to forward to `cargo run`.
     #[clap(flatten)]
     pub cargo_args: CargoRunArgs,

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -19,7 +19,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     let cargo_args = args.cargo_args_builder();
 
     if let Some(RunSubcommands::Web(web_args)) = &args.subcommand {
-        ensure_web_setup()?;
+        ensure_web_setup(args.silent)?;
 
         let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -19,7 +19,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     let cargo_args = args.cargo_args_builder();
 
     if let Some(RunSubcommands::Web(web_args)) = &args.subcommand {
-        ensure_web_setup(args.silent)?;
+        ensure_web_setup(args.skip_prompts)?;
 
         let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
 


### PR DESCRIPTION
Closes #203 

Add a `--yes` flag to `bevy run` and `bevy build`.
Pass the flag to `bevy_cli::external_cli::cargo::install` and `bevy_cli::external_cli::rustup::install_target_if_needed`