### PR TITLE
Make web target configurable

### DIFF
--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -56,6 +56,9 @@ impl BuildArgs {
     /// CLI arguments take precedence.
     pub(crate) fn apply_config(&mut self, config: &CliConfig) {
         tracing::debug!("Using config {config:?}");
+        if self.cargo_args.compilation_args.target.is_none() {
+            self.cargo_args.compilation_args.target = config.target().map(ToOwned::to_owned);
+        }
         self.cargo_args
             .feature_args
             .features

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use crate::external_cli::cargo::metadata::{Metadata, Package};
 
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct CliConfig {
+    /// The platform to target with the build.
+    target: Option<String>,
     /// Additional features that should be enabled.
     features: Vec<String>,
     /// Whether to use default features.
@@ -12,6 +14,11 @@ pub struct CliConfig {
 }
 
 impl CliConfig {
+    /// The platform to target with the build.
+    pub fn target(&self) -> Option<&str> {
+        self.target.as_deref()
+    }
+
     /// Whether to enable default features.
     ///
     /// Defaults to `true` if not configured otherwise.
@@ -96,6 +103,7 @@ impl CliConfig {
         };
 
         Ok(Self {
+            target: extract_target(metadata)?,
             features: extract_features(metadata)?,
             default_features: extract_default_features(metadata)?,
         })
@@ -106,11 +114,25 @@ impl CliConfig {
     /// The other config takes precedence,
     /// it's values overwrite the current values if one has to be chosen.
     pub fn overwrite(mut self, with: &Self) -> Self {
+        self.target = with.target.clone().or(self.target);
         self.default_features = with.default_features.or(self.default_features);
         // Features are additive
         self.features.extend(with.features.iter().cloned());
 
         self
+    }
+}
+
+/// Try to extract the target platform from a metadata map for the CLI.
+fn extract_target(cli_metadata: &Map<String, Value>) -> anyhow::Result<Option<String>> {
+    let Some(target) = cli_metadata.get("target") else {
+        return Ok(None);
+    };
+
+    match target {
+        Value::String(target) => Ok(Some(target).cloned()),
+        Value::Null => Ok(None),
+        _ => bail!("target must be a string"),
     }
 }
 
@@ -176,6 +198,7 @@ mod tests {
             assert_eq!(
                 CliConfig::merged_from_metadata(Some(&metadata), true, false)?,
                 CliConfig {
+                    target: None,
                     features: vec![
                         "base".to_owned(),
                         "dev".to_owned(),
@@ -207,6 +230,7 @@ mod tests {
             assert_eq!(
                 CliConfig::merged_from_metadata(Some(&metadata), false, true)?,
                 CliConfig {
+                    target: None,
                     features: vec![
                         "base".to_owned(),
                         "release".to_owned(),
@@ -250,11 +274,43 @@ mod tests {
             assert_eq!(
                 CliConfig::merged_from_metadata(Some(&metadata), false, true)?,
                 CliConfig {
+                    target: None,
                     features: vec!["base".to_owned(),],
                     default_features: None,
                 }
             );
             Ok(())
+        }
+    }
+
+    mod extract_target {
+        use serde_json::Map;
+
+        use super::*;
+
+        #[test]
+        fn should_return_none_if_no_target_specified() -> anyhow::Result<()> {
+            let cli_metadata = Map::new();
+            assert_eq!(extract_target(&cli_metadata)?, None);
+            Ok(())
+        }
+
+        #[test]
+        fn should_return_target_if_specified() -> anyhow::Result<()> {
+            let mut cli_metadata = Map::new();
+            cli_metadata.insert("target".to_owned(), "wasm32v1-none".into());
+            assert_eq!(
+                extract_target(&cli_metadata)?,
+                Some("wasm32v1-none".to_string())
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn should_return_error_if_target_is_not_a_string() {
+            let mut cli_metadata = Map::new();
+            cli_metadata.insert("target".to_string(), 32.into());
+            assert!(extract_target(&cli_metadata).is_err());
         }
     }
 

--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -91,27 +91,26 @@ impl CargoCompilationArgs {
         }
     }
 
+    /// The platform to target with the build.
+    ///
+    /// On web, defaults to `wasm32-unknown-unknown`.
     pub(crate) fn target(&self, is_web: bool) -> Option<String> {
         if is_web {
-            Some("wasm32-unknown-unknown".to_string())
+            self.target
+                .clone()
+                // Default to `wasm32-unknown-unknown`
+                .or_else(|| Some("wasm32-unknown-unknown".to_string()))
         } else {
             self.target.clone()
         }
     }
 
     pub(crate) fn args_builder(&self, is_web: bool) -> ArgBuilder {
-        // web takes precedence over --target <TRIPLE>
-        let target = if is_web {
-            Some("wasm32-unknown-unknown".to_string())
-        } else {
-            self.target.clone()
-        };
-
         ArgBuilder::new()
             .add_with_value("--profile", self.profile(is_web))
             .add_opt_value("--jobs", &self.jobs.map(|jobs| jobs.to_string()))
             .add_flag_if("--keep-going", self.is_keep_going)
-            .add_opt_value("--target", &target)
+            .add_opt_value("--target", &self.target(is_web))
             .add_opt_value("--target-dir", &self.target_dir)
     }
 }

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -61,6 +61,9 @@ impl RunArgs {
     /// CLI arguments take precedence.
     pub(crate) fn apply_config(&mut self, config: &CliConfig) {
         tracing::debug!("Using config {config:?}");
+        if self.cargo_args.compilation_args.target.is_none() {
+            self.cargo_args.compilation_args.target = config.target().map(ToOwned::to_owned);
+        }
         self.cargo_args
             .feature_args
             .features


### PR DESCRIPTION
# Objective

Closes 225.

On web builds we use the `wasm32-unknown-unknown` target, but that might not be the best target to use for all use-cases.
In particular, it can randomly break browser support on Rust updates as more Wasm features get enabled.

Instead, the `wasm32v1-none` target can be used, which targets a specific spec and uses `no_std` (instead of a stubbed, half-baked `std` version).

However, the `--target` flag currently doesn't work when using `web` commands.
It would also be nice to configure it in the Config so you don't have to set it manually every time.

# Solution

- Only fall back to `wasm32-unknown-unknown` when no `--target` flag was provided
- Allow configuring the default target in `Cargo.toml`

# Testing

- Install the CLI from this branch:
    ```
    cargo install --git https://github.com/TheBevyFlock/bevy_cli --branch 225-configurable-web-target --locked bevy_cli
    ```
- In a Bevy project of your choice, run `bevy build --target=wasm32v1-none web --verbose`. The build will likely fail due to missing `no_std` support, but you should see the target flag passed on to the `cargo` command.
- In the `Cargo.toml`, add the following:
    ```
    [package.metadata.bevy_cli.web]
    target = "wasm32v1-none"
    ```
    Then run `bevy build web --verbose`. Again, the target should be passed to the `cargo` command.