### PR TITLE
Automatically add a sensible title to web page

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Bevy App</title>
     <style>
       /* Styles for the loading screen */
       :root {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -3,7 +3,7 @@ use args::{BuildArgs, BuildSubcommands};
 
 use crate::{
     external_cli::{cargo, rustup, wasm_bindgen, CommandHelpers},
-    run::select_run_binary,
+    run::{select_run_binary, BinTarget},
     web::{
         bundle::{create_web_bundle, PackedBundle, WebBundle},
         profiles::configure_default_web_profiles,
@@ -32,7 +32,7 @@ pub fn build(args: &mut BuildArgs) -> anyhow::Result<()> {
 /// - Optimizing the Wasm binary (in release mode)
 /// - Creating JavaScript bindings
 /// - Creating a bundled folder (if requested)
-pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<WebBundle> {
+pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<(WebBundle, BinTarget)> {
     let Some(BuildSubcommands::Web(web_args)) = &args.subcommand else {
         bail!("tried to build for the web without matching arguments");
     };
@@ -80,7 +80,7 @@ pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<WebBundle> {
         println!("Created bundle at file://{}", path.display());
     }
 
-    Ok(web_bundle)
+    Ok((web_bundle, bin_target))
 }
 
 pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -3,7 +3,7 @@ use args::{BuildArgs, BuildSubcommands};
 
 use crate::{
     external_cli::{cargo, rustup, wasm_bindgen, CommandHelpers},
-    run::{select_run_binary, BinTarget},
+    run::select_run_binary,
     web::{
         bundle::{create_web_bundle, PackedBundle, WebBundle},
         profiles::configure_default_web_profiles,
@@ -32,7 +32,7 @@ pub fn build(args: &mut BuildArgs) -> anyhow::Result<()> {
 /// - Optimizing the Wasm binary (in release mode)
 /// - Creating JavaScript bindings
 /// - Creating a bundled folder (if requested)
-pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<(WebBundle, BinTarget)> {
+pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<WebBundle> {
     let Some(BuildSubcommands::Web(web_args)) = &args.subcommand else {
         bail!("tried to build for the web without matching arguments");
     };
@@ -80,7 +80,7 @@ pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<(WebBundle, BinTarget)>
         println!("Created bundle at file://{}", path.display());
     }
 
-    Ok((web_bundle, bin_target))
+    Ok(web_bundle)
 }
 
 pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -37,7 +37,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             build_args.cargo_args.target_args.bin = Some(bin_target.bin_name);
         }
 
-        let (web_bundle, _) = build_web(&mut build_args)?;
+        let web_bundle = build_web(&mut build_args)?;
 
         let port = web_args.port;
         let url = format!("http://localhost:{port}");

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -37,7 +37,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             build_args.cargo_args.target_args.bin = Some(bin_target.bin_name);
         }
 
-        let (web_bundle, bin_target) = build_web(&mut build_args)?;
+        let (web_bundle, _) = build_web(&mut build_args)?;
 
         let port = web_args.port;
         let url = format!("http://localhost:{port}");
@@ -54,7 +54,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             println!("Open your app at <{url}>!");
         }
 
-        serve::serve(web_bundle, bin_target, port)?;
+        serve::serve(web_bundle, port)?;
     } else {
         let cargo_args = args.cargo_args_builder();
         // For native builds, wrap `cargo run`

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -37,7 +37,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             build_args.cargo_args.target_args.bin = Some(bin_target.bin_name);
         }
 
-        let web_bundle = build_web(&mut build_args)?;
+        let (web_bundle, bin_target) = build_web(&mut build_args)?;
 
         let port = web_args.port;
         let url = format!("http://localhost:{port}");
@@ -54,7 +54,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             println!("Open your app at <{url}>!");
         }
 
-        serve::serve(web_bundle, port)?;
+        serve::serve(web_bundle, bin_target, port)?;
     } else {
         let cargo_args = args.cargo_args_builder();
         // For native builds, wrap `cargo run`
@@ -65,11 +65,11 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct BinTarget {
+pub struct BinTarget {
     /// The path to the directory in `target` which contains the binary.
-    pub(crate) artifact_directory: PathBuf,
+    pub artifact_directory: PathBuf,
     /// The name of the binary (without any extensions).
-    pub(crate) bin_name: String,
+    pub bin_name: String,
 }
 
 /// Determine which binary target should be run.

--- a/src/run/serve.rs
+++ b/src/run/serve.rs
@@ -5,8 +5,6 @@ use futures_util::StreamExt as _;
 
 use crate::web::bundle::{Index, LinkedBundle, PackedBundle, WebBundle};
 
-use super::BinTarget;
-
 /// Serve a static HTML file with the given content.
 async fn serve_static_html(content: &'static str) -> impl Responder {
     // Build the HTTP response with appropriate headers to serve the content as a file
@@ -53,7 +51,7 @@ async fn dev_websocket(req: HttpRequest, stream: web::Payload) -> Result<HttpRes
 }
 
 /// Launch a web server running the Bevy app.
-pub(crate) fn serve(web_bundle: WebBundle, bin_target: BinTarget, port: u16) -> anyhow::Result<()> {
+pub(crate) fn serve(web_bundle: WebBundle, port: u16) -> anyhow::Result<()> {
     rt::System::new().block_on(
         HttpServer::new(move || {
             let mut app = App::new();
@@ -102,28 +100,20 @@ pub(crate) fn serve(web_bundle: WebBundle, bin_target: BinTarget, port: u16) -> 
                     }
 
                     match index {
-                        Index::Folder(path) => {
+                        Index::File(path) => {
                             app = app.service(
                                 actix_files::Files::new("/", path).index_file("index.html"),
                             );
                         }
-                        Index::Static(contents) => {
+                        Index::Content(content) => {
                             // Try to inject the auto reload script in the document body
                             // TODO: Do this also for the other cases when the `index.html` is in a
                             // folder
-                            let mut contents = contents.replace(
+                            let contents = content.replace(
                                 "</body>",
                                 r#"<script src="_bevy_dev/auto_reload.js"></script></body>"#,
                             );
-                            if !contents.contains("</title>") {
-                                contents = contents.replace(
-                                    "</head>",
-                                    &format!(
-                                        "<title>{}</title></head>",
-                                        default_title(&bin_target.bin_name)
-                                    ),
-                                );
-                            }
+
                             // PERF: We have to leak the string to get a static lifetime
                             // But this will only be done once so it should be fine for memory
                             let contents: &'static str = Box::leak(contents.into_boxed_str());
@@ -140,43 +130,4 @@ pub(crate) fn serve(web_bundle: WebBundle, bin_target: BinTarget, port: u16) -> 
     )?;
 
     Ok(())
-}
-
-/// Generate a title to display on the web page by default.
-///
-/// The title is based on the binary name, but makes it a bit more human readable.
-///
-/// bevy_new_2d -> Bevy New 2d
-fn default_title(bin_name: &str) -> String {
-    bin_name
-        .split(['_', '-'])
-        .map(capitalize)
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-/// Make the first letter of the word uppercase.
-///
-/// See <https://stackoverflow.com/a/38406885>.
-fn capitalize(s: &str) -> String {
-    let mut c = s.chars();
-    match c.next() {
-        None => String::new(),
-        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_default_title() {
-        assert_eq!(default_title("bevy_new_2d"), "Bevy New 2d");
-    }
-
-    #[test]
-    fn test_capitalize() {
-        assert_eq!(capitalize("foo"), "Foo");
-    }
 }

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -165,7 +165,8 @@ pub fn create_web_bundle(
     }
 
     // Index (pre-processed)
-    fs::write(base_path.join("index.html"), &index).context("failed to write processed index.html")?;
+    fs::write(base_path.join("index.html"), &index)
+        .context("failed to write processed index.html")?;
 
     Ok(WebBundle::Packed(PackedBundle { path: base_path }))
 }

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -11,9 +11,19 @@ use crate::{external_cli::cargo::metadata::Metadata, run::BinTarget};
 #[derive(Debug, Clone)]
 pub enum Index {
     /// The folder containing a custom `index.html` file.
-    Folder(PathBuf),
+    File(PathBuf),
     /// A static string representing the contents of `index.html`.
-    Static(&'static str),
+    Content(String),
+}
+
+impl Index {
+    /// The content of the `index.html` file.
+    pub fn content(&self) -> anyhow::Result<String> {
+        match self {
+            Self::File(path) => Ok(fs::read_to_string(path)?),
+            Self::Content(content) => Ok(content.clone()),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +56,16 @@ pub enum WebBundle {
     Packed(PackedBundle),
 }
 
+impl WebBundle {
+    /// The index.html file of the bundle.
+    pub fn index(&self) -> Index {
+        match self {
+            Self::Linked(linked) => linked.index.clone(),
+            Self::Packed(packed) => Index::File(packed.path.join("index.html")),
+        }
+    }
+}
+
 /// Create a bundle of all the files needed for serving the app in the web.
 ///
 /// If `packed` is set to `true`, the files will be packed together in a single folder.
@@ -66,6 +86,16 @@ pub fn create_web_bundle(
     let js_file_name = OsString::from(format!("{}.js", bin_target.bin_name));
 
     let custom_web_folder = Path::new("web");
+    let index_path = custom_web_folder.join("index.html");
+
+    let index = if index_path.exists() {
+        Index::File(index_path)
+    } else {
+        println!("No custom `web` folder found, using defaults.");
+        Index::Content(default_index(bin_target))
+    };
+
+    let index = pre_process_index(index.content()?, bin_target);
 
     let linked = LinkedBundle {
         build_artifact_path: bin_target.artifact_directory.clone(),
@@ -76,12 +106,7 @@ pub fn create_web_bundle(
         } else {
             None
         },
-        index: if custom_web_folder.join("index.html").exists() {
-            Index::Folder(custom_web_folder.to_path_buf())
-        } else {
-            println!("No custom `web` folder found, using defaults.");
-            Index::Static(default_index(bin_target))
-        },
+        index: Index::Content(index.clone()),
     };
 
     if !packed {
@@ -125,46 +150,90 @@ pub fn create_web_bundle(
         .context("failed to copy assets")?;
     }
 
-    // Index
-    let index_path = base_path.join("index.html");
-    match linked.index {
-        Index::Folder(path) => {
-            fs_extra::dir::copy(
-                path,
-                &base_path,
-                &fs_extra::dir::CopyOptions {
-                    overwrite: true,
-                    content_only: true,
-                    ..Default::default()
-                },
-            )
-            .context("failed to copy custom web assets")?;
-        }
-        Index::Static(contents) => {
-            fs::write(index_path, contents).context("failed to create index.html")?;
-        }
+    // Custom web assets
+    if custom_web_folder.exists() {
+        fs_extra::dir::copy(
+            custom_web_folder,
+            &base_path,
+            &fs_extra::dir::CopyOptions {
+                overwrite: true,
+                content_only: true,
+                ..Default::default()
+            },
+        )
+        .context("failed to copy custom web assets")?;
     }
+
+    // Index (pre-processed)
+    fs::write(base_path.join("index.html"), &index).context("failed to write processed index.html")?;
 
     Ok(WebBundle::Packed(PackedBundle { path: base_path }))
 }
 
+/// Apply pre-processing to the provided `index.html`.
+fn pre_process_index(mut content: String, bin_target: &BinTarget) -> String {
+    if !content.contains("</title>") {
+        content = content.replace(
+            "</head>",
+            &format!(
+                "<title>{}</title></head>",
+                default_title(&bin_target.bin_name)
+            ),
+        );
+    }
+    content
+}
+
 /// Returns the contents of the default `index.html`,
 /// customized to use the name of the generated binary.
-fn default_index(bin_target: &BinTarget) -> &'static str {
+fn default_index(bin_target: &BinTarget) -> String {
     let template = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/assets/web/index.html"
     ));
 
     // Insert correct path to JS bindings
-    let index = template.replace(
+    template.replace(
         "./build/bevy_app.js",
         format!("./build/{}.js", bin_target.bin_name).as_str(),
-    );
+    )
+}
 
-    // Only static strings can be served in the web app,
-    // so we leak the string memory to convert it to a static reference.
-    // PERF: This is assumed to be used only once and is needed for the rest of the app running
-    // time, making the memory leak acceptable.
-    Box::leak(index.into_boxed_str())
+/// Generate a title to display on the web page by default.
+///
+/// The title is based on the binary name, but makes it a bit more human readable.
+///
+/// bevy_new_2d -> Bevy New 2d
+fn default_title(bin_name: &str) -> String {
+    bin_name
+        .split(['_', '-'])
+        .map(capitalize)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Make the first letter of the word uppercase.
+///
+/// See <https://stackoverflow.com/a/38406885>.
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_title() {
+        assert_eq!(default_title("bevy_new_2d"), "Bevy New 2d");
+    }
+
+    #[test]
+    fn test_capitalize() {
+        assert_eq!(capitalize("foo"), "Foo");
+    }
 }

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -10,7 +10,7 @@ use crate::{external_cli::cargo::metadata::Metadata, run::BinTarget};
 
 #[derive(Debug, Clone)]
 pub enum Index {
-    /// The folder containing a custom `index.html` file.
+    /// The path to the custom `index.html` file.
     File(PathBuf),
     /// A static string representing the contents of `index.html`.
     Content(String),


### PR DESCRIPTION
# Objective

Partially related to #123.
Removes one regression from <https://github.com/TheBevyFlock/bevy_new_2d/pull/312>.

When you currently run an app with `bevy run web`, the browser tab will just be called "Bey App".
This is not very descriptive or nice, so it would be better if we could choose a better default value.

# Solution

- Adjust our bundling pipeline to allow pre-processing of the `index.html` in all cases
- If not provided, add a `<title>` with the name of the binary
    - E.g. `bevy_new_2d` becomes "Bevy New 2d"

As a follow-up to this PR we can also more easily apply the post-processing with the dev-only options for the dev server.

# Testing

1. Install the CLI from this branch.
2. Run any Bevy project with `bevy run web`. It should show the name of the binary in the title. Try for example `bevy run --example=breakout web` in the bevy repository.
3. If you provide a custom `web/index.html` file and set a `<title>`, it should not be overwritten.