### PR TITLE
Use direct field access instead of `HasSession` trait

### DIFF
--- a/bevy_lint/src/lints/pedantic/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/pedantic/main_return_without_appexit.rs
@@ -35,7 +35,7 @@
 
 use crate::{declare_bevy_lint, declare_bevy_lint_pass, utils::hir_parse::MethodCall};
 use clippy_utils::{
-    diagnostics::span_lint_hir_and_then, is_entrypoint_fn, source::HasSession, sym, ty::match_type,
+    diagnostics::span_lint_hir_and_then, is_entrypoint_fn, sym, ty::match_type,
     visitors::for_each_expr,
 };
 use rustc_errors::Applicability;
@@ -90,7 +90,7 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
                     ..
                 }) = MethodCall::try_from(cx, expr)
                     && method_path.ident.name == self.run
-                    && !expr.span.in_external_macro(cx.tcx.sess().source_map())
+                    && !expr.span.in_external_macro(cx.tcx.sess.source_map())
                 {
                     // Get the type of `src` for `src.run()`. We peel away all references because
                     // both `App` and `&mut App` are allowed.

--- a/bevy_lint/src/lints/restriction/missing_reflect.rs
+++ b/bevy_lint/src/lints/restriction/missing_reflect.rs
@@ -55,9 +55,7 @@
 //! Code](../../index.html#toggling-lints-in-code).
 
 use crate::{declare_bevy_lint, declare_bevy_lint_pass};
-use clippy_utils::{
-    def_path_res, diagnostics::span_lint_hir_and_then, source::HasSession, sugg::DiagExt,
-};
+use clippy_utils::{def_path_res, diagnostics::span_lint_hir_and_then, sugg::DiagExt};
 use rustc_errors::Applicability;
 use rustc_hir::{
     HirId, Item, ItemKind, Node, OwnerId, QPath, TyKind,
@@ -116,7 +114,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingReflect {
                 // Skip if a types originates from a foreign crate's macro
                 if without_reflect
                     .item_span
-                    .in_external_macro(cx.tcx.sess().source_map())
+                    .in_external_macro(cx.tcx.sess.source_map())
                 {
                     continue;
                 }

--- a/bevy_lint/src/lints/restriction/panicking_methods.rs
+++ b/bevy_lint/src/lints/restriction/panicking_methods.rs
@@ -78,7 +78,7 @@ use crate::{
 };
 use clippy_utils::{
     diagnostics::span_lint_and_help,
-    source::{HasSession, snippet, snippet_opt},
+    source::{snippet, snippet_opt},
     ty::match_type,
 };
 use rustc_hir::Expr;
@@ -99,7 +99,7 @@ declare_bevy_lint_pass! {
 impl<'tcx> LateLintPass<'tcx> for PanickingMethods {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         // skip expressions that originate from external macros
-        if expr.span.in_external_macro(cx.tcx.sess().source_map()) {
+        if expr.span.in_external_macro(cx.tcx.sess.source_map()) {
             return;
         }
 

--- a/bevy_lint/src/lints/style/plugin_not_ending_in_plugin.rs
+++ b/bevy_lint/src/lints/style/plugin_not_ending_in_plugin.rs
@@ -38,9 +38,7 @@
 //! ```
 
 use crate::{declare_bevy_lint, declare_bevy_lint_pass};
-use clippy_utils::{
-    diagnostics::span_lint_hir_and_then, match_def_path, path_res, source::HasSession,
-};
+use clippy_utils::{diagnostics::span_lint_hir_and_then, match_def_path, path_res};
 use rustc_errors::Applicability;
 use rustc_hir::{HirId, Item, ItemKind, OwnerId, def::Res};
 use rustc_lint::{LateContext, LateLintPass};
@@ -98,7 +96,7 @@ impl<'tcx> LateLintPass<'tcx> for PluginNotEndingInPlugin {
             };
 
             // skip lint if the struct was defined in an external macro
-            if struct_span.in_external_macro(cx.tcx.sess().source_map()) {
+            if struct_span.in_external_macro(cx.tcx.sess.source_map()) {
                 return;
             }
 

--- a/bevy_lint/src/lints/suspicious/insert_event_resource.rs
+++ b/bevy_lint/src/lints/suspicious/insert_event_resource.rs
@@ -45,7 +45,7 @@ use crate::{
 };
 use clippy_utils::{
     diagnostics::span_lint_and_sugg,
-    source::{HasSession, snippet, snippet_with_applicability},
+    source::{snippet, snippet_with_applicability},
     sym,
     ty::{match_type, ty_from_hir_ty},
 };
@@ -75,7 +75,7 @@ const HELP_MESSAGE: &str = "inserting an `Events` resource does not fully setup 
 impl<'tcx> LateLintPass<'tcx> for InsertEventResource {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         // skip expressions that originate from external macros
-        if expr.span.in_external_macro(cx.tcx.sess().source_map()) {
+        if expr.span.in_external_macro(cx.tcx.sess.source_map()) {
             return;
         }
 

--- a/bevy_lint/src/lints/suspicious/insert_unit_bundle.rs
+++ b/bevy_lint/src/lints/suspicious/insert_unit_bundle.rs
@@ -50,7 +50,7 @@
 //! # bevy::ecs::system::assert_is_system(spawn);
 //! ```
 
-use clippy_utils::{diagnostics::span_lint_hir_and_then, source::HasSession, sym, ty::match_type};
+use clippy_utils::{diagnostics::span_lint_hir_and_then, sym, ty::match_type};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -90,7 +90,7 @@ impl<'tcx> LateLintPass<'tcx> for InsertUnitBundle {
 
         // If the method call was not to `Commands::spawn()` or originates from an external macro,
         // we skip it.
-        if !(span.in_external_macro(cx.tcx.sess().source_map())
+        if !(span.in_external_macro(cx.tcx.sess.source_map())
             || match_type(cx, src_ty, &crate::paths::COMMANDS)
                 && method_path.ident.name == self.spawn)
         {


### PR DESCRIPTION
Unifies how we access the `Session`.  Noticed I sometimes used the method to access it after reading https://github.com/TheBevyFlock/bevy_cli/issues/325