### PR TITLE
Add support for unstable cargo flags

### DIFF
--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -161,10 +161,16 @@ pub struct CargoCommonArgs {
     /// This flag may be specified multiple times.
     #[clap(long = "config", value_name = "KEY=VALUE|PATH")]
     pub config: Vec<String>,
+
+    /// Unstable (nightly-only) flags to Cargo, see `cargo -Z help` for details.
+    #[clap(short = 'Z', value_name = "FLAG")]
+    pub unstable_flags: Vec<String>,
 }
 
 impl CargoCommonArgs {
     pub(crate) fn args_builder(&self) -> ArgBuilder {
-        ArgBuilder::new().add_values_separately("--config", self.config.iter())
+        ArgBuilder::new()
+            .add_values_separately("--config", self.config.iter())
+            .add_values_separately("-Z", self.unstable_flags.iter())
     }
 }


### PR DESCRIPTION
# Objective

Closes #348.
Prerequisite for multi-threading support (#226).

# Solution

Forward the `-Z` flags to `cargo`.

# Testing

1. Ensure you are using a nightly version of `cargo` (e.g. via `rustup override set nightly`).
2. Install the CLI from this branch.
3. Try `bevy build -Z help --verbose`: You should see that the `-Z` flag is passed to cargo and see a list of unstable flags that cargo provides. Thus, the flag was forwarded correctly.
4. You can also try `bevy run -Z build-std=std,panic_abort web --verbose` which is what we'll need for multi-threading. It should compile, but not sure if you can see a visual difference (I didn't see any)