### PR TITLE
Optimistic command execution

### DIFF
--- a/src/bin_target.rs
+++ b/src/bin_target.rs
@@ -38,11 +38,19 @@ pub(crate) fn select_run_binary<'p>(
         let package = metadata
             .packages
             .iter()
-            .find(|package| package.name == *package_name)
+            .find(|package| {
+                // Only consider packages in the current workspace and with the correct name
+                metadata.workspace_members.contains(&package.id) && package.name == *package_name
+            })
             .ok_or_else(|| anyhow::anyhow!("Failed to find package {package_name}"))?;
         vec![package]
     } else {
-        metadata.packages.iter().collect()
+        metadata
+            .packages
+            .iter()
+            // Only consider packages in the current workspace
+            .filter(|package| metadata.workspace_members.contains(&package.id))
+            .collect()
     };
 
     let mut is_example = false;

--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -2,7 +2,10 @@ use clap::{ArgAction, Args, Subcommand};
 
 use crate::{
     config::CliConfig,
-    external_cli::{arg_builder::ArgBuilder, cargo::build::CargoBuildArgs},
+    external_cli::{
+        arg_builder::ArgBuilder,
+        cargo::{build::CargoBuildArgs, install::AutoInstall},
+    },
 };
 
 #[derive(Debug, Args)]
@@ -13,7 +16,7 @@ pub struct BuildArgs {
 
     /// Confirm all prompts automatically.
     #[arg(long = "yes", default_value_t = false)]
-    pub skip_prompts: bool,
+    pub confirm_prompts: bool,
 
     /// Arguments to forward to `cargo build`.
     #[clap(flatten)]
@@ -21,6 +24,15 @@ pub struct BuildArgs {
 }
 
 impl BuildArgs {
+    /// Whether to automatically install missing dependencies.
+    pub(crate) fn auto_install(&self) -> AutoInstall {
+        if self.confirm_prompts {
+            AutoInstall::Always
+        } else {
+            AutoInstall::AskUser
+        }
+    }
+
     /// Determine if the app is being built for the web.
     #[cfg(feature = "web")]
     pub(crate) fn is_web(&self) -> bool {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -7,7 +7,7 @@ use crate::{bin_target::select_run_binary, config::CliConfig, external_cli::carg
 pub mod args;
 
 pub fn build(args: &mut BuildArgs) -> anyhow::Result<()> {
-    let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
+    let metadata = cargo::metadata::metadata()?;
 
     let bin_target = select_run_binary(
         &metadata,
@@ -28,7 +28,9 @@ pub fn build(args: &mut BuildArgs) -> anyhow::Result<()> {
     }
 
     let cargo_args = args.cargo_args_builder();
-    cargo::build::command().args(cargo_args).ensure_status()?;
+    cargo::build::command()
+        .args(cargo_args)
+        .ensure_status(args.auto_install())?;
 
     Ok(())
 }

--- a/src/external_cli/cargo/install.rs
+++ b/src/external_cli/cargo/install.rs
@@ -35,7 +35,7 @@ impl AutoInstall {
 pub fn is_installed<P: AsRef<OsStr>>(program: P) -> Option<Vec<u8>> {
     CommandExt::new(program)
         .arg("--version")
-        .output()
+        .output(AutoInstall::Never)
         .map(|output| output.stdout)
         .ok()
 }
@@ -89,7 +89,7 @@ pub(crate) fn if_needed<Pr: AsRef<OsStr>, Pa: AsRef<OsStr>>(
         cmd.arg("--version").arg(package_version.to_string());
     }
 
-    cmd.ensure_status()?;
+    cmd.ensure_status(auto_install)?;
 
     Ok(true)
 }

--- a/src/external_cli/cargo/install.rs
+++ b/src/external_cli/cargo/install.rs
@@ -11,13 +11,20 @@ use crate::external_cli::CommandExt;
 pub enum AutoInstall {
     /// Show a prompt to the user and ask them first before installing.
     AskUser,
-    /// Always perform installation, without asking the user.
+    /// Always perform installation and don't show a prompt to the user.
     Always,
-    /// Never perform installation, without asking the user.
+    /// Never perform installation and don't show a prompt to the user.
     Never,
 }
 
 impl AutoInstall {
+    /// Confirm the installation with the auto install preferences.
+    ///
+    /// The given prompt is used when the user should be asked before installing.
+    ///
+    /// Returns `true` if the installation should be performed and `false` if not.
+    /// An error is returned when an interactive prompt cannot be shown,
+    /// e.g. when used in a non-interactive shell.
     pub fn confirm<S: Into<String>>(&self, prompt: S) -> anyhow::Result<bool> {
         match self {
             AutoInstall::AskUser => Confirm::new().with_prompt(prompt).interact().context(

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -8,7 +8,7 @@ use tracing::Level;
 
 use crate::external_cli::CommandExt;
 
-use super::program;
+use super::{install::AutoInstall, program};
 
 /// Create a command to run `cargo metadata`.
 pub(crate) fn command() -> CommandExt {
@@ -34,7 +34,7 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let output = command().args(additional_args).output()?;
+    let output = command().args(additional_args).output(AutoInstall::Never)?;
     let metadata = serde_json::from_slice(&output.stdout)
         .context("Failed to parse `cargo metadata` output")?;
     Ok(metadata)

--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -5,7 +5,6 @@ use clap::{ArgAction, Args};
 use super::arg_builder::ArgBuilder;
 
 pub(crate) mod build;
-#[cfg(feature = "web")]
 pub(crate) mod install;
 pub(crate) mod metadata;
 pub(crate) mod run;

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -46,7 +46,7 @@ impl CommandExt {
     }
 
     /// Define the package that allows installation of the program.
-    pub fn with_package<S: AsRef<OsStr>>(&mut self, name: S, version: VersionReq) -> &mut Self {
+    pub fn require_package<S: AsRef<OsStr>>(&mut self, name: S, version: VersionReq) -> &mut Self {
         self.package = Some(Package {
             name: name.as_ref().to_owned(),
             version,

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -92,6 +92,7 @@ impl CommandExt {
     ///
     /// This requires the `rustup` feature to be enabled, otherwise it's a noop.
     fn install_target_if_needed(&self) -> anyhow::Result<bool> {
+        #[cfg(feature = "rustup")]
         if let Some(target) = &self.target {
             rustup::install_target_if_needed(
                 target,
@@ -101,6 +102,9 @@ impl CommandExt {
         } else {
             Ok(false)
         }
+
+        #[cfg(not(feature = "rustup"))]
+        Ok(false)
     }
 
     /// Try to fix erroneous configuration before retrying the command.

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -53,6 +53,22 @@ impl CommandExt {
         self
     }
 
+    /// Check if the correct version of the program is installed and install if needed.
+    ///
+    /// The user will be prompted before the installation begins.
+    fn install_if_needed(&self, skip_prompts: bool) -> anyhow::Result<()> {
+        if let Some(package) = &self.package {
+            cargo::install::if_needed(
+                self.inner.get_program(),
+                &package.name,
+                &package.version,
+                skip_prompts,
+            )?;
+        }
+
+        Ok(())
+    }
+
     /// Add an argument to the program.
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
         self.inner.arg(arg.as_ref());

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -64,8 +64,12 @@ impl CommandExt {
     ///
     /// If the command fails and the target is missing,
     /// it can be installed automatically via `rustup`.
-    pub fn require_target<S: AsRef<OsStr>>(&mut self, target: S) -> &mut Self {
-        self.target = Some(target.as_ref().to_owned());
+    pub fn maybe_require_target<S: AsRef<OsStr>>(&mut self, target: Option<S>) -> &mut Self {
+        if let Some(target) = target {
+            self.target = Some(target.as_ref().to_owned());
+        } else {
+            self.target = None;
+        }
         self
     }
 

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -6,6 +6,7 @@ use std::{
     process::{Command, ExitStatus, Output},
 };
 
+use cargo::install::AutoInstall;
 use semver::VersionReq;
 use tracing::{Level, debug, error, info, trace, warn};
 
@@ -65,7 +66,7 @@ impl CommandExt {
                 &package.name,
                 &package.version,
                 // FIXME: Configure
-                false,
+                AutoInstall::Never,
             )
         } else {
             Ok(false)

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -116,6 +116,13 @@ impl CommandExt {
     fn try_fix_before_retry(&self, auto_install: AutoInstall) -> anyhow::Result<bool> {
         let mut retry = false;
 
+        if self.package.is_some() || self.target.is_some() {
+            tracing::warn!(
+                "Failed to run {}, trying to find automatic fix...",
+                self.inner.get_program().to_string_lossy()
+            )
+        }
+
         if self.install_package_if_needed(auto_install)? {
             retry = true;
         }

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -22,7 +22,7 @@ fn is_target_installed(target: &str) -> bool {
     let output = CommandExt::new(program())
         .arg("target")
         .arg("list")
-        .output();
+        .output(AutoInstall::Never);
 
     // Check if the target list has an entry like this:
     // <target_triple> (installed)
@@ -64,7 +64,7 @@ pub(crate) fn install_target_if_needed<T: AsRef<OsStr>>(
         .arg("target")
         .arg("add")
         .arg(target)
-        .ensure_status()
+        .ensure_status(auto_install)
         .context(format!("failed to install target `{target_str}`"))?;
 
     Ok(true)

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -2,13 +2,21 @@ use semver::{Comparator, Version, VersionReq};
 
 use crate::bin_target::BinTarget;
 
-use super::{CommandExt, arg_builder::ArgBuilder, cargo::metadata::Metadata};
+use super::{
+    CommandExt,
+    arg_builder::ArgBuilder,
+    cargo::{install::AutoInstall, metadata::Metadata},
+};
 
 pub(crate) const PACKAGE: &str = "wasm-bindgen-cli";
 pub(crate) const PROGRAM: &str = "wasm-bindgen";
 
 /// Bundle the Wasm build for the web.
-pub(crate) fn bundle(metadata: &Metadata, bin_target: &BinTarget) -> anyhow::Result<()> {
+pub(crate) fn bundle(
+    metadata: &Metadata,
+    bin_target: &BinTarget,
+    auto_install: AutoInstall,
+) -> anyhow::Result<()> {
     let original_wasm = bin_target
         .artifact_directory
         .clone()
@@ -49,7 +57,7 @@ pub(crate) fn bundle(metadata: &Metadata, bin_target: &BinTarget) -> anyhow::Res
                 .add_with_value("--target", "web")
                 .arg(original_wasm.to_string_lossy()),
         )
-        .ensure_status()?;
+        .ensure_status(auto_install)?;
 
     Ok(())
 }

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -1,18 +1,46 @@
+use semver::{Comparator, Version, VersionReq};
+
 use crate::bin_target::BinTarget;
 
-use super::{CommandExt, arg_builder::ArgBuilder};
+use super::{CommandExt, arg_builder::ArgBuilder, cargo::metadata::Metadata};
 
 pub(crate) const PACKAGE: &str = "wasm-bindgen-cli";
 pub(crate) const PROGRAM: &str = "wasm-bindgen";
 
 /// Bundle the Wasm build for the web.
-pub(crate) fn bundle(bin_target: &BinTarget) -> anyhow::Result<()> {
+pub(crate) fn bundle(metadata: &Metadata, bin_target: &BinTarget) -> anyhow::Result<()> {
     let original_wasm = bin_target
         .artifact_directory
         .clone()
         .join(format!("{}.wasm", bin_target.bin_name));
 
+    let Version {
+        major,
+        minor,
+        patch,
+        pre,
+        build: _,
+    } = metadata
+        .packages
+        .iter()
+        .find(|package| package.name == "wasm-bindgen")
+        .map(|package| package.version.clone())
+        .ok_or_else(|| anyhow::anyhow!("Failed to find wasm-bindgen"))?;
+
     CommandExt::new(PROGRAM)
+        .require_package(
+            PACKAGE,
+            VersionReq {
+                comparators: vec![Comparator {
+                    // The wasm-bindgen versions need to match exactly
+                    op: semver::Op::Exact,
+                    major,
+                    minor: Some(minor),
+                    patch: Some(patch),
+                    pre,
+                }],
+            },
+        )
         .args(
             ArgBuilder::new()
                 .arg("--no-typescript")

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -1,6 +1,3 @@
-use semver::Version;
-use std::str::FromStr;
-
 use crate::bin_target::BinTarget;
 
 use super::{CommandExt, arg_builder::ArgBuilder};
@@ -27,20 +24,4 @@ pub(crate) fn bundle(bin_target: &BinTarget) -> anyhow::Result<()> {
         .ensure_status()?;
 
     Ok(())
-}
-
-/// Transforms the output from `wasm-bindgen --version` into a [Version].
-pub(crate) fn wasm_bindgen_cli_version(stdout: &[u8]) -> anyhow::Result<Version> {
-    let stdout = String::from_utf8_lossy(stdout);
-    // Example stdout from `wasm-bindgen --version`: wasm-bindgen 0.2.99
-    stdout
-        .split_whitespace()
-        .nth(1)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "unexpected output format: {}, expected format to be: `wasm-bindgen <version>`",
-                stdout
-            )
-        })
-        .and_then(|version| Version::from_str(version).map_err(|e| anyhow::anyhow!(e)))
 }

--- a/src/external_cli/wasm_opt.rs
+++ b/src/external_cli/wasm_opt.rs
@@ -3,13 +3,19 @@ use std::{fs, time::Instant};
 use semver::VersionReq;
 use tracing::info;
 
-use crate::{bin_target::BinTarget, external_cli::CommandExt};
+use crate::{
+    bin_target::BinTarget,
+    external_cli::{CommandExt, cargo::install::AutoInstall},
+};
 
 pub(crate) const PACKAGE: &str = "wasm-opt";
 pub(crate) const PROGRAM: &str = "wasm-opt";
 
 /// Optimize the Wasm binary at the given path with wasm-opt.
-pub(crate) fn optimize_path(bin_target: &BinTarget) -> anyhow::Result<()> {
+pub(crate) fn optimize_path(
+    bin_target: &BinTarget,
+    auto_install: AutoInstall,
+) -> anyhow::Result<()> {
     let path = bin_target
         .artifact_directory
         .clone()
@@ -26,7 +32,7 @@ pub(crate) fn optimize_path(bin_target: &BinTarget) -> anyhow::Result<()> {
         .arg("-o")
         .arg(&path)
         .arg(&path)
-        .ensure_status()?;
+        .ensure_status(auto_install)?;
 
     let size_after = fs::metadata(path)?.len();
     let size_reduction = 1. - (size_after as f32) / (size_before as f32);

--- a/src/external_cli/wasm_opt.rs
+++ b/src/external_cli/wasm_opt.rs
@@ -1,5 +1,6 @@
 use std::{fs, time::Instant};
 
+use semver::VersionReq;
 use tracing::info;
 
 use crate::{bin_target::BinTarget, external_cli::CommandExt};
@@ -19,6 +20,7 @@ pub(crate) fn optimize_path(bin_target: &BinTarget) -> anyhow::Result<()> {
     let size_before = fs::metadata(&path)?.len();
 
     CommandExt::new(PROGRAM)
+        .require_package(PACKAGE, VersionReq::STAR)
         .arg("--strip-debug")
         .arg("-Os")
         .arg("-o")

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, anyhow, ensure};
 use std::{env, path::PathBuf};
 
-use crate::external_cli::CommandExt;
+use crate::external_cli::{CommandExt, cargo::install::AutoInstall};
 
 /// Runs `bevy_lint`, if it is installed, with the given arguments.
 ///
@@ -10,7 +10,9 @@ use crate::external_cli::CommandExt;
 pub fn lint(args: Vec<String>) -> anyhow::Result<()> {
     let bevy_lint_path = find_bevy_lint()?;
 
-    let status = CommandExt::new(bevy_lint_path).args(args).ensure_status()?;
+    let status = CommandExt::new(bevy_lint_path)
+        .args(args)
+        .ensure_status(AutoInstall::Never)?;
 
     ensure!(
         status.success(),

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -5,7 +5,10 @@ use crate::build::args::{BuildSubcommands, BuildWebArgs};
 use crate::{
     build::args::BuildArgs,
     config::CliConfig,
-    external_cli::{arg_builder::ArgBuilder, cargo::run::CargoRunArgs},
+    external_cli::{
+        arg_builder::ArgBuilder,
+        cargo::{install::AutoInstall, run::CargoRunArgs},
+    },
 };
 
 use super::cargo::build::{CargoBuildArgs, CargoPackageBuildArgs, CargoTargetBuildArgs};
@@ -18,7 +21,7 @@ pub struct RunArgs {
 
     /// Confirm all prompts automatically.
     #[arg(long = "yes", default_value_t = false)]
-    pub skip_prompts: bool,
+    pub confirm_prompts: bool,
 
     /// Commands to forward to `cargo run`.
     #[clap(flatten)]
@@ -26,6 +29,15 @@ pub struct RunArgs {
 }
 
 impl RunArgs {
+    /// Whether to automatically install missing dependencies.
+    pub(crate) fn auto_install(&self) -> AutoInstall {
+        if self.confirm_prompts {
+            AutoInstall::Always
+        } else {
+            AutoInstall::AskUser
+        }
+    }
+
     /// Whether to run the app in the browser.
     #[cfg(feature = "web")]
     pub(crate) fn is_web(&self) -> bool {
@@ -108,7 +120,7 @@ pub struct RunWebArgs {
 impl From<RunArgs> for BuildArgs {
     fn from(args: RunArgs) -> Self {
         BuildArgs {
-            confirm_prompts: args.skip_prompts,
+            confirm_prompts: args.confirm_prompts,
             cargo_args: CargoBuildArgs {
                 common_args: args.cargo_args.common_args,
                 compilation_args: args.cargo_args.compilation_args,

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -108,7 +108,7 @@ pub struct RunWebArgs {
 impl From<RunArgs> for BuildArgs {
     fn from(args: RunArgs) -> Self {
         BuildArgs {
-            skip_prompts: args.skip_prompts,
+            confirm_prompts: args.skip_prompts,
             cargo_args: CargoBuildArgs {
                 common_args: args.cargo_args.common_args,
                 compilation_args: args.cargo_args.compilation_args,

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -7,7 +7,7 @@ pub use self::args::RunArgs;
 pub mod args;
 
 pub fn run(args: &mut RunArgs) -> anyhow::Result<()> {
-    let metadata = cargo::metadata::metadata_with_args(["--no-deps"])?;
+    let metadata = cargo::metadata::metadata()?;
 
     let bin_target = select_run_binary(
         &metadata,
@@ -28,7 +28,9 @@ pub fn run(args: &mut RunArgs) -> anyhow::Result<()> {
 
     let cargo_args = args.cargo_args_builder();
     // For native builds, wrap `cargo run`
-    cargo::run::command().args(cargo_args).ensure_status()?;
+    cargo::run::command()
+        .args(cargo_args)
+        .ensure_status(args.auto_install())?;
 
     Ok(())
 }

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -96,7 +96,7 @@ pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {
         wasm_bindgen::PROGRAM,
         wasm_bindgen::PACKAGE,
         // wasm-bindgen version needs to be matched exactly
-        VersionReq::parse(&format!("={}", wasm_bindgen_version))
+        &VersionReq::parse(&format!("={}", wasm_bindgen_version))
             .context("failed to determine required wasm-bindgen version")?,
         skip_prompts,
     )?;
@@ -106,7 +106,7 @@ pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {
     cargo::install::if_needed(
         wasm_opt::PACKAGE,
         wasm_opt::PROGRAM,
-        VersionReq::STAR,
+        &VersionReq::STAR,
         skip_prompts,
     )?;
 

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -50,14 +50,14 @@ pub fn build_web(
         // Wasm targets are not installed by default
         .maybe_require_target(args.target())
         .args(cargo_args)
-        .ensure_status()?;
+        .ensure_status(args.auto_install())?;
 
     info!("Bundling JavaScript bindings...");
-    wasm_bindgen::bundle(metadata, bin_target)?;
+    wasm_bindgen::bundle(metadata, bin_target, args.auto_install())?;
 
     #[cfg(feature = "wasm-opt")]
     if args.is_release() {
-        wasm_opt::optimize_path(bin_target)?;
+        wasm_opt::optimize_path(bin_target, args.auto_install())?;
     }
 
     let web_bundle = create_web_bundle(

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -1,4 +1,5 @@
 use anyhow::Context as _;
+use semver::VersionReq;
 use tracing::info;
 
 #[cfg(feature = "rustup")]
@@ -94,13 +95,20 @@ pub(crate) fn ensure_web_setup(skip_prompts: bool) -> anyhow::Result<()> {
     cargo::install::if_needed(
         wasm_bindgen::PROGRAM,
         wasm_bindgen::PACKAGE,
-        Some(&wasm_bindgen_version),
+        // wasm-bindgen version needs to be matched exactly
+        VersionReq::parse(&format!("={}", wasm_bindgen_version))
+            .context("failed to determine required wasm-bindgen version")?,
         skip_prompts,
     )?;
 
     // `wasm-opt` for optimizing wasm files
     #[cfg(feature = "wasm-opt")]
-    cargo::install::if_needed(wasm_opt::PACKAGE, wasm_opt::PROGRAM, None, skip_prompts)?;
+    cargo::install::if_needed(
+        wasm_opt::PACKAGE,
+        wasm_opt::PROGRAM,
+        VersionReq::STAR,
+        skip_prompts,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
# Objective

We currently check if the required programs and targets are installed _every time_ when we run the `web` commands.
This adds overhead to the command execution and also makes the logs noisier.

# Solution

First try to execute the command and only perform the checks and potential fixes if the command exits with an error.
The `ensure_web_setup` function has been removed entirely.

<details>
<summary>The new version shortens the `--verbose` output</summary>

```diff
DEBUG Using config CliConfig { target: None, features: [], default_features: None }
-DEBUG Running: `rustup --version`
-DEBUG Running: `rustup target list`
-DEBUG Running: `wasm-bindgen --version`
 INFO Compiling to WebAssembly...
DEBUG Running: `cargo build --config profile.web.inherits="dev" --config profile.web-release.inherits="release" --config profile.web-release.strip="debuginfo" --config profile.web-release.opt-level="s" --bin cplx --profile web --target wasm32-unknown-unknown`
    Finished `web` profile [unoptimized + debuginfo] target(s) in 0.23s
 INFO Bundling JavaScript bindings...
DEBUG Running: `wasm-bindgen --no-typescript --out-name cplx --out-dir /home/tim/dev/bevyengine/bevy_complex_repo/app/target/wasm32-unknown-unknown/web --target web /home/tim/dev/bevyengine/bevy_complex_repo/app/target/wasm32-unknown-unknown/web/cplx.wasm`
 INFO No custom `web` folder found, using defaults.
 INFO Open your app at <http://localhost:4000>!
DEBUG Adding response headers {}
```
</details>

There's still things that can be improved (e.g. not logging when we don't add any response headers), but we already save 3 command executions!

<details>
<summary>Error example (`wasm32-unknown-unknown` target missing)</summary>

```diff
DEBUG Using config CliConfig { target: None, features: [], default_features: None }
 INFO Compiling to WebAssembly...
DEBUG Running: `cargo build --config profile.web.inherits="dev" --config profile.web-release.inherits="release" --config profile.web-release.strip="debuginfo" --config profile.web-release.opt-level="s" --bin cplx --profile web --target wasm32-unknown-unknown`
   Compiling proc-macro2 v1.0.93
   Compiling unicode-ident v1.0.15
   Compiling cfg-if v1.0.0
   Compiling once_cell v1.20.2
   Compiling wasm-bindgen-shared v0.2.100
   Compiling bumpalo v3.16.0
   Compiling log v0.4.25
   Compiling rustversion v1.0.19
   Compiling serde v1.0.217
   Compiling wasm-bindgen v0.2.100
   Compiling autocfg v1.4.0
   Compiling pin-project-lite v0.2.16
   Compiling version_check v0.9.5
   Compiling equivalent v1.0.1
   Compiling hashbrown v0.15.2
   Compiling toml_datetime v0.6.8
error[E0463]: can't find crate for `core`
  |
  = note: the `wasm32-unknown-unknown` target may not be installed
  = help: consider downloading the target with `rustup target add wasm32-unknown-unknown`

For more information about this error, try `rustc --explain E0463`.
error: could not compile `cfg-if` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error[E0463]: can't find crate for `std`
  |
  = note: the `wasm32-unknown-unknown` target may not be installed
  = help: consider downloading the target with `rustup target add wasm32-unknown-unknown`

error: could not compile `once_cell` (lib) due to 1 previous error
error: could not compile `pin-project-lite` (lib) due to 1 previous error
+ WARN Failed to run cargo, trying to find automatic fix...
+DEBUG Running: `rustup --version`
+DEBUG Running: `rustup target list`
+Compilation target `wasm32-unknown-unknown` is missing, should I install it for you? [y/n]
```
</details>

To enable these changes, the installation process has been reworked.
Instead of a simple boolean to check prompting, the `AutoInstall` enum gives us more control about when to automatically install dependencies.
Package installation with versions has been generalized to avoid special cases for `wasm-bindgen`.
The `CommandExt` has been extended to allow defining required packages and targets to automatically fix errors and retry the command.

# Testing

- Install the Bevy CLI from this branch:
  ```sh
  cargo install --git https://github.com/TheBevyFlock/bevy_cli --branch optimistic-execution --locked --force bevy_cli
  ```
- Try the happy path on a Bevy repo of your choice:
  ```sh
  bevy run web --verbose
  ```
- Try the error path when a target is missing:
  ```sh
  rustup target remove wasm32-unknown-unknown
  cargo clean  # otherwise the build might just be reused
  bevy run web --verbose
  ```
- Try the error path when a package is missing:
  ```sh
  cargo uninstall wasm-bindgen-cli
  bevy run web --verbose
  ```
- Try the error path when a package has the wrong version:
  ```sh
  cargo install wasm-bindgen-cli --version 0.2.92  # or another wrong version
  bevy run web --verbose
  ```

# Follow-up work

- Add a `--no` flag analogous to the `--yes` flag, which will use `AutoInstall::Never`
- Further clean up verbose logging
- Align the style of the logging to blend in more nicely with `cargo`