### PR TITLE
Fix determining artifact folder for dev profile

### DIFF
--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -82,7 +82,7 @@ impl CargoCompilationArgs {
         } else if self.is_release {
             "release"
         } else {
-            "debug"
+            "dev"
         }
     }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -215,12 +215,12 @@ pub(crate) fn select_run_binary(
 
 /// Determine the path to the directory which contains the compilation artifacts.
 fn get_artifact_directory(
-    target_directory: PathBuf,
+    target_directory: impl Into<PathBuf>,
     target: Option<&str>,
     profile: &str,
     is_example: bool,
 ) -> PathBuf {
-    let mut artifact_directory = target_directory;
+    let mut artifact_directory = target_directory.into();
 
     if let Some(target) = target {
         artifact_directory.push(target);
@@ -243,6 +243,7 @@ fn get_artifact_directory(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn test_artifact_directory_dev_native() {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::Context;
 use args::RunSubcommands;
@@ -201,7 +201,7 @@ pub(crate) fn select_run_binary(
 
     // Assemble the path where the binary will be put
     let artifact_directory = get_artifact_directory(
-        &metadata.target_directory,
+        metadata.target_directory.clone(),
         compile_target,
         compile_profile,
         is_example,
@@ -215,12 +215,12 @@ pub(crate) fn select_run_binary(
 
 /// Determine the path to the directory which contains the compilation artifacts.
 fn get_artifact_directory(
-    target_directory: &Path,
+    target_directory: PathBuf,
     target: Option<&str>,
     profile: &str,
     is_example: bool,
 ) -> PathBuf {
-    let mut artifact_directory = target_directory.to_owned();
+    let mut artifact_directory = target_directory;
 
     if let Some(target) = target {
         artifact_directory.push(target);

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use args::RunSubcommands;
@@ -200,20 +200,90 @@ pub(crate) fn select_run_binary(
     };
 
     // Assemble the path where the binary will be put
-    let mut artifact_directory = metadata.target_directory.clone();
-
-    if let Some(target) = compile_target {
-        artifact_directory.push(target);
-    }
-
-    artifact_directory.push(compile_profile);
-
-    if is_example {
-        artifact_directory.push("examples");
-    }
+    let artifact_directory = get_artifact_directory(
+        &metadata.target_directory,
+        compile_target,
+        compile_profile,
+        is_example,
+    );
 
     Ok(BinTarget {
         bin_name: target.name.clone(),
         artifact_directory,
     })
+}
+
+/// Determine the path to the directory which contains the compilation artifacts.
+fn get_artifact_directory(
+    target_directory: &Path,
+    target: Option<&str>,
+    profile: &str,
+    is_example: bool,
+) -> PathBuf {
+    let mut artifact_directory = target_directory.to_owned();
+
+    if let Some(target) = target {
+        artifact_directory.push(target);
+    }
+
+    if profile == "dev" {
+        // For some reason, the dev profile has a debug folder instead
+        artifact_directory.push("debug");
+    } else {
+        artifact_directory.push(profile);
+    }
+
+    if is_example {
+        artifact_directory.push("examples");
+    }
+
+    artifact_directory
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_artifact_directory_dev_native() {
+        let actual = get_artifact_directory(Path::new("/target"), None, "dev", false);
+        assert_eq!(actual, Path::new("/target/debug"));
+    }
+
+    #[test]
+    fn test_artifact_directory_release_native() {
+        let actual = get_artifact_directory(Path::new("/target"), None, "release", false);
+        assert_eq!(actual, Path::new("/target/release"));
+    }
+
+    #[test]
+    fn test_artifact_directory_dev_native_example() {
+        let actual = get_artifact_directory(Path::new("/target"), None, "dev", true);
+        assert_eq!(actual, Path::new("/target/debug/examples"));
+    }
+
+    #[test]
+    fn test_artifact_directory_dev_web() {
+        let actual = get_artifact_directory(
+            Path::new("/target"),
+            Some("wasm32-unknown-unknown"),
+            "web",
+            false,
+        );
+        assert_eq!(actual, Path::new("/target/wasm32-unknown-unknown/web"));
+    }
+
+    #[test]
+    fn test_artifact_directory_release_web() {
+        let actual = get_artifact_directory(
+            Path::new("/target"),
+            Some("wasm32-unknown-unknown"),
+            "web-release",
+            false,
+        );
+        assert_eq!(
+            actual,
+            Path::new("/target/wasm32-unknown-unknown/web-release")
+        );
+    }
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -188,14 +188,12 @@ pub(crate) fn select_run_binary(
                 anyhow::bail!(
                     "Found multiple `default_run` definitions, I don't know which one to pick!"
                 );
-            } else {
-                let default_run = default_runs[0];
-                bins.iter()
-                    .find(|bin| bin.name == *default_run)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Didn't find `default_run` binary {default_run}")
-                    })?
             }
+
+            let default_run = default_runs[0];
+            bins.iter()
+                .find(|bin| bin.name == *default_run)
+                .ok_or_else(|| anyhow::anyhow!("Didn't find `default_run` binary {default_run}"))?
         }
     };
 


### PR DESCRIPTION
# Objective

Closes #218.

For some reason, the profile `dev` has a target folder named `debug` instead of `dev`.
This caused a compile error on native dev builds.

# Solution

- Extract the artifact folder path logic into a separate function
- Add a special case for the `dev` profile
- Add some unit tests

# Testing

Run `bevy build` on a Bevy project, using this branch for the Bevy CLI.
It shouldn't fail with an error.

# Future work

We should probably set up some more tests for the CLI, testing all the build and run commands and potentially different targets and profiles.
But that would require non-trivial setup work, so I will defer it for a future task.