### PR TITLE
Add compatibility notes if JavaScript or canvas is unsupported

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -6,6 +6,7 @@
       /* Styles for the loading screen */
       :root {
         --web-bg-color: #2b2c2f;
+        --web-color: white;
       }
 
       * {
@@ -31,6 +32,7 @@
 
       body {
         background-color: var(--web-bg-color);
+        color: var(--web-color);
       }
 
       .spinner {
@@ -58,6 +60,7 @@
   </head>
 
   <body class="center">
+    <noscript>JavaScript support is required to run this app</noscript>
     <div id="loading-screen" class="center">
       <span class="spinner"></span>
     </div>

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -149,6 +149,12 @@
         for (const record of records) {
           for (const addedNode of record.addedNodes) {
             if (addedNode instanceof HTMLCanvasElement) {
+              if (addedNode.innerText.trim().length === 0) {
+                // Add compatibility note
+                addedNode.innerText =
+                  "Canvas support is required to run this app";
+              }
+
               // A new canvas has been created, which means that the game has been loaded
               // Hide the loading screen!
               loading_screen.style.display = "none";


### PR DESCRIPTION
# Objective

Closes #274.

If a browser doesn't support JavaScript or the user disabled/blocked it, the game will never load.
We should let the user know about it in this case.

# Solution

- Add `noscript` element for missing JavaScript support
- Upon creation of the `canvas`, add a compatibility note inside of it

Not pretty, but functional:
![JavaScript support is required to run this app](https://github.com/user-attachments/assets/c783648b-b24b-4b3f-b707-c853c2b1f9a1)
