### PR TITLE
Force rustup to add `rustc_driver.dll` to the `PATH`

### DIFF
--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -33,6 +33,12 @@ fn main() -> anyhow::Result<ExitCode> {
         // This instructs `rustc` to call `bevy_lint_driver` instead of its default routine.
         // This lets us register custom lints.
         .env("RUSTC_WORKSPACE_WRAPPER", driver_path)
+        // Rustup on Windows does not modify the `PATH` variable by default so a toolchain-specific
+        // version of `cargo` or `rustc` is not accidentally run instead of Rustup's proxy version.
+        // This isn't desired for us, however, because we need the `PATH` modified to discover and
+        // link to `rustc_driver.dll`. Setting `RUSTUP_WINDOWS_PATH_ADD_BIN=1` forces Rustup to
+        // modify the path. For more info, please see <https://github.com/rust-lang/rustup/pull/3703>.
+        .env("RUSTUP_WINDOWS_PATH_ADD_BIN", "1")
         .status()
         .context("Failed to spawn `cargo check`.")?;
 


### PR DESCRIPTION
Fixes #267! For more context, see [this comment](https://github.com/TheBevyFlock/bevy_cli/issues/267#issuecomment-2678683811):

> I found the issue! Due to [rust-lang/rustup#3703](https://github.com/rust-lang/rustup/pull/3703), Rustup no longer modifies the `PATH` on Windows because it prevented sub-invocations of `cargo` and `rustc` from going through their proxy. There was a [call for testing](https://internals.rust-lang.org/t/help-test-windows-behavior-between-rustup-and-cargo/20237) related to this, but it was announced before the linter was ever created. Because I don't use Windows frequently, I never caught the issue.
> 
> We can fix this by setting `RUSTUP_WINDOWS_PATH_ADD_BIN=1`:
> 
> ```cmd
> > set RUSTUP_WINDOWS_PATH_ADD_BIN=1
> > rustup run nightly-2025-01-09 .\bevy_lint.exe
> ```