### PR TITLE
Make errors more informative when cargo metadata fails

### DIFF
--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -30,13 +30,12 @@ where
     S: AsRef<OsStr>,
 {
     let output = command().args(additional_args).output()?;
-    let metadata = serde_json::from_slice(&output.stdout).with_context(|| {
-        if let Ok(stderr) = std::str::from_utf8(&output.stderr) {
-            format!("Failed to parse `cargo metadata` output: {stderr}")
-        } else {
-            format!("Failed to parse `cargo metadata` output: {:?}", output)
-        }
-    })?;
+    let output = command().args(additional_args)
+        // Display errors to the user directly.
+        .stderr(Stdio::inherit())
+        .output()?;
+    let metadata = serde_json::from_slice(&output.stdout)
+        .context("Failed to parse `cargo metadata` output")?;
     Ok(metadata)
 }
 

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -1,5 +1,9 @@
 #![expect(dead_code, reason = "Will be used for bevy bump and perhaps bevy run")]
-use std::{ffi::OsStr, path::PathBuf, process::{Command, Stdio}};
+use std::{
+    ffi::OsStr,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
 
 use anyhow::Context;
 use semver::{Version, VersionReq};

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -1,5 +1,5 @@
 #![expect(dead_code, reason = "Will be used for bevy bump and perhaps bevy run")]
-use std::{ffi::OsStr, path::PathBuf, process::Command};
+use std::{ffi::OsStr, path::PathBuf, process::{Command, Stdio}};
 
 use anyhow::Context;
 use semver::{Version, VersionReq};
@@ -29,7 +29,6 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let output = command().args(additional_args).output()?;
     let output = command()
         .args(additional_args)
         // Display errors to the user directly.

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -30,7 +30,8 @@ where
     S: AsRef<OsStr>,
 {
     let output = command().args(additional_args).output()?;
-    let output = command().args(additional_args)
+    let output = command()
+        .args(additional_args)
         // Display errors to the user directly.
         .stderr(Stdio::inherit())
         .output()?;


### PR DESCRIPTION
When the a call to `cargo metadata` fails the only output the user sees is "Error: EOF while parsing a value at line 1 column 0" which doesn't explain anything. This change adds additional context.

I have made the choice to try to print stderr if it can be decoded as utf-8 because that is where I believe all the useful stuff will always be. If decoding fails I print the debug format for the Output struct which will at least have some information.

fixes: #242 