### PR TITLE
Add cache for test workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,19 @@ jobs:
         with:
           sweep-cache: true
 
+      # We have a separate workspace where we execute the CLI in the E2E tests
+      # It has it's own `target` folder, hence we need to cache it separately
+      - name: Cache test workspace
+        uses: Leafwing-Studios/cargo-cache@v2
+        with:
+          sweep-cache: true
+          # The cache-group needs to be different to not collide with the cache for the test executing itself
+          cache-group: "test_workspace-${{ hashFiles(env.workflow_path) }}-${{ github.job }}-${{ strategy.job-index }}"
+          # cargo-cache doesn't support `working-directory` yet, we have to do it manually
+          # See https://github.com/Leafwing-Studios/cargo-cache/issues/44
+          cargo-target-dir: ./tests/bevy_cli_test/target
+          manifest-path: ./tests/bevy_cli_tests/Cargo.toml
+
       # The CLI's UI tests depend on Bevy with default features.
       # This requires extra packages, such as `alsa` and `udev`, to be installed on Linux.
       - name: Install Linux dependencies for Bevy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           # cargo-cache doesn't support `working-directory` yet, we have to do it manually
           # See https://github.com/Leafwing-Studios/cargo-cache/issues/44
           cargo-target-dir: ./tests/bevy_cli_test/target
-          manifest-path: ./tests/bevy_cli_tests/Cargo.toml
+          manifest-path: ./tests/bevy_cli_test/Cargo.toml
 
       # The CLI's UI tests depend on Bevy with default features.
       # This requires extra packages, such as `alsa` and `udev`, to be installed on Linux.


### PR DESCRIPTION
# Objective

Closes #254.
Should reduce CI times again by caching the workspace we use for the CLI E2E tests, so we don't have to rebuild them every time.

# Solution

I opted for adding a separate cache for the test workspace instead of adding the testing package to the CLI workspace (which would then include it in the CLI cache).
That way, the Bevy dependency is not included in the caches of the other jobs and we can keep it a separate workspace, making it easier to test the workspace-related CLI arguments.

The downside is that the cache size will probably grow.

The `cargo-cache` action also doesn't have a `working-directory` input yet, so it's a bit more verbose to change that. I opened <https://github.com/Leafwing-Studios/cargo-cache/issues/44> to track this.

# Testing

Let's let it run through and see if it works.