### PR TITLE
Allow custom headers for web dev server

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod build;
 pub mod external_cli;
 pub mod lint;
+mod memory;
 pub mod run;
 pub mod template;
 #[cfg(feature = "web")]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,11 @@
+//! Utils for memory management.
+
+/// Create a static reference by leaking the memory.
+///
+/// # Performance
+///
+/// Be careful with using this function in order to not exhaust the system's memory.
+/// It should only be used when the string is expected to live until the end of the program anyway.
+pub(crate) fn leak_to_static(s: &str) -> &'static str {
+    Box::leak(s.to_owned().into_boxed_str())
+}

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -58,9 +58,15 @@ pub struct RunWebArgs {
     #[arg(short = 'o', long = "open", action = ArgAction::SetTrue, default_value_t = false)]
     pub open: bool,
 
-    // Bundle all web artifacts into a single folder.
+    /// Bundle all web artifacts into a single folder.
     #[arg(short = 'b', long = "bundle", action = ArgAction::SetTrue, default_value_t = false)]
     pub create_packed_bundle: bool,
+
+    /// Header to add to the web-server responses, in the format `name:value` or `name=value`.
+    ///
+    /// Can be defined multiple times to add multiple headers.
+    #[clap(long = "header", value_name = "HEADER")]
+    pub headers: Vec<String>,
 }
 
 impl From<RunArgs> for BuildArgs {

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -62,10 +62,10 @@ pub struct RunWebArgs {
     #[arg(short = 'b', long = "bundle", action = ArgAction::SetTrue, default_value_t = false)]
     pub create_packed_bundle: bool,
 
-    /// Header to add to the web-server responses, in the format `name:value` or `name=value`.
+    /// Headers to add to the web-server responses, in the format `name:value` or `name=value`.
     ///
     /// Can be defined multiple times to add multiple headers.
-    #[clap(long = "header", value_name = "HEADER")]
+    #[clap(short = 'H', long = "headers", value_name = "HEADERS")]
     pub headers: Vec<String>,
 }
 

--- a/src/web/run.rs
+++ b/src/web/run.rs
@@ -1,8 +1,11 @@
+use anyhow::Context as _;
+use http::{HeaderMap, HeaderValue};
 use tracing::{error, info};
 
 use crate::{
     build::args::BuildArgs,
     external_cli::cargo,
+    memory::leak_to_static,
     run::{RunArgs, args::RunSubcommands},
 };
 
@@ -15,6 +18,8 @@ pub(crate) fn run_web(args: &RunArgs) -> anyhow::Result<()> {
     let Some(RunSubcommands::Web(web_args)) = &args.subcommand else {
         anyhow::bail!("tried to run on the web without corresponding args");
     };
+
+    let header_map = parse_headers(&web_args.headers)?;
 
     let mut build_args: BuildArgs = args.clone().into();
 
@@ -55,7 +60,30 @@ pub(crate) fn run_web(args: &RunArgs) -> anyhow::Result<()> {
         info!("Open your app at <{url}>!");
     }
 
-    serve(web_bundle, port)?;
+    serve(web_bundle, port, header_map)?;
 
     Ok(())
+}
+
+fn parse_headers(headers: &[String]) -> anyhow::Result<HeaderMap> {
+    let mut header_map = HeaderMap::with_capacity(headers.len());
+
+    for header in headers {
+        let (key, value) = header
+            .split_once(':')
+            .or(header.split_once('='))
+            .ok_or_else(|| {
+                anyhow::anyhow!("headers must separate name and value with ':' or '='")
+            })?;
+
+        header_map.insert(
+            // PERF: Leaking is necessary here to satisfy lifetime rules.
+            // The memory cost is bounded by the number of headers, which is expected to be low.
+            // In any case, the headers are needed until the termination of the program.
+            leak_to_static(key),
+            HeaderValue::from_str(value).context("invalid header value")?,
+        );
+    }
+
+    Ok(header_map)
 }

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -47,7 +47,7 @@ pub(crate) async fn serve(
 
     let mut router = Router::new();
 
-    dbg!(&header_map);
+    tracing::debug!("Adding response headers {header_map:?}");
 
     match web_bundle.clone() {
         WebBundle::Packed(PackedBundle { path }) => {


### PR DESCRIPTION
# Objective

Closes #233.

For some use-cases, such as [using multi-threading in Wasm](https://github.com/bevyengine/bevy/issues/4078#issuecomment-2030735387), you need to add custom response headers to the web server.
We need to provide an option for the user to set them.

# Solution

Add a CLI argument `--headers`/`-H` to define custom headers. It can be provided multiple times to add multiple headers.
For example:
```
bevy-dev run --no-default-features web -H Cross-Origin-Opener-Policy='same-origin' -H Cross-Origin-Embedder-Policy='require-corp' -H X-My-Header:awesome --verbose
```
will add the following headers:
```
cross-origin-opener-policy: same-origin
cross-origin-embedder-policy: require-corp
x-my-header: awesome
```
(the first two being required for multi-threading in Wasm)

A middleware layer is used to inject the headers into the responses.

# Testing

- Install this version of the CLI:
    ```
    cargo install --git https://github.com/TheBevyFlock/bevy_cli --branch 233-allow-custom-headers-for-web-server --locked bevy_cli
    ```
- Go into a Bevy app of your choice and run a command like this:
    ```
    bevy-dev run --no-default-features web -H Cross-Origin-Opener-Policy='same-origin' -H Cross-Origin-Embedder-Policy='require-corp' -H X-My-Header:awesome --verbose
    ```
- Open the served app in your browser, open the dev tools, go to the network tab and ensure that the headers are added to the responses