### PR TITLE
Don't install Linux dependencies in CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,6 @@ jobs:
           toolchain: ${{ needs.extract-rust-version.outputs.channel }}
           components: ${{ needs.extract-rust-version.outputs.components }}
 
-      # The CLI and linter's UI tests depend on Bevy with default features. This requires extra
-      # packages, such as `alsa` and `udev`, to be installed on Linux.
-      - name: Install Linux dependencies
-        uses: bevyengine/bevy/.github/actions/install-linux-deps@v0.15.1
-
       - name: Cache build artifacts
         uses: Leafwing-Studios/cargo-cache@v2
         with:


### PR DESCRIPTION
I don't think we need the Linux dependencies in CI at all since: https://github.com/TheBevyFlock/bevy_cli/pull/291.
Came to my attention in: https://github.com/TheBevyFlock/bevy_cli/pull/330 but was a bit too late.