### PR TITLE
Make `LintGroup` a trait

### DIFF
--- a/bevy_lint/src/lint.rs
+++ b/bevy_lint/src/lint.rs
@@ -60,7 +60,7 @@ macro_rules! declare_bevy_lint {
     {
         $(#[$attr:meta])*
         $vis:vis $name:ident,
-        $group:expr,
+        $group:ty,
         $desc:expr,
         $(@report_in_external_macro = $report_in_external_macro:expr,)?
         $(@crate_level_only = $crate_level_only:expr,)?
@@ -76,28 +76,25 @@ macro_rules! declare_bevy_lint {
         /// }
         /// ```
         $(#[$attr])*
-        $vis static $name: &$crate::lint::BevyLint = &$crate::lint::BevyLint {
-            lint: &::rustc_lint::Lint {
-                // Fields that are always configured by macro.
-                name: concat!("bevy::", stringify!($name)),
-                default_level: $group.level,
-                desc: $desc,
+        $vis static $name: &::rustc_lint::Lint = &::rustc_lint::Lint {
+            // Fields that are always configured by macro.
+            name: concat!("bevy::", stringify!($name)),
+            default_level: <$group as $crate::lint::LintGroup>::LEVEL,
+            desc: $desc,
 
-                // Fields that cannot be configured.
-                edition_lint_opts: None,
-                future_incompatible: None,
-                feature_gate: None,
-                is_externally_loaded: true,
+            // Fields that cannot be configured.
+            edition_lint_opts: None,
+            future_incompatible: None,
+            feature_gate: None,
+            is_externally_loaded: true,
 
-                // Fields that may sometimes be configured by macro. These all default to false in
-                // `Lint::default_fields_for_macro()`, but may be overridden to true.
-                $(report_in_external_macro: $report_in_external_macro,)?
-                $(crate_level_only: $crate_level_only,)?
-                $(eval_always: $eval_always,)?
+            // Fields that may sometimes be configured by macro. These all default to false in
+            // `Lint::default_fields_for_macro()`, but may be overridden to true.
+            $(report_in_external_macro: $report_in_external_macro,)?
+            $(crate_level_only: $crate_level_only,)?
+            $(eval_always: $eval_always,)?
 
-                ..::rustc_lint::Lint::default_fields_for_macro()
-            },
-            group: $group,
+            ..::rustc_lint::Lint::default_fields_for_macro()
         };
     };
 }

--- a/bevy_lint/src/lints/cargo.rs
+++ b/bevy_lint/src/lints/cargo.rs
@@ -9,7 +9,7 @@ use rustc_session::{config::Input, utils::was_invoked_from_cargo};
 use rustc_span::Symbol;
 
 declare_bevy_lint_pass! {
-    pub Cargo => [DUPLICATE_BEVY_DEPENDENCIES.lint],
+    pub Cargo => [DUPLICATE_BEVY_DEPENDENCIES],
     @default = {
         bevy: Symbol = sym!(bevy),
     },

--- a/bevy_lint/src/lints/complexity/mod.rs
+++ b/bevy_lint/src/lints/complexity/mod.rs
@@ -2,11 +2,16 @@
 //!
 //! These lints are **warn** by default.
 
-use rustc_lint::Level;
+use rustc_lint::{Level, Lint, LintStore};
 
 use crate::lint::LintGroup;
 
-pub(crate) static COMPLEXITY: &LintGroup = &LintGroup {
-    name: "bevy::complexity",
-    level: Level::Warn,
-};
+pub(crate) struct Complexity;
+
+impl LintGroup for Complexity {
+    const NAME: &str = "bevy::complexity";
+    const LEVEL: Level = Level::Warn;
+    const LINTS: &[&Lint] = &[];
+
+    fn register_passes(_store: &mut LintStore) {}
+}

--- a/bevy_lint/src/lints/correctness/mod.rs
+++ b/bevy_lint/src/lints/correctness/mod.rs
@@ -5,11 +5,16 @@
 //!
 //! These lints are **deny** by default.
 
-use rustc_lint::Level;
+use rustc_lint::{Level, Lint, LintStore};
 
 use crate::lint::LintGroup;
 
-pub(crate) static CORRECTNESS: &LintGroup = &LintGroup {
-    name: "bevy::correctness",
-    level: Level::Deny,
-};
+pub(crate) struct Correctness;
+
+impl LintGroup for Correctness {
+    const NAME: &str = "bevy::correctness";
+    const LEVEL: Level = Level::Deny;
+    const LINTS: &[&Lint] = &[];
+
+    fn register_passes(_store: &mut LintStore) {}
+}

--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -22,8 +22,9 @@
 //!
 //! [lint groups that can be toggled together]: crate#toggling-lints-in-cargotoml
 
-use crate::lint::{BevyLint, LintGroup};
-use rustc_lint::{Lint, LintStore};
+use rustc_lint::LintStore;
+
+use crate::lint::LintGroup;
 
 mod cargo;
 
@@ -36,85 +37,40 @@ pub mod restriction;
 pub mod style;
 pub mod suspicious;
 
-/// A list of all [`BevyLint`]s.
-///
-/// If a group is not in this list, it will not be registered in [`register_lints()`].
-static LINTS: &[&BevyLint] = &[
-    // This list should be sorted alphabetically based on the lint's name, not group.
-    pedantic::borrowed_reborrowable::BORROWED_REBORROWABLE,
-    nursery::duplicate_bevy_dependencies::DUPLICATE_BEVY_DEPENDENCIES,
-    suspicious::insert_event_resource::INSERT_EVENT_RESOURCE,
-    suspicious::insert_unit_bundle::INSERT_UNIT_BUNDLE,
-    suspicious::iter_current_update_events::ITER_CURRENT_UPDATE_EVENTS,
-    pedantic::main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT,
-    restriction::missing_reflect::MISSING_REFLECT,
-    restriction::panicking_methods::PANICKING_METHODS,
-    style::plugin_not_ending_in_plugin::PLUGIN_NOT_ENDING_IN_PLUGIN,
-    nursery::zst_query::ZST_QUERY,
-];
-
-/// A list of all [`LintGroup`]s.
-///
-/// If a group is not in this list, it will not be registered in [`register_groups()`].
-static GROUPS: &[&LintGroup] = &[
-    // This list should be sorted alphabetically.
-    complexity::COMPLEXITY,
-    correctness::CORRECTNESS,
-    nursery::NURSERY,
-    pedantic::PEDANTIC,
-    performance::PERFORMANCE,
-    restriction::RESTRICTION,
-    style::STYLE,
-    suspicious::SUSPICIOUS,
-];
-
 /// Registers all [`BevyLint`]s in [`LINTS`] with the [`LintStore`].
 pub(crate) fn register_lints(store: &mut LintStore) {
-    let lints: Vec<&Lint> = LINTS.iter().map(|x| x.lint).collect();
-    store.register_lints(&lints);
+    complexity::Complexity::register_lints(store);
+    correctness::Correctness::register_lints(store);
+    nursery::Nursery::register_lints(store);
+    pedantic::Pedantic::register_lints(store);
+    performance::Performance::register_lints(store);
+    restriction::Restriction::register_lints(store);
+    style::Style::register_lints(store);
+    suspicious::Suspicious::register_lints(store);
 }
 
 /// Registers all lint passes with the [`LintStore`].
 pub(crate) fn register_passes(store: &mut LintStore) {
-    store.register_late_pass(|_| {
-        Box::new(pedantic::borrowed_reborrowable::BorrowedReborrowable::default())
-    });
+    complexity::Complexity::register_passes(store);
+    correctness::Correctness::register_passes(store);
+    nursery::Nursery::register_passes(store);
+    pedantic::Pedantic::register_passes(store);
+    performance::Performance::register_passes(store);
+    restriction::Restriction::register_passes(store);
+    style::Style::register_passes(store);
+    suspicious::Suspicious::register_passes(store);
+
     store.register_late_pass(|_| Box::new(cargo::Cargo::default()));
-    store.register_late_pass(|_| {
-        Box::new(suspicious::insert_event_resource::InsertEventResource::default())
-    });
-    store.register_late_pass(|_| {
-        Box::new(suspicious::insert_unit_bundle::InsertUnitBundle::default())
-    });
-    store.register_late_pass(|_| {
-        Box::new(suspicious::iter_current_update_events::IterCurrentUpdateEvents::default())
-    });
-    store.register_late_pass(|_| {
-        Box::new(pedantic::main_return_without_appexit::MainReturnWithoutAppExit::default())
-    });
-    store.register_late_pass(|_| Box::new(restriction::missing_reflect::MissingReflect::default()));
-    store.register_late_pass(|_| {
-        Box::new(restriction::panicking_methods::PanickingMethods::default())
-    });
-    store.register_late_pass(|_| {
-        Box::new(style::plugin_not_ending_in_plugin::PluginNotEndingInPlugin::default())
-    });
-    store.register_late_pass(|_| Box::new(nursery::zst_query::ZstQuery::default()));
 }
 
 /// Registers all [`LintGroup`]s in [`GROUPS`] with the [`LintStore`].
 pub(crate) fn register_groups(store: &mut LintStore) {
-    for &group in GROUPS {
-        let lints = LINTS
-            .iter()
-            .copied()
-            // Only select lints of this specified group.
-            .filter(|l| l.group == group)
-            // Convert the lints into their `LintId`s.
-            .map(BevyLint::id)
-            // Collect into a `Vec`.
-            .collect();
-
-        store.register_group(true, group.name, None, lints);
-    }
+    complexity::Complexity::register_group(store);
+    correctness::Correctness::register_group(store);
+    nursery::Nursery::register_group(store);
+    pedantic::Pedantic::register_group(store);
+    performance::Performance::register_group(store);
+    restriction::Restriction::register_group(store);
+    style::Style::register_group(store);
+    suspicious::Suspicious::register_group(store);
 }

--- a/bevy_lint/src/lints/nursery/duplicate_bevy_dependencies.rs
+++ b/bevy_lint/src/lints/nursery/duplicate_bevy_dependencies.rs
@@ -79,7 +79,7 @@ use toml::Spanned;
 
 declare_bevy_lint! {
     pub DUPLICATE_BEVY_DEPENDENCIES,
-    super::NURSERY,
+    super::Nursery,
     "multiple versions of the `bevy` crate found",
     @crate_level_only = true,
 }
@@ -169,9 +169,9 @@ fn lint_with_target_version(
         if let Some(cargo_toml_reference) = cargo_toml.dependencies.get(*mismatching_dependency.0) {
             span_lint_and_then(
                 cx,
-                DUPLICATE_BEVY_DEPENDENCIES.lint,
+                DUPLICATE_BEVY_DEPENDENCIES,
                 toml_span(cargo_toml_reference.span(), file),
-                DUPLICATE_BEVY_DEPENDENCIES.lint.desc,
+                DUPLICATE_BEVY_DEPENDENCIES.desc,
                 |diag| {
                     diag.span_help(
                         bevy_cargo_toml_span,
@@ -228,7 +228,7 @@ fn minimal_lint(
     if resolved_bevy_versions.len() > 1 {
         span_lint(
             cx,
-            DUPLICATE_BEVY_DEPENDENCIES.lint,
+            DUPLICATE_BEVY_DEPENDENCIES,
             rustc_span::DUMMY_SP,
             "found multiple versions of bevy",
         );

--- a/bevy_lint/src/lints/nursery/mod.rs
+++ b/bevy_lint/src/lints/nursery/mod.rs
@@ -2,14 +2,25 @@
 //!
 //! These lints are **allow** by default.
 
-use rustc_lint::Level;
+use rustc_lint::{Level, Lint, LintStore};
 
 use crate::lint::LintGroup;
 
 pub mod duplicate_bevy_dependencies;
 pub mod zst_query;
 
-pub(crate) static NURSERY: &LintGroup = &LintGroup {
-    name: "bevy::nursery",
-    level: Level::Allow,
-};
+pub(crate) struct Nursery;
+
+impl LintGroup for Nursery {
+    const NAME: &str = "bevy::nursery";
+    const LEVEL: Level = Level::Allow;
+    const LINTS: &[&Lint] = &[
+        duplicate_bevy_dependencies::DUPLICATE_BEVY_DEPENDENCIES,
+        zst_query::ZST_QUERY,
+    ];
+
+    fn register_passes(store: &mut LintStore) {
+        // `duplicate_bevy_dependencies` is a Cargo pass, so it does not get registered here.
+        store.register_late_pass(|_| Box::new(zst_query::ZstQuery::default()));
+    }
+}

--- a/bevy_lint/src/lints/nursery/zst_query.rs
+++ b/bevy_lint/src/lints/nursery/zst_query.rs
@@ -70,12 +70,12 @@ declare_bevy_lint! {
     pub ZST_QUERY,
     // This will eventually be a `RESTRICTION` lint, but due to
     // <https://github.com/TheBevyFlock/bevy_cli/issues/279> it is not yet ready for production.
-    super::NURSERY,
+    super::Nursery,
     "queried a zero-sized type",
 }
 
 declare_bevy_lint_pass! {
-    pub ZstQuery => [ZST_QUERY.lint],
+    pub ZstQuery => [ZST_QUERY],
 }
 
 impl<'tcx> LateLintPass<'tcx> for ZstQuery {
@@ -107,9 +107,9 @@ impl<'tcx> LateLintPass<'tcx> for ZstQuery {
             //       instead suggest `Has<Foo>`
             span_lint_and_help(
                 cx,
-                ZST_QUERY.lint,
+                ZST_QUERY,
                 hir_ty.span,
-                ZST_QUERY.lint.desc,
+                ZST_QUERY.desc,
                 None,
                 query_kind.help(peeled),
             );

--- a/bevy_lint/src/lints/pedantic/borrowed_reborrowable.rs
+++ b/bevy_lint/src/lints/pedantic/borrowed_reborrowable.rs
@@ -112,12 +112,12 @@ use rustc_span::{
 
 declare_bevy_lint! {
     pub BORROWED_REBORROWABLE,
-    super::PEDANTIC,
+    super::Pedantic,
     "function parameter takes a mutable reference to a re-borrowable type",
 }
 
 declare_bevy_lint_pass! {
-    pub BorrowedReborrowable => [BORROWED_REBORROWABLE.lint],
+    pub BorrowedReborrowable => [BORROWED_REBORROWABLE],
 }
 
 impl<'tcx> LateLintPass<'tcx> for BorrowedReborrowable {
@@ -209,7 +209,7 @@ impl<'tcx> LateLintPass<'tcx> for BorrowedReborrowable {
 
             span_lint_and_sugg(
                 cx,
-                BORROWED_REBORROWABLE.lint,
+                BORROWED_REBORROWABLE,
                 span,
                 reborrowable.message(),
                 reborrowable.help(),

--- a/bevy_lint/src/lints/pedantic/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/pedantic/main_return_without_appexit.rs
@@ -46,12 +46,12 @@ use std::ops::ControlFlow;
 
 declare_bevy_lint! {
     pub MAIN_RETURN_WITHOUT_APPEXIT,
-    super::PEDANTIC,
+    super::Pedantic,
     "an entrypoint that calls `App::run()` does not return `AppExit`",
 }
 
 declare_bevy_lint_pass! {
-    pub MainReturnWithoutAppExit => [MAIN_RETURN_WITHOUT_APPEXIT.lint],
+    pub MainReturnWithoutAppExit => [MAIN_RETURN_WITHOUT_APPEXIT],
     @default = {
         run: Symbol = sym!(run),
     },
@@ -100,10 +100,10 @@ impl<'tcx> LateLintPass<'tcx> for MainReturnWithoutAppExit {
                     if match_type(cx, ty, &crate::paths::APP) {
                         span_lint_hir_and_then(
                             cx,
-                            MAIN_RETURN_WITHOUT_APPEXIT.lint,
+                            MAIN_RETURN_WITHOUT_APPEXIT,
                             expr.hir_id,
                             span,
-                            MAIN_RETURN_WITHOUT_APPEXIT.lint.desc,
+                            MAIN_RETURN_WITHOUT_APPEXIT.desc,
                             |diag| {
                                 diag.note("`App::run()` returns `AppExit`, which can be used to determine whether the app exited successfully or not");
 

--- a/bevy_lint/src/lints/pedantic/mod.rs
+++ b/bevy_lint/src/lints/pedantic/mod.rs
@@ -6,14 +6,29 @@
 //!
 //! These lints are **allow** by default.
 
-use rustc_lint::Level;
+use rustc_lint::{Level, Lint, LintStore};
 
 use crate::lint::LintGroup;
 
 pub mod borrowed_reborrowable;
 pub mod main_return_without_appexit;
 
-pub(crate) static PEDANTIC: &LintGroup = &LintGroup {
-    name: "bevy::pedantic",
-    level: Level::Allow,
-};
+pub(crate) struct Pedantic;
+
+impl LintGroup for Pedantic {
+    const NAME: &str = "bevy::pedantic";
+    const LEVEL: Level = Level::Allow;
+    const LINTS: &[&Lint] = &[
+        borrowed_reborrowable::BORROWED_REBORROWABLE,
+        main_return_without_appexit::MAIN_RETURN_WITHOUT_APPEXIT,
+    ];
+
+    fn register_passes(store: &mut LintStore) {
+        store.register_late_pass(|_| {
+            Box::new(borrowed_reborrowable::BorrowedReborrowable::default())
+        });
+        store.register_late_pass(|_| {
+            Box::new(main_return_without_appexit::MainReturnWithoutAppExit::default())
+        });
+    }
+}

--- a/bevy_lint/src/lints/performance/mod.rs
+++ b/bevy_lint/src/lints/performance/mod.rs
@@ -2,11 +2,16 @@
 //!
 //! These lints are **warn** by default.
 
-use rustc_lint::Level;
+use rustc_lint::{Level, Lint, LintStore};
 
 use crate::lint::LintGroup;
 
-pub(crate) static PERFORMANCE: &LintGroup = &LintGroup {
-    name: "bevy::performance",
-    level: Level::Warn,
-};
+pub(crate) struct Performance;
+
+impl LintGroup for Performance {
+    const NAME: &str = "bevy::performance";
+    const LEVEL: Level = Level::Warn;
+    const LINTS: &[&Lint] = &[];
+
+    fn register_passes(_store: &mut LintStore) {}
+}

--- a/bevy_lint/src/lints/restriction/missing_reflect.rs
+++ b/bevy_lint/src/lints/restriction/missing_reflect.rs
@@ -67,14 +67,14 @@ use rustc_span::Span;
 
 declare_bevy_lint! {
     pub MISSING_REFLECT,
-    super::RESTRICTION,
+    super::Restriction,
     "defined a component, resource, or event without a `Reflect` implementation",
     // We only override `check_crate()`.
     @crate_level_only = true,
 }
 
 declare_bevy_lint_pass! {
-    pub MissingReflect => [MISSING_REFLECT.lint],
+    pub MissingReflect => [MISSING_REFLECT],
 }
 
 impl<'tcx> LateLintPass<'tcx> for MissingReflect {
@@ -121,7 +121,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingReflect {
 
                 span_lint_hir_and_then(
                     cx,
-                    MISSING_REFLECT.lint,
+                    MISSING_REFLECT,
                     // This tells `rustc` where to search for `#[allow(...)]` attributes.
                     without_reflect.hir_id,
                     without_reflect.item_span,

--- a/bevy_lint/src/lints/restriction/mod.rs
+++ b/bevy_lint/src/lints/restriction/mod.rs
@@ -6,14 +6,25 @@
 //!
 //! These lints are **allow** by default.
 
-use rustc_lint::Level;
+use rustc_lint::{Level, Lint, LintStore};
 
 use crate::lint::LintGroup;
 
 pub mod missing_reflect;
 pub mod panicking_methods;
 
-pub(crate) static RESTRICTION: &LintGroup = &LintGroup {
-    name: "bevy::restriction",
-    level: Level::Allow,
-};
+pub(crate) struct Restriction;
+
+impl LintGroup for Restriction {
+    const NAME: &str = "bevy::restriction";
+    const LEVEL: Level = Level::Allow;
+    const LINTS: &[&Lint] = &[
+        missing_reflect::MISSING_REFLECT,
+        panicking_methods::PANICKING_METHODS,
+    ];
+
+    fn register_passes(store: &mut LintStore) {
+        store.register_late_pass(|_| Box::new(missing_reflect::MissingReflect::default()));
+        store.register_late_pass(|_| Box::new(panicking_methods::PanickingMethods::default()));
+    }
+}

--- a/bevy_lint/src/lints/restriction/panicking_methods.rs
+++ b/bevy_lint/src/lints/restriction/panicking_methods.rs
@@ -64,12 +64,12 @@ use rustc_span::Symbol;
 
 declare_bevy_lint! {
     pub PANICKING_METHODS,
-    super::RESTRICTION,
+    super::Restriction,
     "called a method that can panic when a non-panicking alternative exists",
 }
 
 declare_bevy_lint_pass! {
-    pub PanickingMethods => [PANICKING_METHODS.lint],
+    pub PanickingMethods => [PANICKING_METHODS],
 }
 
 impl<'tcx> LateLintPass<'tcx> for PanickingMethods {
@@ -191,7 +191,7 @@ impl<'tcx> LateLintPass<'tcx> for PanickingMethods {
 
             span_lint_and_help(
                 cx,
-                PANICKING_METHODS.lint,
+                PANICKING_METHODS,
                 span,
                 format!(
                     "called a `{}` method that can panic when a non-panicking alternative exists",

--- a/bevy_lint/src/lints/style/mod.rs
+++ b/bevy_lint/src/lints/style/mod.rs
@@ -4,13 +4,22 @@
 //!
 //! These lints are **warn** by default.
 
-use rustc_lint::Level;
+use rustc_lint::{Level, Lint, LintStore};
 
 use crate::lint::LintGroup;
 
 pub mod plugin_not_ending_in_plugin;
 
-pub(crate) static STYLE: &LintGroup = &LintGroup {
-    name: "bevy::style",
-    level: Level::Warn,
-};
+pub(crate) struct Style;
+
+impl LintGroup for Style {
+    const NAME: &str = "bevy::style";
+    const LEVEL: Level = Level::Warn;
+    const LINTS: &[&Lint] = &[plugin_not_ending_in_plugin::PLUGIN_NOT_ENDING_IN_PLUGIN];
+
+    fn register_passes(store: &mut LintStore) {
+        store.register_late_pass(|_| {
+            Box::new(plugin_not_ending_in_plugin::PluginNotEndingInPlugin::default())
+        });
+    }
+}

--- a/bevy_lint/src/lints/style/plugin_not_ending_in_plugin.rs
+++ b/bevy_lint/src/lints/style/plugin_not_ending_in_plugin.rs
@@ -46,12 +46,12 @@ use rustc_span::symbol::Ident;
 
 declare_bevy_lint! {
     pub PLUGIN_NOT_ENDING_IN_PLUGIN,
-    super::STYLE,
+    super::Style,
     "implemented `Plugin` for a structure whose name does not end in \"Plugin\"",
 }
 
 declare_bevy_lint_pass! {
-    pub PluginNotEndingInPlugin => [PLUGIN_NOT_ENDING_IN_PLUGIN.lint],
+    pub PluginNotEndingInPlugin => [PLUGIN_NOT_ENDING_IN_PLUGIN],
 }
 
 impl<'tcx> LateLintPass<'tcx> for PluginNotEndingInPlugin {
@@ -121,10 +121,10 @@ impl<'tcx> LateLintPass<'tcx> for PluginNotEndingInPlugin {
 
             span_lint_hir_and_then(
                 cx,
-                PLUGIN_NOT_ENDING_IN_PLUGIN.lint,
+                PLUGIN_NOT_ENDING_IN_PLUGIN,
                 struct_hir_id,
                 struct_span,
-                PLUGIN_NOT_ENDING_IN_PLUGIN.lint.desc,
+                PLUGIN_NOT_ENDING_IN_PLUGIN.desc,
                 |diag| {
                     diag.span_suggestion(
                         struct_span,

--- a/bevy_lint/src/lints/suspicious/insert_event_resource.rs
+++ b/bevy_lint/src/lints/suspicious/insert_event_resource.rs
@@ -58,12 +58,12 @@ use std::borrow::Cow;
 
 declare_bevy_lint! {
     pub INSERT_EVENT_RESOURCE,
-    super::SUSPICIOUS,
+    super::Suspicious,
     "called `App::insert_resource(Events<T>)` or `App::init_resource::<Events<T>>()` instead of `App::add_event::<T>()`",
 }
 
 declare_bevy_lint_pass! {
-    pub InsertEventResource => [INSERT_EVENT_RESOURCE.lint],
+    pub InsertEventResource => [INSERT_EVENT_RESOURCE],
     @default = {
         insert_resource: Symbol = sym!(insert_resource),
         init_resource: Symbol = sym!(init_resource),
@@ -130,7 +130,7 @@ fn check_insert_resource(cx: &LateContext<'_>, method_call: &MethodCall) {
             let receiver_snippet = snippet(cx, method_call.receiver.span, "");
             span_lint_and_sugg(
                 cx,
-                INSERT_EVENT_RESOURCE.lint,
+                INSERT_EVENT_RESOURCE,
                 method_call.span,
                 format!(
                     "called `App::insert_resource{generics_snippet}({receiver_snippet}, {args_snippet})` instead of `App::add_event::<{event_ty_snippet}>({receiver_snippet})`"
@@ -142,7 +142,7 @@ fn check_insert_resource(cx: &LateContext<'_>, method_call: &MethodCall) {
         } else {
             span_lint_and_sugg(
                 cx,
-                INSERT_EVENT_RESOURCE.lint,
+                INSERT_EVENT_RESOURCE,
                 method_call.span,
                 format!(
                     "called `App::insert_resource{generics_snippet}({args_snippet})` instead of `App::add_event::<{event_ty_snippet}>()`"
@@ -210,7 +210,7 @@ fn check_init_resource<'tcx>(cx: &LateContext<'tcx>, method_call: &MethodCall<'t
                 let receiver_snippet = snippet(cx, method_call.receiver.span, "");
                 span_lint_and_sugg(
                     cx,
-                    INSERT_EVENT_RESOURCE.lint,
+                    INSERT_EVENT_RESOURCE,
                     method_call.span,
                     format!(
                         "called `App::init_resource{generics_snippet}({receiver_snippet})` instead of `App::add_event::<{event_ty_snippet}>({receiver_snippet})`"
@@ -222,7 +222,7 @@ fn check_init_resource<'tcx>(cx: &LateContext<'tcx>, method_call: &MethodCall<'t
             } else {
                 span_lint_and_sugg(
                     cx,
-                    INSERT_EVENT_RESOURCE.lint,
+                    INSERT_EVENT_RESOURCE,
                     method_call.span,
                     format!(
                         "called `App::init_resource{generics_snippet}({args_snippet})` instead of `App::add_event::<{event_ty_snippet}>()`"

--- a/bevy_lint/src/lints/suspicious/insert_unit_bundle.rs
+++ b/bevy_lint/src/lints/suspicious/insert_unit_bundle.rs
@@ -61,12 +61,12 @@ use crate::{declare_bevy_lint, declare_bevy_lint_pass, utils::hir_parse::MethodC
 
 declare_bevy_lint! {
     pub INSERT_UNIT_BUNDLE,
-    super::SUSPICIOUS,
+    super::Suspicious,
     "inserted a `Bundle` containing a unit `()` type",
 }
 
 declare_bevy_lint_pass! {
-    pub InsertUnitBundle => [INSERT_UNIT_BUNDLE.lint],
+    pub InsertUnitBundle => [INSERT_UNIT_BUNDLE],
     @default = {
         spawn: Symbol = sym!(spawn),
     },
@@ -109,10 +109,10 @@ impl<'tcx> LateLintPass<'tcx> for InsertUnitBundle {
         if bundle_ty.is_unit() {
             span_lint_hir_and_then(
                 cx,
-                INSERT_UNIT_BUNDLE.lint,
+                INSERT_UNIT_BUNDLE,
                 bundle_expr.hir_id,
                 bundle_expr.span,
-                INSERT_UNIT_BUNDLE.lint.desc,
+                INSERT_UNIT_BUNDLE.desc,
                 |diag| {
                     diag.note("unit `()` types are skipped instead of spawned")
                         .span_suggestion(
@@ -136,10 +136,10 @@ impl<'tcx> LateLintPass<'tcx> for InsertUnitBundle {
 
             span_lint_hir_and_then(
                 cx,
-                INSERT_UNIT_BUNDLE.lint,
+                INSERT_UNIT_BUNDLE,
                 expr.hir_id,
                 expr.span,
-                INSERT_UNIT_BUNDLE.lint.desc,
+                INSERT_UNIT_BUNDLE.desc,
                 |diag| {
                     diag.note("unit `()` types are skipped instead of spawned");
                 },

--- a/bevy_lint/src/lints/suspicious/iter_current_update_events.rs
+++ b/bevy_lint/src/lints/suspicious/iter_current_update_events.rs
@@ -47,12 +47,12 @@ use crate::{declare_bevy_lint, declare_bevy_lint_pass, utils::hir_parse::MethodC
 
 declare_bevy_lint! {
     pub ITER_CURRENT_UPDATE_EVENTS,
-    super::SUSPICIOUS,
+    super::Suspicious,
     "called `Events::<T>::iter_current_update_events()`",
 }
 
 declare_bevy_lint_pass! {
-    pub IterCurrentUpdateEvents => [ITER_CURRENT_UPDATE_EVENTS.lint],
+    pub IterCurrentUpdateEvents => [ITER_CURRENT_UPDATE_EVENTS],
 
     @default = {
         iter_current_update_events: Symbol = Symbol::intern("iter_current_update_events"),
@@ -94,9 +94,9 @@ impl<'tcx> LateLintPass<'tcx> for IterCurrentUpdateEvents {
             if method_call.method_path.ident.name == self.iter_current_update_events {
                 span_lint_and_help(
                     cx,
-                    ITER_CURRENT_UPDATE_EVENTS.lint,
+                    ITER_CURRENT_UPDATE_EVENTS,
                     method_call.span,
-                    ITER_CURRENT_UPDATE_EVENTS.lint.desc,
+                    ITER_CURRENT_UPDATE_EVENTS.desc,
                     None,
                     "`iter_current_update_events()` does not track which events have already been seen, consider using `EventReader<T>` instead",
                 );

--- a/bevy_lint/src/lints/suspicious/mod.rs
+++ b/bevy_lint/src/lints/suspicious/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! These lints are **warn** by default.
 
-use rustc_lint::Level;
+use rustc_lint::{Level, Lint, LintStore};
 
 use crate::lint::LintGroup;
 
@@ -13,7 +13,24 @@ pub mod insert_event_resource;
 pub mod insert_unit_bundle;
 pub mod iter_current_update_events;
 
-pub(crate) static SUSPICIOUS: &LintGroup = &LintGroup {
-    name: "bevy::suspicious",
-    level: Level::Warn,
-};
+pub(crate) struct Suspicious;
+
+impl LintGroup for Suspicious {
+    const NAME: &str = "bevy::suspicious";
+    const LEVEL: Level = Level::Warn;
+    const LINTS: &[&Lint] = &[
+        insert_event_resource::INSERT_EVENT_RESOURCE,
+        insert_unit_bundle::INSERT_UNIT_BUNDLE,
+        iter_current_update_events::ITER_CURRENT_UPDATE_EVENTS,
+    ];
+
+    fn register_passes(store: &mut LintStore) {
+        store.register_late_pass(|_| {
+            Box::new(insert_event_resource::InsertEventResource::default())
+        });
+        store.register_late_pass(|_| Box::new(insert_unit_bundle::InsertUnitBundle::default()));
+        store.register_late_pass(|_| {
+            Box::new(iter_current_update_events::IterCurrentUpdateEvents::default())
+        });
+    }
+}


### PR DESCRIPTION
This removes the concept of `BevyLint`, and makes each lint group responsible for registering its lints.