### PR TITLE
v0.2.0 changelog, migration guide, and other small changes

### DIFF
--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 - `rustc_driver.dll` not found on Windows ([#281](https://github.com/TheBevyFlock/bevy_cli/pull/281))
     - `bevy_lint` should now work on Windows, as it was previously broken by this bug.
 
-## 0.1.0 - 2024-11-17
+## v0.1.0 - 2024-11-17
 
 **All Changes**: [`17834eb...lint-v0.1.0`](https://github.com/TheBevyFlock/bevy_cli/compare/17834eb...lint-v0.1.0)
 

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -11,6 +11,29 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 **All Changes**: [`lint-v0.1.0...main`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.1.0...main)
 
+### Added
+
+- Lint `borrowed_reborrowable` to `pedantic` ([#164](https://github.com/TheBevyFlock/bevy_cli/pull/164))
+- Lint `insert_unit_bundle` to `suspicious` ([#210](https://github.com/TheBevyFlock/bevy_cli/pull/210))
+- Lint configuration in `Cargo.toml` ([#251](https://github.com/TheBevyFlock/bevy_cli/pull/251))
+- Support for `bevy_lint --version` ([#257](https://github.com/TheBevyFlock/bevy_cli/pull/257))
+- Support for qualified method syntax in several lints ([#253](https://github.com/TheBevyFlock/bevy_cli/pull/253))
+- Lint `duplicate_bevy_dependencies` ([#280](https://github.com/TheBevyFlock/bevy_cli/pull/280))
+
+### Changed
+
+- The linter now supports Bevy 0.15, but no longer supports Bevy 0.14 ([#191](https://github.com/TheBevyFlock/bevy_cli/pull/191))
+    - Eventually the linter will support multiple versions of Bevy at the same time. Please see [#138](https://github.com/TheBevyFlock/bevy_cli/issues/138) for more information.
+- Bumped nightly toolchain to `nightly-2025-02-20` ([#278](https://github.com/TheBevyFlock/bevy_cli/pull/278))
+- Lowered `zst_query` lint from `restriction` to `nursery` ([#261](https://github.com/TheBevyFlock/bevy_cli/pull/261))
+    - `zst_query` does not respect `QueryData::Item`, meaning it is broken for queries like `Has<T>` and `AnyOf<T>`. Please see [#279](https://github.com/TheBevyFlock/bevy_cli/issues/279) for more information.
+- Merged `panicking_query_methods` and `panicking_world_methods` into a single lint: `panicking_methods` ([#271](https://github.com/TheBevyFlock/bevy_cli/pull/271))
+
+### Fixed
+
+- `rustc_driver.dll` not found on Windows ([#281](https://github.com/TheBevyFlock/bevy_cli/pull/281))
+    - `bevy_lint` should now work on Windows, as it was previously broken by this bug.
+
 ## 0.1.0 - 2024-11-17
 
 **All Changes**: [`17834eb...lint-v0.1.0`](https://github.com/TheBevyFlock/bevy_cli/compare/17834eb...lint-v0.1.0)

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 - `rustc_driver.dll` not found on Windows ([#281](https://github.com/TheBevyFlock/bevy_cli/pull/281))
     - `bevy_lint` should now work on Windows, as it was previously broken by this bug.
 
-## v0.1.0 - 2024-11-17
+## [v0.1.0] - 2024-11-17
 
 **All Changes**: [`17834eb...lint-v0.1.0`](https://github.com/TheBevyFlock/bevy_cli/compare/17834eb...lint-v0.1.0)
 

--- a/bevy_lint/MIGRATION.md
+++ b/bevy_lint/MIGRATION.md
@@ -1,0 +1,80 @@
+# Migration Guide
+
+Occasionally, changes are made to `bevy_lint` that may break existing projects, or majorly changes how it is intended to be used. This document provides a guide recommending how to upgrade your existing project to a newer version of the linter.
+
+To actually install the new version of the linter, please see [the docs] and [the releases page]. Note that some changes listed here are optional (and will be explicitly marked as such). If you ever run into issues while upgrading, please feel free to [submit an issue].
+
+[the docs]: https://thebevyflock.github.io/bevy_cli/bevy_lint/index.html
+[the releases page]: https://github.com/TheBevyFlock/bevy_cli/releases
+[submit an issue]: https://github.com/TheBevyFlock/bevy_cli/issues
+
+## v0.1.0 to v0.2.0
+
+### [Bevy 0.15 Support](https://github.com/TheBevyFlock/bevy_cli/pull/191)
+
+The linter now supports Bevy 0.15, but no longer supports Bevy 0.14. You may still be able to run the linter successfully on Bevy 0.14 projects, but no guarantee is made on stability or correctness.
+
+To migrate your code base to Bevy 0.15, please see the [release post] and [migration guide].
+
+[release post]: https://bevyengine.org/news/bevy-0-15/
+[migration guide]: https://bevyengine.org/learn/migration-guides/0-14-to-0-15/
+
+### [Bumped Nightly Toolchain to `nightly-2025-02-20`](https://github.com/TheBevyFlock/bevy_cli/pull/278)
+
+The linter now requires the `nightly-2025-02-20` Rustup toolchain to be installed, instead of `nightly-2024-11-14`. The supported Rust language version is now 1.87.0[^rust-2024] instead of the previous 1.84.0.
+
+For more information on how to install this toolchain and its required components, please see the [linter docs].
+
+[linter docs]: https://thebevyflock.github.io/bevy_cli/bevy_lint/index.html
+
+[^rust-2024]: As a nice side-effect, `bevy_lint` now officially supports [Rust 2024](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html).
+
+### [Merged `panicking_query_methods` and `panicking_world_methods`](https://github.com/TheBevyFlock/bevy_cli/pull/271)
+
+The `panicking_query_methods` and `panicking_world_methods` lints have been merged into a single lint: `panicking_methods`. This new lint has the same functionality as the two previous lints combined.
+
+```rust
+// v0.1.0
+#[cfg_attr(bevy_lint, deny(bevy::panicking_query_methods))]
+fn critical_system(query: Query<&MyComponent>) {
+    // ...
+}
+
+// v0.2.0
+#[cfg_attr(bevy_lint, deny(bevy::panicking_methods))]
+fn critical_system(query: Query<&MyComponent>) {
+    // ...
+}
+```
+
+### [Lowered `zst_query` from `restriction` to `nursery`](https://github.com/TheBevyFlock/bevy_cli/pull/261)
+
+A critical bug was found in `zst_query` where it would incorrectly warn on certain queries that _do_ actually query data, such as [`Has<T>`] and [`AnyOf<T>`]. As such, it has been temporarily moved to the [`nursery`] lint group, meaning that it is marked as unstable and may be removed.
+
+Until [#279] is fixed, it is recommended to remove references of this lint from your project.
+
+[`Has<T>`]: https://docs.rs/bevy/0.15.3/bevy/ecs/prelude/struct.Has.html
+[`AnyOf<T>`]: https://docs.rs/bevy/0.15.3/bevy/ecs/prelude/struct.AnyOf.html
+[`nursery`]: https://thebevyflock.github.io/bevy_cli/bevy_lint/groups/static.NURSERY.html
+[#279]: https://github.com/TheBevyFlock/bevy_cli/issues/279
+
+### [Lint Configuration in `Cargo.toml`](https://github.com/TheBevyFlock/bevy_cli/pull/251) (Optional)
+
+It is now possible to configure lints in a crate's `Cargo.toml` instead of directly in its code.
+
+```rust
+#![cfg_attr(bevy_lint, feature(register_tool), register_tool(bevy))]
+
+// You can delete these attributes from your crate root.
+#![cfg_attr(bevy_lint, warn(bevy::pedantic))]
+#![cfg_attr(bevy_lint, deny(bevy::panicking_methods))]
+```
+
+```toml
+# And add them to `Cargo.toml` instead.
+[package.metadata.bevy_lint]
+pedantic = "warn"
+panicking_methods = "deny"
+```
+
+Lint levels specified in `Cargo.toml` will be applied for the entire crate, but can still be overridden in your code.

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -155,8 +155,9 @@ Once `bevy` is registered, you can toggle lints throughout your code, as long as
 // Enable pedantic lints, which are off by default.
 #![cfg_attr(bevy_lint, warn(bevy::pedantic))]
 
-// Deny methods of `World` in this system that can panic when a non-panicking alternative exists.
-#[cfg_attr(bevy_lint, deny(bevy::panicking_world_methods))]
+// Deny panicking `World` and `Query` methods in this system when a non-panicking alternatives
+// exist.
+#[cfg_attr(bevy_lint, deny(bevy::panicking_methods))]
 fn my_critical_system(world: &mut World) {
     // ...
 }

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -155,8 +155,7 @@ Once `bevy` is registered, you can toggle lints throughout your code, as long as
 // Enable pedantic lints, which are off by default.
 #![cfg_attr(bevy_lint, warn(bevy::pedantic))]
 
-// Deny panicking `World` and `Query` methods in this system when a non-panicking alternatives
-// exist.
+// Deny panicking Bevy methods in this system when a non-panicking alternatives exist.
 #[cfg_attr(bevy_lint, deny(bevy::panicking_methods))]
 fn my_critical_system(world: &mut World) {
     // ...

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -31,7 +31,7 @@ rustup toolchain install $TOOLCHAIN_VERSION \
     --component llvm-tools-preview
 ```
 
-For example, you would replace `$TOOLCHAIN_VERSION` with `nightly-2024-11-14` if you were installing `bevy_lint` 0.1.0, based on the [compatibility table](#compatibility). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].
+For example, you would replace `$TOOLCHAIN_VERSION` with `nightly-2024-11-14` if you were installing `bevy_lint` v0.1.0, based on the [compatibility table](#compatibility). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].
 
 [^keep-toolchain-installed]: `bevy_lint` imports internal `rustc` libraries in order to hook into the compiler process. These crates are stored in a [dynamic library](https://en.wikipedia.org/wiki/Dynamic_linker) that is installed with the `rustc-dev` component and loaded by `bevy_lint` at runtime. Uninstalling the nightly toolchain would remove this dynamic library, causing `bevy_lint` to fail.
 
@@ -45,7 +45,7 @@ rustup run $TOOLCHAIN_VERSION cargo install \
     bevy_lint
 ```
 
-Make sure to replace `$TOOLCHAIN_VERSION` and `$TAG` in the above command. The tag for a specific release can be found in the [releases tab](https://github.com/TheBevyFlock/bevy_cli/releases). For example, the tag for 0.1.0 is `lint-v0.1.0`.
+Make sure to replace `$TOOLCHAIN_VERSION` and `$TAG` in the above command. The tag for a specific release can be found in the [releases tab](https://github.com/TheBevyFlock/bevy_cli/releases). For example, the tag for v0.1.0 is `lint-v0.1.0`.
 
 ## Usage
 

--- a/bevy_lint/docs/how-to/release.md
+++ b/bevy_lint/docs/how-to/release.md
@@ -22,7 +22,12 @@
 ````markdown
 <!-- One-sentence summary of changes. What awesome features can we spotlight? What critical bugs were fixed? -->
 
-You can find the live documentation for this release [here](https://thebevyflock.github.io/bevy_cli/bevy_lint/).
+You can find the live documentation for this release [here](https://thebevyflock.github.io/bevy_cli/bevy_lint/). You may also be interested in [the changelog] and [the migration guide].
+
+<!-- Make sure to update the tags in these links to point to the correct version. -->
+
+[the changelog]: https://github.com/TheBevyFlock/bevy_cli/blob/lint-vX.Y.Z/bevy_lint/CHANGELOG.md
+[the migration guide]: https://github.com/TheBevyFlock/bevy_cli/blob/lint-vX.Y.Z/bevy_lint/MIGRATION.md
 
 > [!WARNING]
 >

--- a/bevy_lint/docs/how-to/release.md
+++ b/bevy_lint/docs/how-to/release.md
@@ -3,13 +3,14 @@
 ## Kick-off Pull Request
 
 1. Review the [changelog](../../CHANGELOG.md) and ensure that all notable changes have been documented.
-2. Replace `[Unreleased]` heading with the version with the format `[X.Y.Z] - YYYY-MM-DD`.
+2. Replace `[Unreleased]` heading with the version with the format `[vX.Y.Z] - YYYY-MM-DD`.
 3. Update the `**All Changes**` link to compare from `main` to the new tag `lint-vX.Y.Z`. (E.g. `lint-v0.1.0...main` to `lint-v0.1.0...lint-v0.2.0`.)
+4. Review the [migration guide](../../MIGRATION.md) and ensure all breaking / significant changes from the previous version are documented.
 4. Remove the `-dev` suffix from the version in [`Cargo.toml`](../../Cargo.toml) and the compatibility table in [`README.md`](../../README.md).
-      - Please ensure that [`Cargo.lock`](../../../Cargo.lock) also updates!
+    - Please ensure that [`Cargo.lock`](../../../Cargo.lock) also updates!
 6. Commit all of these changes and open a pull request.
 7. Merge the PR once a core Bevy maintainer approves it with no outstanding issues from other contributors.
-      - This starts the release process, enacting a freeze on all other changes until the release has finished. While maintainers need to be aware of this so they do not merge PRs during this time, the release process should take less than an hour, so it's unlikely to ever be an issue.
+    - This starts the release process, enacting a freeze on all other changes until the release has finished. While maintainers need to be aware of this so they do not merge PRs during this time, the release process should take less than an hour, so it's unlikely to ever be an issue.
 
 ## Release on Github
 

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -64,7 +64,7 @@ fn show_version() {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-    println!("{NAME} {VERSION}");
+    println!("{NAME} v{VERSION}");
 }
 
 /// Returns the path to `bevy_lint_driver`.


### PR DESCRIPTION
This PR adds a new entry to the changelog for v0.2.0. I checked over every change made between 8691821292922ba3b2ea7f52eb57cd637cfd5cfb and 9292db980bcbce820826f8e1c6ad3f7ee23336be, though I may have missed something!

This PR also creates a new file, `MIGRATION.md`, which is a migration guide. It is based off of [Bevy's migration guide](https://bevyengine.org/learn/migration-guides/introduction/), and intends to help users upgrade.

Finally, I made two smaller changes / fixes that got bundled into this PR. I removed a leftover reference to `panicking_world_methods` from the `README.md`, and I changed the format for version numbers to be vX.Y.Z instead of just X.Y.Z.