### PR TITLE
Add note in `MethodCall::receiver` docs that it may include the reference

### DIFF
--- a/bevy_lint/src/utils/hir_parse.rs
+++ b/bevy_lint/src/utils/hir_parse.rs
@@ -144,9 +144,10 @@ pub struct MethodCall<'tcx> {
 
     /// The receiver, or the object, of the method.
     ///
-    /// This can be used to find what type the method is implemented for.
-    ///
-    /// TODO(BD103): Does this include the `&` reference? Should we suggest stripping it?
+    /// This can be used to find what type the method is implemented for. Note that this will
+    /// include the reference in the type _only_ if the method is fully-qualified. This reference
+    /// will be omitted when the method is in receiver form. As such, you may want to call
+    /// [`Ty::peel_refs()`](rustc_middle::ty::Ty::peel_refs) on the result before processing it.
     ///
     /// # Example
     ///


### PR DESCRIPTION
This was a leftover TODO that I forgot to fix, whoops!

I experimented, turns out `MethodCall::receiver` only includes the `&` when the method is fully-qualified. I added a recommendation to `peel_refs()` in this case, since if you forget your lint may behave differently.