### PR TITLE
switch to `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,8 @@ dependencies = [
  "serde_json",
  "serial_test",
  "toml_edit",
+ "tracing",
+ "tracing-subscriber",
  "wasm-opt",
  "webbrowser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ futures-util = "0.3.31"
 
 # Logging crates
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "std"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [build-dependencies]
 # We don't use `cc` directly, but our dependency `wasm-opt-sys` fails to compile on Windows when using a newer version.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ actix-ws = "0.3.0"
 # Utilities for futures which we use for the dev server
 futures-util = "0.3.31"
 
+# Logging crates
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "std"] }
+
 [build-dependencies]
 # We don't use `cc` directly, but our dependency `wasm-opt-sys` fails to compile on Windows when using a newer version.
 # This can be removed when https://github.com/rust-lang/cc-rs/issues/1324 is fixed. 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ At this point, the CLI is not published as a package yet and needs to be install
 cargo install --git https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
 ```
 
+## Logging
+
+The default logging level for the CLI is set to `info`. To change the log level set the `BEVY_LOG` environment variable.
+
+```sh
+export BEVY_LOG=trace
+```
+
 ## Bevy web apps
 
 The CLI makes it easy to build and run web apps made with Bevy, using `bevy build web` and `bevy run web`.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,8 +1,19 @@
 use anyhow::Result;
 use bevy_cli::{build::args::BuildArgs, run::RunArgs};
 use clap::{Args, CommandFactory, Parser, Subcommand};
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 fn main() -> Result<()> {
+    // Initialize tracing and set the default level to `info`.
+    // This can be overridden by the `RUST_LOG` environment variable.
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("bevy_cli=info")),
+        )
+        .init();
+
     let cli = Cli::parse();
 
     match cli.subcommand {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,8 +5,10 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<()> {
     // Set default log level to info for the `bevy_cli` crate if `BEVY_LOG` is not set.
-    let env = tracing_subscriber::EnvFilter::try_from_env("BEVY_LOG")
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("bevy_cli=info"));
+    let env = tracing_subscriber::EnvFilter::try_from_env("BEVY_LOG").map_or_else(
+        |_| tracing_subscriber::EnvFilter::new("bevy_cli=info"),
+        |filter| tracing_subscriber::EnvFilter::new(format!("bevy_cli={filter}")),
+    );
 
     let fmt_layer = tracing_subscriber::fmt::layer()
         // remove timestamps

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context as _};
 use args::{BuildArgs, BuildSubcommands};
+use tracing::info;
 
 use crate::{
     external_cli::{cargo, rustup, wasm_bindgen, CommandHelpers},
@@ -57,10 +58,10 @@ pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<WebBundle> {
 
     let cargo_args = args.cargo_args_builder();
 
-    println!("Compiling to WebAssembly...");
+    info!("Compiling to WebAssembly...");
     cargo::build::command().args(cargo_args).ensure_status()?;
 
-    println!("Bundling JavaScript bindings...");
+    info!("Bundling JavaScript bindings...");
     wasm_bindgen::bundle(&bin_target)?;
 
     #[cfg(feature = "wasm-opt")]
@@ -77,7 +78,7 @@ pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<WebBundle> {
     .context("Failed to create web bundle")?;
 
     if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
-        println!("Created bundle at file://{}", path.display());
+        info!("Created bundle at file://{}", path.display());
     }
 
     Ok(web_bundle)

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -4,6 +4,7 @@ use std::{env, ffi::OsString, process::Command};
 
 use anyhow::Context;
 use dialoguer::Confirm;
+use tracing::info;
 
 /// The rustup command can be customized via the `BEVY_CLI_RUSTUP` env
 fn program() -> OsString {
@@ -43,7 +44,7 @@ pub(crate) fn install_target_if_needed(target: &str, silent: bool) -> anyhow::Re
         }
     }
 
-    println!("Installing missing target: `{target}`");
+    info!("Installing missing target: `{target}`");
 
     let mut cmd = Command::new(program());
     cmd.arg("target").arg("add").arg(target);

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -48,7 +48,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             match webbrowser::open(&url) {
                 Ok(()) => info!("Your app is running at <{url}>!"),
                 Err(error) => {
-                    info!("Failed to open the browser automatically, open the app at <{url}>. (Error: {error:?}");
+                    error!("Failed to open the browser automatically, open the app at <{url}>. (Error: {error:?}");
                 }
             }
         } else {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use args::RunSubcommands;
-use tracing::info;
+use tracing::{error, info};
 
 use crate::{
     build::{args::BuildArgs, build_web},

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use args::RunSubcommands;
+use tracing::info;
 
 use crate::{
     build::{args::BuildArgs, build_web},
@@ -45,13 +46,13 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         // Serving the app is blocking, so we open the page first
         if web_args.open {
             match webbrowser::open(&url) {
-                Ok(()) => println!("Your app is running at <{url}>!"),
+                Ok(()) => info!("Your app is running at <{url}>!"),
                 Err(error) => {
-                    println!("Failed to open the browser automatically, open the app at <{url}>. (Error: {error:?}");
+                    info!("Failed to open the browser automatically, open the app at <{url}>. (Error: {error:?}");
                 }
             }
         } else {
-            println!("Open your app at <{url}>!");
+            info!("Open your app at <{url}>!");
         }
 
         serve::serve(web_bundle, port)?;

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::Context;
+use tracing::info;
 
 use crate::{external_cli::cargo::metadata::Metadata, run::BinTarget};
 
@@ -91,7 +92,7 @@ pub fn create_web_bundle(
     let index = if index_path.exists() {
         Index::File(index_path)
     } else {
-        println!("No custom `web` folder found, using defaults.");
+        info!("No custom `web` folder found, using defaults.");
         Index::Content(default_index(bin_target))
     };
 

--- a/src/web/wasm_opt.rs
+++ b/src/web/wasm_opt.rs
@@ -1,6 +1,7 @@
 use std::{fs, path::Path, time::Instant};
 
 use anyhow::Context as _;
+use tracing::info;
 
 use crate::run::BinTarget;
 
@@ -16,7 +17,7 @@ pub(crate) fn optimize_bin(bin_target: &BinTarget) -> anyhow::Result<()> {
 
 /// Optimize the Wasm binary at the given path with wasm-opt.
 fn optimize_path(path: &Path) -> anyhow::Result<()> {
-    println!("Optimizing with wasm-opt...");
+    info!("Optimizing with wasm-opt...");
 
     let start = Instant::now();
     let size_before = fs::metadata(path)?.len();
@@ -29,8 +30,8 @@ fn optimize_path(path: &Path) -> anyhow::Result<()> {
     let size_reduction = 1. - (size_after as f32) / (size_before as f32);
     let duration = start.elapsed();
 
-    println!(
-        "    Finished in {duration:.2?}. Size reduced by {:.0}%.",
+    info!(
+        "Finished in {duration:.2?}. Size reduced by {:.0}%.",
         size_reduction * 100.
     );
 


### PR DESCRIPTION
# Objective

For features like https://github.com/TheBevyFlock/bevy_cli/issues/275 a dedicated logging crate would be helpful to implement `-v`/`--verbose`.

# Solution

I opted for `tracing` instead of `log` even though it's a bit overkill for us at the moment. `tracing` seems to be the most flexible and is also mostly used in `bevy`. But I don't really have a strong opinion on this.

# Testing

```sh
❯ bevy run web
2025-02-24T21:49:19.817751Z  INFO bevy_cli::build: Compiling to WebAssembly...
    Finished `web` profile [unoptimized + debuginfo] target(s) in 0.11s
2025-02-24T21:49:19.970038Z  INFO bevy_cli::build: Bundling JavaScript bindings...
2025-02-24T21:49:22.969352Z  INFO bevy_cli::web::bundle: No custom `web` folder found, using defaults.
2025-02-24T21:49:22.969406Z  INFO bevy_cli::run: Open your app at <http://localhost:4000>!
```
```sh
❯ export RUST_LOG="bevy_cli=error"
❯ bevy run web
    Finished `web` profile [unoptimized + debuginfo] target(s) in 0.15s
```
Closes #236

