### PR TITLE
Add CLI config in Cargo.toml to set feature flags

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,100 @@
+use anyhow::bail;
+use serde_json::{Map, Value};
+
+use crate::external_cli::cargo::metadata::{Metadata, Package};
+
+#[derive(Debug, Clone)]
+pub struct CliConfig {
+    features: Vec<String>,
+    default_features: bool,
+}
+
+impl Default for CliConfig {
+    fn default() -> Self {
+        Self {
+            features: Vec::new(),
+            default_features: true,
+        }
+    }
+}
+
+impl CliConfig {
+    pub fn for_package(
+        metadata: &Metadata,
+        package: &Package,
+        is_web: bool,
+        is_release: bool,
+    ) -> anyhow::Result<Self> {
+        let Some(package_metadata) = metadata.packages.iter().find_map(|cur_package| {
+            if package == cur_package {
+                Some(cur_package.metadata.clone())
+            } else {
+                None
+            }
+        }) else {
+            return Ok(Self::default());
+        };
+
+        let Some(cli_metadata) = package_metadata.get("bevy_cli") else {
+            return Ok(Self::default());
+        };
+
+        let Value::Object(cli_metadata) = cli_metadata else {
+            bail!("Bevy CLI config must be a table");
+        };
+
+        Ok(Self {
+            features: extract_features(cli_metadata)?,
+            default_features: true,
+        })
+    }
+}
+
+fn extract_features(cli_metadata: &Map<String, Value>) -> anyhow::Result<Vec<String>> {
+    let Some(features) = cli_metadata.get("features") else {
+        return Ok(Vec::new());
+    };
+
+    match features {
+        Value::Array(features) => features
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .map(|str| str.to_string())
+                    .ok_or_else(|| anyhow::anyhow!("each feature must be a string"))
+            })
+            .collect(),
+        Value::Null => Ok(Vec::new()),
+        _ => bail!("package.metadata.bevy_cli.features must be an array"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod extract_features {
+        use serde_json::Map;
+
+        use super::*;
+
+        #[test]
+        fn should_return_empty_vec_if_no_features_specified() -> anyhow::Result<()> {
+            let cli_metadata = Map::new();
+            assert_eq!(extract_features(&cli_metadata)?, Vec::<String>::new());
+            Ok(())
+        }
+
+        #[test]
+        fn should_return_features_if_listed() -> anyhow::Result<()> {
+            let mut cli_metadata = Map::new();
+            cli_metadata.insert("features".to_string(), vec!["dev", "web"].into());
+            assert_eq!(
+                extract_features(&cli_metadata)?,
+                vec!["dev".to_string(), "web".to_string()]
+            );
+            Ok(())
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ impl CliConfig {
         self.default_features.unwrap_or(true)
     }
 
+    /// Determine the Bevy CLI config as defined in the given package.
     pub fn for_package(
         metadata: &Metadata,
         package: &Package,
@@ -76,7 +77,7 @@ impl CliConfig {
 
         Ok(Self {
             features: extract_features(cli_metadata)?,
-            default_features: None,
+            default_features: extract_default_features(cli_metadata)?,
         })
     }
 
@@ -111,6 +112,19 @@ fn extract_features(cli_metadata: &Map<String, Value>) -> anyhow::Result<Vec<Str
             .collect(),
         Value::Null => Ok(Vec::new()),
         _ => bail!("features must be an array"),
+    }
+}
+
+/// Try to extract whether default_features are enabled from a metadata map for the CLI.
+fn extract_default_features(cli_metadata: &Map<String, Value>) -> anyhow::Result<Option<bool>> {
+    let Some(default_features) = cli_metadata.get("default_features") else {
+        return Ok(None);
+    };
+
+    match default_features {
+        Value::Bool(default_features) => Ok(Some(default_features).copied()),
+        Value::Null => Ok(None),
+        _ => bail!("default_features must be an array"),
     }
 }
 

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -62,6 +62,9 @@ pub struct Metadata {
     /// The absolute path to the root of the workspace.
     /// This will be the root of the package if no workspace is used.
     pub workspace_root: PathBuf,
+    /// Workspace metadata.
+    /// This is `null` if no metadata is specified.
+    pub metadata: serde_json::Value,
 }
 
 #[derive(Debug, Deserialize)]
@@ -79,6 +82,9 @@ pub struct Package {
     pub manifest_path: PathBuf,
     /// Optional string that is the default binary picked by cargo run.
     pub default_run: Option<String>,
+    /// Package metadata.
+    /// This is `null` if no metadata is specified.
+    pub metadata: serde_json::Value,
 }
 
 impl Package {

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -113,6 +113,12 @@ impl Package {
     }
 }
 
+impl PartialEq for Package {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Dependency {
     /// The name of the dependency.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod run;
 pub mod template;
 #[cfg(feature = "web")]
 pub(crate) mod web;
+pub mod config;


### PR DESCRIPTION
# Objective

Closes #250.

Bevy apps often want to configure different features in dev vs. release mode or when targeting native vs. web.
With native `cargo`, that's currently a pain to do.

With this PR, the user can configure `features` and `default_features` in the CLI in general, but also specific for the different modes as mentioned above.

# Solution

The `cargo metadata` output also includes the contents of the `metadata` table of each package.
We retrieve the value for the package that we build for and then extract the config from that metadata.

For example, a user can configure `package.metadata.bevy_cli.web.release` to set up features when compiling for the web in release mode.
The `bevy_cli.release` and `bevy_cli.web` configs are hereby merged into the more specific configs to make configuration a bit less boilerplaty.

Note that the workspace config is currently _not_ considered, because configuring features only makes sense for packages.

# TODO

- Determine package for the binary that needs to be compiled
- Apply config to build/run arguments

# Feedback wanted

- Is the config merge order base -> profile -> platform -> platform-profile the one you'd expect?