### PR TITLE
Improve error message when showing prompt in non-interactive shell

### DIFF
--- a/src/external_cli/cargo/install.rs
+++ b/src/external_cli/cargo/install.rs
@@ -3,6 +3,7 @@ use std::{
     str::FromStr,
 };
 
+use anyhow::Context;
 use dialoguer::Confirm;
 use semver::Version;
 
@@ -64,7 +65,10 @@ pub(crate) fn if_needed(
                     format!("`{program}` is missing, should I install it for you?")
                 }),
             )
-            .interact()?
+            .interact()
+            .context(
+                "failed to show interactive prompt, try using `--yes` to confirm automatically",
+            )?
     {
         exit(1);
     }

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -2,6 +2,7 @@
 
 use std::{env, ffi::OsString, process::Command};
 
+use anyhow::Context;
 use dialoguer::Confirm;
 
 /// The rustup command can be customized via the `BEVY_CLI_RUSTUP` env
@@ -33,7 +34,10 @@ pub(crate) fn install_target_if_needed(target: &str, silent: bool) -> anyhow::Re
             .with_prompt(format!(
                 "Compilation target `{target}` is missing, should I install it for you?",
             ))
-            .interact()?
+            .interact()
+            .context(
+                "failed to show interactive prompt, try using `--yes` to confirm automatically",
+            )?
         {
             anyhow::bail!("User does not want to install target `{target}`.");
         }


### PR DESCRIPTION
# Objective

Closes #212.

We are showing interactive prompts before we install any required tooling.

In non-interactive shells (e.g. CI), this will fail with an error.

We should improve this error message to guide the user towards the `--yes` flag, which confirms the prompts automatically.

# Solution

Use `anyhow`'s `.context(...)` to make the error message more useful, guiding the user towards `--yes`.

# Testing

Tested in one of [testing repositories in CI](https://github.com/TimJentzsch/bevy_complex_repo/actions/runs/12867761889/job/35873080585?pr=1#step:6:9).

New output:

```txt
Error: failed to show interactive prompt, try using `--yes` to confirm automatically
Caused by:
    0: IO error: not a terminal
    1: not a terminal
Error: Process completed with exit code 1.
```