### PR TITLE
pass `args.is_web()` to `CliConfig::for_package()`

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -18,7 +18,13 @@ pub fn build(args: &mut BuildArgs) -> anyhow::Result<()> {
         args.profile(),
     )?;
 
-    let config = CliConfig::for_package(&metadata, bin_target.package, true, args.is_release())?;
+    let config = CliConfig::for_package(
+        &metadata,
+        bin_target.package,
+        args.is_web(),
+        args.is_release(),
+    )?;
+
     args.apply_config(&config);
 
     #[cfg(feature = "web")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -244,6 +244,43 @@ mod tests {
         }
 
         #[test]
+        fn should_return_merged_config_for_native_dev() -> anyhow::Result<()> {
+            let metadata = json!({
+                "features": ["native-dev"],
+                "dev": {
+                    "features": [
+                        "bevy/dynamic_linking",
+                        "bevy/bevy_dev_tools",
+                        "bevy/bevy_ui_debug"
+                    ],
+                    "default_features": true,
+                },
+                "web": {
+                    "features": ["web"],
+                    "default_features": false,
+                    "dev": {
+                        "features": ["web-dev"],
+                    }
+                }
+            });
+
+            assert_eq!(
+                CliConfig::merged_from_metadata(Some(&metadata), false, false)?,
+                CliConfig {
+                    target: None,
+                    features: vec![
+                        "native-dev".to_owned(),
+                        "bevy/dynamic_linking".to_owned(),
+                        "bevy/bevy_dev_tools".to_owned(),
+                        "bevy/bevy_ui_debug".to_owned()
+                    ],
+                    default_features: Some(true),
+                }
+            );
+            Ok(())
+        }
+
+        #[test]
         fn should_not_require_any_config() -> anyhow::Result<()> {
             let metadata = json!({});
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -18,7 +18,12 @@ pub fn run(args: &mut RunArgs) -> anyhow::Result<()> {
         args.profile(),
     )?;
 
-    let config = CliConfig::for_package(&metadata, bin_target.package, true, args.is_release())?;
+    let config = CliConfig::for_package(
+        &metadata,
+        bin_target.package,
+        args.is_web(),
+        args.is_release(),
+    )?;
     args.apply_config(&config);
 
     #[cfg(feature = "web")]


### PR DESCRIPTION
The Bevy CLI config was always built for the web targets.

# Testing

I added the unit test first but the issue was not even there so it passed from the start ^^ so testing is done as described here: https://github.com/TheBevyFlock/bevy_cli/issues/370#issue-3002023740 

## Native dev build

```sh
❯ bevy build -v
DEBUG Using config CliConfig { target: None, features: [], default_features: None }
DEBUG Running: `cargo build --profile dev`
   Compiling bevy_new_2d v0.1.0 (bevy_new_2d)
error: dev_native active
 --> src/main.rs:5:1
  |
5 | compile_error!("dev_native active");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `bevy_new_2d` (bin "bevy_new_2d") due to 1 previous error
Error: Command cargo exited with status code exit status: 101
```
## Native release build

```sh
❯ bevy build -r -v
DEBUG Using config CliConfig { target: None, features: [], default_features: Some(false) }
DEBUG Running: `cargo build --no-default-features --profile release`
    Finished `release` profile [optimized] target(s) in 0.14s
```

## Web dev build

```sh
❯ bevy build web -v
DEBUG Using config CliConfig { target: None, features: ["dev"], default_features: Some(false) }
DEBUG Running: `rustup --version`
DEBUG Running: `rustup target list`
DEBUG Running: `wasm-bindgen --version`
 INFO Compiling to WebAssembly...
DEBUG Running: `cargo build --config profile.web.inherits="dev" --features dev --no-default-features --profile web --target wasm32-unknown-unknown`
    Finished `web` profile [optimized + debuginfo] target(s) in 0.13s
 INFO Bundling JavaScript bindings...
DEBUG Running: `wasm-bindgen --no-typescript --out-name bevy_new_2d --out-dir 
bevy_new_2d/target/wasm32-unknown-unknown/web --target web 
bevy_new_2d/target/wasm32-unknown-unknown/web/bevy_new_2d.wasm`
 INFO No custom `web` folder found, using defaults.
```

## Web release build

```sh
❯ bevy build -r web  -v
DEBUG Using config CliConfig { target: None, features: [], default_features: Some(false) }
DEBUG Running: `rustup --version`
DEBUG Running: `rustup target list`
DEBUG Running: `wasm-bindgen --version`
 INFO Compiling to WebAssembly...
DEBUG Running: `cargo build --config profile.web.inherits="dev" --no-default-features --profile web-release --target wasm32-unknown-unknown`
    Finished `web-release` profile [optimized] target(s) in 0.13s
```

Closes #370