### PR TITLE
Post-release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_lint"
-version = "0.2.0"
+version = "0.3.0-dev"
 dependencies = [
  "anyhow",
  "bevy",

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+**All Changes**: [`lint-v0.2.0...main`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.2.0...main)
+
 ## [v0.2.0] - 2025-03-19
 
 **All Changes**: [`lint-v0.1.0...lint-v0.2.0`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.1.0...lint-v0.2.0)

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_lint"
-version = "0.2.0"
+version = "0.3.0-dev"
 authors = ["BD103"]
 edition = "2024"
 description = "A collection of lints for the Bevy game engine"

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -176,6 +176,7 @@ There are several other ways to toggle lints, although some have varying levels 
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
+|0.3.0-dev|1.84.0|`nightly-2025-02-20`|0.15|
 |0.2.0|1.84.0|`nightly-2025-02-20`|0.15|
 |0.1.0|1.84.0|`nightly-2024-11-14`|0.14|
 


### PR DESCRIPTION
Following the [release checklist](https://github.com/TheBevyFlock/bevy_cli/blob/b5012ec0065d9f3c0070697451b8fd2404c640e3/bevy_lint/docs/how-to/release.md#post-release), this prepares `bevy_lint` for development for the next release: v0.3.0. This PR:

1. Bumps `bevy_lint` to v0.3.0-dev
2. Adds a new row to the compatibility table in the `README.md`
3. Adds a new section to the changelog

Merging this PR will resolve the feature freeze, letting other PRs be merged as well! :)