### PR TITLE
Add Shell-Completion Auto-generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
  "cargo-generate",
  "cc",
  "clap",
+ "clap_complete",
  "dialoguer",
  "fs_extra",
  "futures-util",
@@ -1094,6 +1095,15 @@ dependencies = [
  "clap_lex",
  "strsim",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ wasm-opt = ["dep:wasm-opt"]
 [dependencies]
 # CLI argument parsing
 clap = { version = "4.5.16", features = ["derive"] }
+# autocompletion auto-generation
+clap_complete = "4.5.44"
 
 # Easy error propagation and contexts
 anyhow = "1.0.86"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
         Subcommands::Lint { args } => bevy_cli::lint::lint(args)?,
         Subcommands::Build(mut args) => bevy_cli::build::build(&mut args)?,
         Subcommands::Run(args) => bevy_cli::run::run(&args)?,
-        Subcommands::Completion { shell } => {
+        Subcommands::Completions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "bevy", &mut std::io::stdout());
         }
     }
@@ -53,7 +53,7 @@ pub enum Subcommands {
         args: Vec<String>,
     },
     /// Generate autocompletion for `bevy_cli`
-    Completion { shell: clap_complete::Shell },
+    Completions { shell: clap_complete::Shell },
 }
 
 /// Arguments for creating a new Bevy project.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use bevy_cli::{build::args::BuildArgs, run::RunArgs};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -12,6 +12,9 @@ fn main() -> Result<()> {
         Subcommands::Lint { args } => bevy_cli::lint::lint(args)?,
         Subcommands::Build(mut args) => bevy_cli::build::build(&mut args)?,
         Subcommands::Run(args) => bevy_cli::run::run(&args)?,
+        Subcommands::Completion { shell } => {
+            clap_complete::generate(shell, &mut Cli::command(), "bevy", &mut std::io::stdout());
+        }
     }
 
     Ok(())
@@ -49,6 +52,8 @@ pub enum Subcommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Generate autocompletion for `bevy_cli`
+    Completion { shell: clap_complete::Shell },
 }
 
 /// Arguments for creating a new Bevy project.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -52,7 +52,13 @@ pub enum Subcommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Generate autocompletion for `bevy_cli`
+    /// Generate autocompletion for `bevy` CLI tool.
+    ///
+    /// You can add this or a variant of this to your shells `.profile` by just added
+    ///
+    /// ```
+    /// source <(bevy completion zsh)
+    /// ```
     Completions { shell: clap_complete::Shell },
 }
 


### PR DESCRIPTION
`clap_complete` is a neat little crate which allows to generate shell auto-completions for `clap` based CLI projects. 

### Usage

It works by running e.g. `bevy completion bash` which will print out a lot of shell code to the commandline. This is can then be used by users to manually install the autocompletions for their shell or by package managers to automatically install the completions while installing the binary.

### Naming

I'm not sure about the `completion` subcommand name. Feel free to suggest anything else and I'll adapt this PR.