### PR TITLE
Add aliases for `build` and `run` commands

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -64,8 +64,10 @@ pub enum Subcommands {
     /// Create a new Bevy project from a specified template.
     New(NewArgs),
     /// Build your Bevy app.
+    #[command(visible_alias = "b")]
     Build(BuildArgs),
     /// Run your Bevy app.
+    #[command(visible_alias = "r")]
     Run(RunArgs),
     /// Check the current project using Bevy-specific lints.
     ///


### PR DESCRIPTION
Closes #366

Adds `b` and `r` aliases for the `build` and `run` commands. `bevy -h` now prints:
```
  build        Build your Bevy app [aliases: b]
  run          Run your Bevy app [aliases: r]
```

I'd prefer
```
  build, b     Build your Bevy app
  run, r       Run your Bevy app
```
but I don't know how to do that :)