### PR TITLE
Filter for wasm32 dependencies in metadata

### DIFF
--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -81,7 +81,8 @@ pub fn build_web(args: &mut BuildArgs) -> anyhow::Result<WebBundle> {
 pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {
     // The resolved dependency graph is needed to ensure the `wasm-bindgen-cli` version matches
     // exactly the `wasm-bindgen` version
-    let metadata = cargo::metadata::metadata()?;
+    let metadata =
+        cargo::metadata::metadata_with_args(["--filter-platform", "wasm32-unknown-unknown"])?;
 
     let wasm_bindgen_version = metadata
         .packages


### PR DESCRIPTION
For whatever reason `wasm-bindgen` simply won't show up in the output of `cargo metadata` unless you filter specifically for `wasm32-unknown-unknown` OR if you depend on `wasm-bindgen` directly.

Not sure why it behaves this way. Closes https://github.com/TheBevyFlock/bevy_cli/issues/335