### PR TITLE
Use rustc to determine if target is already installed

### DIFF
--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -1,6 +1,6 @@
 //! Utilities for the `rustup` CLI tool.
 
-use std::{env, ffi::OsString};
+use std::{env, ffi::OsString, path::Path};
 
 use anyhow::Context;
 use dialoguer::Confirm;
@@ -13,19 +13,27 @@ fn program() -> OsString {
     env::var_os("BEVY_CLI_RUSTUP").unwrap_or("rustup".into())
 }
 
+/// The rustc command can be customized via the `BEVY_CLI_RUSTC` env
+fn rustc_program() -> OsString {
+    env::var_os("BEVY_CLI_RUSTC").unwrap_or("rustc".into())
+}
+
 /// Given a target triple, determine if it is already installed.
 fn is_target_installed(target: &str) -> bool {
-    let output = CommandExt::new(program())
-        .arg("target")
-        .arg("list")
+    let output = CommandExt::new(rustc_program())
+        .arg("--print")
+        .arg("sysroot")
         .output();
 
-    // Check if the target list has an entry like this:
-    // <target_triple> (installed)
     let Ok(output) = output else { return false };
-    let list = String::from_utf8_lossy(&output.stdout);
-    list.lines()
-        .any(|line| line.contains(target) && line.contains("(installed)"))
+
+    let sysroot = String::from_utf8_lossy(&output.stdout);
+
+    Path::new(&format!(
+        "{}/lib/rustlib/{target}",
+        sysroot.strip_suffix("\n").unwrap_or(&sysroot)
+    ))
+    .is_dir()
 }
 
 /// Install a compilation target, if it is not already installed.


### PR DESCRIPTION
This makes it possible to run `bevy run web` on systems without `rustup` (https://github.com/TheBevyFlock/bevy_cli/issues/336).