### PR TITLE
Bump linter to `nightly-2025-01-09`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,9 +1080,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.85"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7bc44cade8ee3453cbb02297635ac506c6ea9eda9e5ed85c7eee8649f56bbc"
+checksum = "8af2d96f902b34d144749decfdcb15187980e511e840c33801fb977a3dd9bad7"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -28,7 +28,7 @@ harness = false
 # Contains a series of useful utilities when writing lints. The version is chosen to work with the
 # currently pinned nightly Rust version. When the Rust version changes, this too needs to be
 # updated!
-clippy_utils = "=0.1.85"
+clippy_utils = "=0.1.86"
 
 # Easy error propagation and contexts.
 anyhow = "1.0.86"

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -154,7 +154,7 @@ There are several other ways to toggle lints, but they have varying levels of su
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
-|0.2.0-dev|1.84.0|`nightly-2024-11-28`|0.15|
+|0.2.0-dev|1.84.0|`nightly-2025-01-09`|0.15|
 |0.1.0|1.84.0|`nightly-2024-11-14`|0.14|
 
 The Rust version in the above table specifies what [version of the Rust language](https://github.com/rust-lang/rust/releases) can be compiled with `bevy_lint`. Code written for a later version of Rust may not compile. (This is not usually an issue, though, because `bevy_lint`'s Rust version is kept 1 to 2 releases ahead of stable Rust.)

--- a/bevy_lint/docs/README.md
+++ b/bevy_lint/docs/README.md
@@ -7,6 +7,7 @@ Thanks for your interest in contributing to `bevy_lint`! Please feel free to ski
     - [Setting up your Editor](how-to/editor.md)
     - [How to Work with Types](how-to/types.md)
     - [How to Release `bevy_lint`](how-to/release.md)
+    - [Bump to a Newer Version of Rust](how-to/bump-rust.md)
 - [Reference](reference/)
 - [Explanations](explanations/)
 

--- a/bevy_lint/docs/how-to/bump-rust.md
+++ b/bevy_lint/docs/how-to/bump-rust.md
@@ -1,0 +1,34 @@
+# How to Bump to a Newer Version of Rust
+
+`bevy_lint` matches nightly Rust versions with `clippy_utils`. A new version of `clippy_utils` is released with each version of Rust, which `bevy_lint` should keep up to date with.
+
+1. Go to [`clippy_utils`'s page on crates.io](https://crates.io/crates/clippy_utils) and find the nightly toolchain it requires. For example:
+
+    > This crate is only guaranteed to build with this nightly toolchain:
+    >
+    > ```
+    > nightly-2025-01-09
+    > ```
+
+2. Change the `channel` field in [`rust-toolchain.toml`](../../../rust-toolchain.toml) to the version specified by `clippy_utils`.
+3. Update the [compatibility table in `README.md`](../../README.md#compatibility) for the latest `-dev` version.
+4. Increase the version of `clippy_utils` in [`Cargo.toml`](../../Cargo.toml) to the latest version.
+
+Once you've finished upgrading the Rust toolchain and `clippy_utils`, there are a few extra steps that can verify `bevy_lint` still functions the same.
+
+1. Read over the [release notes](https://github.com/rust-lang/rust/releases) for potentially breaking changes.
+2. Skim through [diff.rs for `clippy_utils`](https://diff.rs/clippy_utils) to see if anything the linter uses may have changed.
+    - `clippy_utils` doesn't provide a user-facing changelog, unfortunately. You may find the [Git history](https://github.com/rust-lang/rust-clippy/commits/master/clippy_utils) useful, though!
+3. Verify you've installed the latest pinned Rust toolchain. If you use Rustup, it should be automatically installed the first time you run `rustc` or `cargo` in the workspace.
+
+    ```shell
+    rustc --version
+    ```
+
+4. Test that the linter still compiles and passes all tests.
+
+    ```shell
+    cargo clean
+    cargo build
+    cargo test
+    ```

--- a/bevy_lint/src/bin/driver.rs
+++ b/bevy_lint/src/bin/driver.rs
@@ -39,7 +39,9 @@ fn main() -> ExitCode {
         args.remove(0);
 
         // Call the compiler with our custom callback.
-        RunCompiler::new(&args, &mut BevyLintCallback).run()
+        RunCompiler::new(&args, &mut BevyLintCallback).run();
+
+        Ok(())
     });
 
     // We truncate the `i32` to a `u8`. `catch_with_exit_code()` currently only returns 1 or 0, so

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,6 +4,6 @@
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version
 # so that builds are reproducible.
-channel = "nightly-2024-11-28"
+channel = "nightly-2025-01-09"
 # These components are required to use `rustc` crates.
 components = ["rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
Rust 1.84 has been released, meaning it's time to bump our Rust toolchain and `clippy_utils`! Additionally, I've written some documentation on how to do this so that others can follow the same steps.