### PR TITLE
Only log headers if any are added

### DIFF
--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -47,7 +47,9 @@ pub(crate) async fn serve(
 
     let mut router = Router::new();
 
-    tracing::debug!("Adding response headers {header_map:?}");
+    if !header_map.is_empty() {
+        tracing::debug!("Adding response headers {header_map:?}");
+    }
 
     match web_bundle.clone() {
         WebBundle::Packed(PackedBundle { path }) => {


### PR DESCRIPTION
Cleans up one unnecessary `--verbose` log