### PR TITLE
Support extra fields in `declare_bevy_lint!`

### DIFF
--- a/bevy_lint/src/lint.rs
+++ b/bevy_lint/src/lint.rs
@@ -28,14 +28,43 @@ pub struct LintGroup {
     pub level: Level,
 }
 
+/// Creates a new [`BevyLint`].
+///
+/// # Example
+///
+/// ```ignore
+/// declare_bevy_lint! {
+///     // This lint will be named `bevy::lint_name`.
+///     pub LINT_NAME,
+///     // See the `groups` module for the available names.
+///     LINT_GROUP,
+///     // The description printed by `bevy_lint_driver rustc -W help`, and sometimes also used in
+///     // diagnostic messages.
+///     "short description of lint",
+///
+///     // The following are optional fields, and may be excluded. They all default to false.
+///     //
+///     // Whether to report this lint, even if it is inside the expansion of an external macro.
+///     @report_in_external_macro = true,
+///     // Whether to only run this macro for the crate root. This should be enabled for lint
+///     // passes that only override `check_crate()`.
+///     @crate_level_only = false,
+///     // The compiler can sometimes skip lint passes that are guaranteed not to run. This can
+///     // disable that behavior.
+///     @eval_always = true,
+/// }
+/// ```
 #[macro_export]
-#[doc(hidden)]
+// #[doc(hidden)]
 macro_rules! declare_bevy_lint {
     {
         $(#[$attr:meta])*
         $vis:vis $name:ident,
         $group:ident,
-        $desc:expr$(,)?
+        $desc:expr,
+        $(@report_in_external_macro = $report_in_external_macro:expr,)?
+        $(@crate_level_only = $crate_level_only:expr,)?
+        $(@eval_always = $eval_always:expr,)?
     } => {
         /// Click me for more information.
         ///
@@ -49,16 +78,24 @@ macro_rules! declare_bevy_lint {
         $(#[$attr])*
         $vis static $name: &$crate::lint::BevyLint = &$crate::lint::BevyLint {
             lint: &::rustc_lint::Lint {
+                // Fields that are always configured by macro.
                 name: concat!("bevy::", stringify!($name)),
                 default_level: $crate::groups::$group.level,
                 desc: $desc,
+
+                // Fields that cannot be configured.
                 edition_lint_opts: None,
-                report_in_external_macro: false,
                 future_incompatible: None,
-                is_externally_loaded: true,
                 feature_gate: None,
-                crate_level_only: false,
-                eval_always: false,
+                is_externally_loaded: true,
+
+                // Fields that may sometimes be configured by macro. These all default to false in
+                // `Lint::default_fields_for_macro()`, but may be overridden to true.
+                $(report_in_external_macro: $report_in_external_macro,)?
+                $(crate_level_only: $crate_level_only,)?
+                $(eval_always: $eval_always,)?
+
+                ..::rustc_lint::Lint::default_fields_for_macro()
             },
             group: &$crate::groups::$group,
         };

--- a/bevy_lint/src/lints/missing_reflect.rs
+++ b/bevy_lint/src/lints/missing_reflect.rs
@@ -47,6 +47,8 @@ declare_bevy_lint! {
     pub MISSING_REFLECT,
     RESTRICTION,
     "defined a component, resource, or event without a `Reflect` implementation",
+    // We only override `check_crate()`.
+    @crate_level_only = true,
 }
 
 declare_lint_pass! {

--- a/bevy_lint/src/lints/panicking_methods.rs
+++ b/bevy_lint/src/lints/panicking_methods.rs
@@ -91,13 +91,13 @@ use rustc_span::{Span, Symbol};
 declare_bevy_lint! {
     pub PANICKING_QUERY_METHODS,
     RESTRICTION,
-    "called a `Query` or `QueryState` method that can panic when a non-panicking alternative exists"
+    "called a `Query` or `QueryState` method that can panic when a non-panicking alternative exists",
 }
 
 declare_bevy_lint! {
     pub PANICKING_WORLD_METHODS,
     RESTRICTION,
-    "called a `World` method that can panic when a non-panicking alternative exists"
+    "called a `World` method that can panic when a non-panicking alternative exists",
 }
 
 declare_lint_pass! {

--- a/bevy_lint/src/lints/zst_query.rs
+++ b/bevy_lint/src/lints/zst_query.rs
@@ -51,7 +51,7 @@ use rustc_session::declare_lint_pass;
 declare_bevy_lint! {
     pub ZST_QUERY,
     RESTRICTION,
-    "query for a zero-sized type"
+    "query for a zero-sized type",
 }
 
 declare_lint_pass! {


### PR DESCRIPTION
This adds support for `report_in_external_macro`, `crate_level_only`, and `eval_only` in `declare_bevy_lint!`. The syntax is inspired by the original [`declare_lint!`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint_defs/macro.declare_lint.html), but slightly modified.

For documentation on what each field does, see the fields of [`Lint`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint_defs/struct.Lint.html#fields). I only implemented the fields that I thought could be useful, but I may have missed something!