### PR TITLE
Update linter install link and fix `declare_bevy_lint!` visibility

### DIFF
--- a/bevy_lint/src/lint.rs
+++ b/bevy_lint/src/lint.rs
@@ -55,7 +55,7 @@ pub struct LintGroup {
 /// }
 /// ```
 #[macro_export]
-// #[doc(hidden)]
+#[doc(hidden)]
 macro_rules! declare_bevy_lint {
     {
         $(#[$attr:meta])*

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -42,7 +42,7 @@ pub fn find_bevy_lint() -> anyhow::Result<PathBuf> {
     } else {
         ensure!(
             bevy_lint_path.exists(),
-            "`bevy_lint` could not be found at {}. Please follow the instructions at <https://github.com/TheBevyFlock/bevy_cli> to install it.",
+            "`bevy_lint` could not be found at {}. Please follow the instructions at <https://thebevyflock.github.io/bevy_cli/bevy_lint> to install it.",
             bevy_lint_path.display(),
         );
     }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -42,7 +42,7 @@ pub fn find_bevy_lint() -> anyhow::Result<PathBuf> {
     } else {
         ensure!(
             bevy_lint_path.exists(),
-            "`bevy_lint` could not be found at {}. Please follow the instructions at <https://thebevyflock.github.io/bevy_cli/bevy_lint> to install it.",
+            "`bevy_lint` could not be found at {}. Please follow the instructions at <https://thebevyflock.github.io/bevy_cli/bevy_lint/#installation> to install it.",
             bevy_lint_path.display(),
         );
     }


### PR DESCRIPTION
Now when you run `bevy lint` (from the CLI) and the linter is _not_ installed, it will recommend installing it from [the website](https://thebevyflock.github.io/bevy_cli/bevy_lint/), not Github.

Additionally, it looks like I accidentally commented out `#[doc(hidden)]` on `declare_bevy_lint!` in #216, so this fixes that too.