### PR TITLE
Add linter section to CLI `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ To avoid this problem, use the `--yes` flag to automatically confirm the prompts
 bevy build --yes web
 ```
 
+## Linter
+
+The CLI has 1st-party support for `bevy_lint`, the static analysis tool that checks over your code (similar to Clippy!). It must be installed first using the [installation guide], but then you can run the linter with the `lint` subcommand:
+
+```sh
+bevy lint
+```
+
+This command uses the same arguments as `cargo check`:
+
+```sh
+bevy lint --workspace --all-features
+```
+
+You can view a full list of supported options with:
+
+```sh
+bevy lint -- --help
+```
+
+[installation guide]: https://thebevyflock.github.io/bevy_cli/bevy_lint/index.html#installation
+
 ## License
 
 The Bevy CLI is licensed under either of

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you need assistance or want to help, reach out to the [`bevy_cli` working gro
 
 At this point, the CLI is not published as a package yet and needs to be installed via git:
 
-```cli
+```sh
 cargo install --git https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
 ```
 
@@ -32,7 +32,7 @@ Necessary tools will also be installed automatically.
 >
 > The arguments you know from `cargo` (like `--release`) must be placed before the `web` subcommand, while the web-specific options (like `--open`) must be placed afterwards, e.g.
 >
-> ```cli
+> ```sh
 > bevy run --release web --open
 > ```
 
@@ -77,7 +77,7 @@ These prompts will break your pipeline if they are triggered in CI.
 
 To avoid this problem, use the `--yes` flag to automatically confirm the prompts:
 
-```cli
+```sh
 bevy build --yes web
 ```
 


### PR DESCRIPTION
Closes #239!

The section is pretty sparse, especially because I intentionally omitted the installation instructions (they're too complicated + too likely to go out-of-date, in my opinion).

As an extra drive-by fix, I switched the `cli` code block attributes to `sh`, which fixes syntax highlighting for me in VSCode. I can revert this if it's not desired!