### PR TITLE
De-duplicate web build code

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use bevy_cli::{build::BuildArgs, run::RunArgs};
+use bevy_cli::{build::args::BuildArgs, run::RunArgs};
 use clap::{Args, Parser, Subcommand};
 
 fn main() -> Result<()> {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,8 +1,9 @@
+use anyhow::bail;
 use args::BuildSubcommands;
 
 use crate::{
     external_cli::{cargo, rustup, wasm_bindgen, CommandHelpers},
-    run::select_run_binary,
+    run::{select_run_binary, BinTarget},
     web::{
         bundle::{create_web_bundle, PackedBundle, WebBundle},
         profiles::configure_default_web_profiles,
@@ -14,46 +15,66 @@ pub use self::args::BuildArgs;
 mod args;
 
 pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
-    let mut cargo_args = args.cargo_args_builder();
-
-    if let Some(BuildSubcommands::Web(web_args)) = &args.subcommand {
-        ensure_web_setup(args.skip_prompts)?;
-
-        let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
-        let bin_target = select_run_binary(
-            &metadata,
-            args.cargo_args.package_args.package.as_deref(),
-            args.cargo_args.target_args.bin.as_deref(),
-            args.cargo_args.target_args.example.as_deref(),
-            args.target().as_deref(),
-            args.profile(),
-        )?;
-
-        cargo_args = cargo_args.append(configure_default_web_profiles(&metadata)?);
-
-        println!("Compiling to WebAssembly...");
-        cargo::build::command().args(cargo_args).ensure_status()?;
-
-        println!("Bundling JavaScript bindings...");
-        wasm_bindgen::bundle(&bin_target)?;
-
-        #[cfg(feature = "wasm-opt")]
-        if args.is_release() {
-            crate::web::wasm_opt::optimize_bin(&bin_target)?;
-        }
-
-        if web_args.create_packed_bundle {
-            let web_bundle = create_web_bundle(&metadata, args.profile(), bin_target, true)?;
-
-            if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
-                println!("Created bundle at file://{}", path.display());
-            }
-        }
+    if args.is_web() {
+        build_web(args)?;
     } else {
+        let cargo_args = args.cargo_args_builder();
         cargo::build::command().args(cargo_args).ensure_status()?;
     }
 
     Ok(())
+}
+
+/// Build the Bevy app for use in the browser.
+///
+/// The following steps will be performed:
+/// - Installing required tooling
+/// - Setting up default web compilation profiles
+/// - Compiling to Wasm
+/// - Optimizing the Wasm binary (in release mode)
+/// - Creating JavaScript bindings
+/// - Creating a bundled folder (if requested)
+fn build_web(args: &BuildArgs) -> anyhow::Result<BinTarget> {
+    let Some(BuildSubcommands::Web(web_args)) = &args.subcommand else {
+        bail!("tried to build for the web without matching arguments");
+    };
+
+    ensure_web_setup(args.skip_prompts)?;
+
+    let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
+    let bin_target = select_run_binary(
+        &metadata,
+        args.cargo_args.package_args.package.as_deref(),
+        args.cargo_args.target_args.bin.as_deref(),
+        args.cargo_args.target_args.example.as_deref(),
+        args.target().as_deref(),
+        args.profile(),
+    )?;
+
+    let cargo_args = args
+        .cargo_args_builder()
+        .append(configure_default_web_profiles(&metadata)?);
+
+    println!("Compiling to WebAssembly...");
+    cargo::build::command().args(cargo_args).ensure_status()?;
+
+    println!("Bundling JavaScript bindings...");
+    wasm_bindgen::bundle(&bin_target)?;
+
+    #[cfg(feature = "wasm-opt")]
+    if args.is_release() {
+        crate::web::wasm_opt::optimize_bin(&bin_target)?;
+    }
+
+    if web_args.create_packed_bundle {
+        let web_bundle = create_web_bundle(&metadata, args.profile(), &bin_target, true)?;
+
+        if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
+            println!("Created bundle at file://{}", path.display());
+        }
+    }
+
+    Ok(bin_target)
 }
 
 pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::bail;
-use args::BuildSubcommands;
+use args::{BuildArgs, BuildSubcommands};
 
 use crate::{
     external_cli::{cargo, rustup, wasm_bindgen, CommandHelpers},
@@ -10,9 +10,7 @@ use crate::{
     },
 };
 
-pub use self::args::BuildArgs;
-
-mod args;
+pub mod args;
 
 pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
     if args.is_web() {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,9 +1,9 @@
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use args::{BuildArgs, BuildSubcommands};
 
 use crate::{
     external_cli::{cargo, rustup, wasm_bindgen, CommandHelpers},
-    run::{select_run_binary, BinTarget},
+    run::select_run_binary,
     web::{
         bundle::{create_web_bundle, PackedBundle, WebBundle},
         profiles::configure_default_web_profiles,
@@ -32,7 +32,7 @@ pub fn build(args: &BuildArgs) -> anyhow::Result<()> {
 /// - Optimizing the Wasm binary (in release mode)
 /// - Creating JavaScript bindings
 /// - Creating a bundled folder (if requested)
-fn build_web(args: &BuildArgs) -> anyhow::Result<BinTarget> {
+pub fn build_web(args: &BuildArgs) -> anyhow::Result<WebBundle> {
     let Some(BuildSubcommands::Web(web_args)) = &args.subcommand else {
         bail!("tried to build for the web without matching arguments");
     };
@@ -64,15 +64,19 @@ fn build_web(args: &BuildArgs) -> anyhow::Result<BinTarget> {
         crate::web::wasm_opt::optimize_bin(&bin_target)?;
     }
 
-    if web_args.create_packed_bundle {
-        let web_bundle = create_web_bundle(&metadata, args.profile(), &bin_target, true)?;
+    let web_bundle = create_web_bundle(
+        &metadata,
+        args.profile(),
+        &bin_target,
+        web_args.create_packed_bundle,
+    )
+    .context("Failed to create web bundle")?;
 
-        if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
-            println!("Created bundle at file://{}", path.display());
-        }
+    if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
+        println!("Created bundle at file://{}", path.display());
     }
 
-    Ok(bin_target)
+    Ok(web_bundle)
 }
 
 pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {

--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -13,7 +13,7 @@ fn program() -> OsString {
     env::var_os("BEVY_CLI_CARGO").unwrap_or("cargo".into())
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Feature Selection")]
 pub struct CargoFeatureArgs {
     /// Space or comma separated list of features to activate
@@ -38,7 +38,7 @@ impl CargoFeatureArgs {
     }
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Compilation Options")]
 pub struct CargoCompilationArgs {
     /// Build artifacts in release mode, with optimizations.
@@ -111,7 +111,7 @@ impl CargoCompilationArgs {
     }
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Manifest Options")]
 pub struct CargoManifestArgs {
     /// Path to Cargo.toml

--- a/src/external_cli/cargo/run.rs
+++ b/src/external_cli/cargo/run.rs
@@ -13,7 +13,7 @@ pub(crate) fn command() -> Command {
     command
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Clone)]
 pub struct CargoRunArgs {
     #[clap(flatten)]
     pub package_args: CargoPackageRunArgs,
@@ -38,7 +38,7 @@ impl CargoRunArgs {
     }
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Package Selection")]
 pub struct CargoPackageRunArgs {
     /// Package with the target to run
@@ -52,7 +52,7 @@ impl CargoPackageRunArgs {
     }
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Target Selection")]
 pub struct CargoTargetRunArgs {
     /// Build only the specified binary.

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::cargo::build::{CargoBuildArgs, CargoPackageBuildArgs, CargoTargetBuildArgs};
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Clone)]
 pub struct RunArgs {
     /// The subcommands available for the run command.
     #[command(subcommand)]
@@ -28,35 +28,19 @@ impl RunArgs {
         matches!(self.subcommand, Some(RunSubcommands::Web(_)))
     }
 
-    /// Whether to build with optimizations.
-    #[cfg(feature = "wasm-opt")]
-    pub(crate) fn is_release(&self) -> bool {
-        self.cargo_args.compilation_args.is_release
-    }
-
-    /// The profile used to compile the app.
-    pub(crate) fn profile(&self) -> &str {
-        self.cargo_args.compilation_args.profile(self.is_web())
-    }
-
-    /// The targeted platform.
-    pub(crate) fn target(&self) -> Option<String> {
-        self.cargo_args.compilation_args.target(self.is_web())
-    }
-
     /// Generate arguments for `cargo`.
     pub(crate) fn cargo_args_builder(&self) -> ArgBuilder {
         self.cargo_args.args_builder(self.is_web())
     }
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Subcommand, Clone)]
 pub enum RunSubcommands {
     /// Run your app in the browser.
     Web(RunWebArgs),
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Clone)]
 pub struct RunWebArgs {
     /// The port to run the web server on.
     #[arg(short, long, default_value_t = 4000)]

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -53,7 +53,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         let web_bundle = create_web_bundle(
             &metadata,
             args.profile(),
-            bin_target,
+            &bin_target,
             web_args.create_packed_bundle,
         )
         .context("Failed to create web bundle")?;

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -56,7 +56,7 @@ pub enum WebBundle {
 pub fn create_web_bundle(
     metadata: &Metadata,
     profile: &str,
-    bin_target: BinTarget,
+    bin_target: &BinTarget,
     packed: bool,
 ) -> anyhow::Result<WebBundle> {
     let assets_path = Path::new("assets");
@@ -80,7 +80,7 @@ pub fn create_web_bundle(
             Index::Folder(custom_web_folder.to_path_buf())
         } else {
             println!("No custom `web` folder found, using defaults.");
-            Index::Static(default_index(&bin_target))
+            Index::Static(default_index(bin_target))
         },
     };
 
@@ -92,7 +92,7 @@ pub fn create_web_bundle(
         .target_directory
         .join("bevy_web")
         .join(profile)
-        .join(bin_target.bin_name);
+        .join(&bin_target.bin_name);
 
     // Remove the previous bundle
     // The error can be ignored, because the folder doesn't need to exist yet


### PR DESCRIPTION
# Objective

Closes #229.

The `bevy run web` command cannot just wrap `cargo run`, as we don't want to run a native application, but run the code in the user's browser.
Hence, we have to manually build with `cargo build` instead.

This causes quite a lot of code (also including calling `wasm-bindgen`) to be duplicated between `bevy build web` and `bevy run web`.

To ensure consistency and aid development, the code should be shared where possible.
This will enable us to build more complex features like #226.

# Solution

- Extract reusable part of `bevy build web` into dedicated function.
- Add a conversion from run args to build args.
- Call the `bevy build web` logic in `bevy run web` as well.

The functionality _should_ be equivalent.

In the future, we might refine how exactly the shared build function is called.
For example, I assume that we will pass the binary targets we want to build from the outside instead of determining it in the function itself, that will enable us to implement changes like #200 and #230.