### PR TITLE
Lower `zst_query` to be a nursery lint

### DIFF
--- a/bevy_lint/src/lints/zst_query.rs
+++ b/bevy_lint/src/lints/zst_query.rs
@@ -49,7 +49,9 @@ use rustc_middle::ty::{
 
 declare_bevy_lint! {
     pub ZST_QUERY,
-    RESTRICTION,
+    // This will eventually be a `RESTRICTION` lint, but due to <https://github.com/TheBevyFlock/bevy_cli/issues/252>
+    // it is not yet ready for production.
+    NURSERY,
     "query for a zero-sized type",
 }
 


### PR DESCRIPTION
Due to #252, `zst_query` isn't yet ready to be out in production. This PR lowers it to the [`NURSERY`](https://thebevyflock.github.io/bevy_cli/bevy_lint/groups/static.NURSERY.html) lint group, which marks it as unstable for the time being.