### PR TITLE
Don't use `cargo +TOOLCHAIN` shortcut and move `--cfg bevy_lint` logic

### DIFF
--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -33,18 +33,6 @@ fn main() -> anyhow::Result<ExitCode> {
         // This instructs `rustc` to call `bevy_lint_driver` instead of its default routine.
         // This lets us register custom lints.
         .env("RUSTC_WORKSPACE_WRAPPER", driver_path)
-        // Pass `--cfg bevy_lint` so that programs can conditionally configure lints. If
-        // `RUSTFLAGS` is already set, we append `--cfg bevy_lint` to the end.
-        .env(
-            "RUSTFLAGS",
-            env::var("RUSTFLAGS").map_or_else(
-                |_| "--cfg bevy_lint".to_string(),
-                |mut flags| {
-                    flags.push_str(" --cfg bevy_lint");
-                    flags
-                },
-            ),
-        )
         .status()
         .context("Failed to spawn `cargo check`.")?;
 

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -21,10 +21,11 @@ fn main() -> anyhow::Result<ExitCode> {
     // Find the path to `bevy_lint_driver`.
     let driver_path = driver_path()?;
 
-    // Run `cargo check`.
-    let status = Command::new("cargo")
-        // Assuming that Rustup is installed, we can specify which toolchain to use with this.
-        .arg(format!("+{RUST_TOOLCHAIN_CHANNEL}"))
+    // Run `rustup run nightly-YYYY-MM-DD cargo check`.
+    let status = Command::new("rustup")
+        .arg("run")
+        .arg(RUST_TOOLCHAIN_CHANNEL)
+        .arg("cargo")
         .arg("check")
         // Forward all arguments to `cargo check` except for the first, which is the path to the
         // current executable.

--- a/bevy_lint/src/callback.rs
+++ b/bevy_lint/src/callback.rs
@@ -27,6 +27,9 @@ impl Callbacks for BevyLintCallback {
     fn config(&mut self, config: &mut Config) {
         crate::config::load_config(config);
 
+        // Add `--cfg bevy_lint` so programs can conditionally configure lints.
+        config.crate_cfg.push("bevy_lint".to_string());
+
         // We're overwriting `register_lints`, but we don't want to completely delete the original
         // function. Instead, we save it so we can call it ourselves inside its replacement.
         let previous = config.register_lints.take();


### PR DESCRIPTION
The `bevy_lint` executable currently runs:

```shell
RUSTC_WORKSPACE_WRAPPER=path/to/bevy_lint_driver cargo +TOOLCHAIN check --cfg bevy_lint
```

This broke for [someone on Discord](https://discord.com/channels/691052431525675048/1278871953721262090/1337252666027540503), however, because the `+TOOLCHAIN` syntax requires [Rustup's `cargo` proxy](https://rust-lang.github.io/rustup/concepts/proxies.html), which may not be in their `PATH`. This PR fixes this by instead calling `rustup run` directly:

```shell
RUSTC_WORKSPACE_WRAPPER=path/to/bevy_lint_driver rustup run TOOLCHAIN cargo check --cfg bevy_lint
```

Both versions do the exact same thing, and both will fail if you do not have Rustup installed, but the latter version should work in a few more scenarios. (And it makes the error message clearer, since it mentions Rustup.)

Furthermore, this PR moves the `--cfg bevy_lint` logic from the `bevy_lint` executable to `bevy_lint_driver`. While the linter should still behave the same, this means programs will still be able to detect the linter even if the use called `bevy_lint_driver` directly instead of `bevy_lint`.[^0]

[^0]: For example, our UI tests call `bevy_lint_driver` directly. This means we can now technically use `#[cfg(bevy_lint)]` in our UI tests, even if it doesn't make sense to do so.