### PR TITLE
Bump Rust toolchain to `nightly-2025-04-03`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,9 +1073,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657c43813e9c80e700ff3a277547d10a99710c865ad8528874ed64e079a69635"
+checksum = "07a197dfde816f2732f1e1f43df2e4b93a8eead5f26d4deb3bc54b1fb6412ebf"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -32,7 +32,7 @@ harness = false
 # Contains a series of useful utilities when writing lints. The version is chosen to work with the
 # currently pinned nightly Rust version. When the Rust version changes, this too needs to be
 # updated!
-clippy_utils = "=0.1.87"
+clippy_utils = "=0.1.88"
 
 # Easy error propagation and contexts.
 anyhow = "1.0.86"

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -187,7 +187,7 @@ There are several other ways to toggle lints, although some have varying levels 
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
-|0.3.0-dev|1.87.0|`nightly-2025-02-20`|0.16|
+|0.3.0-dev|1.88.0|`nightly-2025-04-03`|0.16|
 |0.2.0|1.87.0|`nightly-2025-02-20`|0.15|
 |0.1.0|1.84.0|`nightly-2024-11-14`|0.14|
 

--- a/bevy_lint/src/lints/pedantic/borrowed_reborrowable.rs
+++ b/bevy_lint/src/lints/pedantic/borrowed_reborrowable.rs
@@ -99,16 +99,16 @@
 use std::ops::ControlFlow;
 
 use crate::{declare_bevy_lint, declare_bevy_lint_pass};
-use clippy_utils::{diagnostics::span_lint_and_sugg, source::snippet_opt, ty::match_type};
+use clippy_utils::{
+    diagnostics::span_lint_and_sugg,
+    source::{snippet, snippet_opt},
+    ty::match_type,
+};
 use rustc_errors::Applicability;
 use rustc_hir::{Body, FnDecl, MutTy, Mutability, intravisit::FnKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{Interner, Ty, TyKind, TypeVisitable, TypeVisitor};
-use rustc_span::{
-    Span,
-    def_id::LocalDefId,
-    symbol::{Ident, kw},
-};
+use rustc_span::{Span, def_id::LocalDefId, symbol::kw};
 
 declare_bevy_lint! {
     pub BORROWED_REBORROWABLE,
@@ -126,7 +126,7 @@ impl<'tcx> LateLintPass<'tcx> for BorrowedReborrowable {
         cx: &LateContext<'tcx>,
         kind: FnKind<'tcx>,
         decl: &'tcx FnDecl<'tcx>,
-        _: &'tcx Body<'tcx>,
+        body: &'tcx Body<'tcx>,
         fn_span: Span,
         def_id: LocalDefId,
     ) {
@@ -142,17 +142,29 @@ impl<'tcx> LateLintPass<'tcx> for BorrowedReborrowable {
             _ => cx.tcx.fn_sig(def_id).instantiate_identity(),
         };
 
+        // A list of argument types, used in the actual lint check.
+        let arg_types = fn_sig.inputs().skip_binder();
+        // A list of argument names, used to check and skip `&mut self`.
         let arg_names = cx.tcx.fn_arg_names(def_id);
+        // A list of argument parameters, used to find the span of arguments.
+        let arg_params = body.params;
 
-        let args = fn_sig.inputs().skip_binder();
+        debug_assert_eq!(
+            arg_types.len(),
+            arg_names.len(),
+            "there must be the same number of argument types and names"
+        );
+        debug_assert_eq!(
+            arg_types.len(),
+            arg_params.len(),
+            "there must be the same number of argument types and parameters"
+        );
 
-        for (arg_index, arg_ty) in args.iter().enumerate() {
+        for (arg_index, arg_ty) in arg_types.iter().enumerate() {
             let TyKind::Ref(region, ty, Mutability::Mut) = arg_ty.kind() else {
                 // We only care about `&mut` parameters
                 continue;
             };
-
-            let arg_ident = arg_names[arg_index];
 
             // This lint would emit a warning on `&mut self` if `self` was reborrowable. This isn't
             // useful, though, because it would hurt the ergonomics of using methods of
@@ -161,7 +173,7 @@ impl<'tcx> LateLintPass<'tcx> for BorrowedReborrowable {
             // To avoid this, we skip any parameter named `self`. This won't false-positive on
             // other function arguments named `self`, since it is a special keyword that is
             // disallowed in other positions.
-            if arg_ident.name == kw::SelfLower {
+            if arg_names[arg_index].is_some_and(|ident| ident.name == kw::SelfLower) {
                 continue;
             }
 
@@ -187,8 +199,6 @@ impl<'tcx> LateLintPass<'tcx> for BorrowedReborrowable {
                 continue;
             }
 
-            let span = decl.inputs[arg_index].span.to(arg_ident.span);
-
             // This tries to get the user-written form of `T` given the HIR representation for `&T`
             // / `&mut T`. If we cannot for whatever reason, we fallback to using
             // `Ty::to_string()` to get the fully-qualified form of `T`.
@@ -205,15 +215,17 @@ impl<'tcx> LateLintPass<'tcx> for BorrowedReborrowable {
                 // If it's not a `Ref` for whatever reason, fallback to our default value.
                 _ => None,
             }
+            // We previously peeled the `&mut` reference, so `ty` is just the underlying `T`.
             .unwrap_or_else(|| ty.to_string());
 
             span_lint_and_sugg(
                 cx,
                 BORROWED_REBORROWABLE.lint,
-                span,
+                // The span contains both the argument name and type.
+                arg_params[arg_index].span,
                 reborrowable.message(),
                 reborrowable.help(),
-                reborrowable.suggest(arg_ident, ty_snippet),
+                reborrowable.suggest(cx, arg_params[arg_index].pat.span, ty_snippet),
                 // Not machine-applicable since the function body may need to
                 // also be updated to account for the removed ref
                 Applicability::MaybeIncorrect,
@@ -293,8 +305,9 @@ impl Reborrowable {
         format!("use `{name}` instead")
     }
 
-    fn suggest(&self, ident: Ident, ty: String) -> String {
-        format!("mut {ident}: {ty}")
+    fn suggest(&self, cx: &LateContext, name: Span, ty: String) -> String {
+        let name = snippet(cx, name, "_");
+        format!("mut {name}: {ty}")
     }
 }
 

--- a/bevy_lint/src/utils/hir_parse.rs
+++ b/bevy_lint/src/utils/hir_parse.rs
@@ -6,7 +6,7 @@ use rustc_hir::{
     def::{DefKind, Res},
 };
 use rustc_lint::LateContext;
-use rustc_span::{Span, Symbol};
+use rustc_span::{Ident, Span, kw};
 
 /// Returns the list of types inside a tuple type.
 ///
@@ -243,9 +243,13 @@ impl<'tcx> MethodCall<'tcx> {
                     // If the name of the first argument is `self`, then it *must* be a method.
                     // `self` is a reserved keyword, and cannot be used as a general function
                     // argument name.
-                    if inputs
-                        .first()
-                        .is_some_and(|ident| ident.name == Symbol::intern("self"))
+                    if let [
+                        Some(Ident {
+                            name: kw::SelfLower,
+                            ..
+                        }),
+                        ..,
+                    ] = inputs
                     {
                         let method_path = match *qpath {
                             // If the qualified path is resolved, the method path must be the final

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,6 +4,6 @@
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version
 # so that builds are reproducible.
-channel = "nightly-2025-02-20"
+channel = "nightly-2025-04-03"
 # These components are required to use `rustc` crates.
 components = ["rustc-dev", "llvm-tools-preview"]

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -92,9 +92,7 @@ impl Package {
     pub fn has_bin(&self) -> bool {
         self.targets.iter().any(|target| {
             target
-                .kind
-                .iter()
-                .any(|target_kind| *target_kind == TargetKind::Bin)
+                .kind.contains(&TargetKind::Bin)
         })
     }
 
@@ -102,14 +100,14 @@ impl Package {
     pub fn bin_targets(&self) -> impl Iterator<Item = &Target> {
         self.targets
             .iter()
-            .filter(|target| target.kind.iter().any(|kind| *kind == TargetKind::Bin))
+            .filter(|target| target.kind.contains(&TargetKind::Bin))
     }
 
     /// An iterator over all example targets contained in this package.
     pub fn example_targets(&self) -> impl Iterator<Item = &Target> {
         self.targets
             .iter()
-            .filter(|target| target.kind.iter().any(|kind| *kind == TargetKind::Example))
+            .filter(|target| target.kind.contains(&TargetKind::Example))
     }
 }
 

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -90,10 +90,9 @@ pub struct Package {
 impl Package {
     /// Check if the package has an executable binary.
     pub fn has_bin(&self) -> bool {
-        self.targets.iter().any(|target| {
-            target
-                .kind.contains(&TargetKind::Bin)
-        })
+        self.targets
+            .iter()
+            .any(|target| target.kind.contains(&TargetKind::Bin))
     }
 
     /// An iterator over all binary targets contained in this package.


### PR DESCRIPTION
Another [version of `clippy_utils` has released](https://crates.io/crates/clippy_utils/0.1.88), meaning it's time to update the linter's required toolchain! Following the [process outlined in the contributor's guide](https://github.com/TheBevyFlock/bevy_cli/blob/b6d80516f6282c6b61a9fe89cbd39bb023d04d87/bevy_lint/docs/how-to/bump-rust.md), the compatibility table is now as follows:

|`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
|-|-|-|-|
|0.3.0-dev|1.88.0|`nightly-2025-04-03`|0.16|

The largest noticeable breaking change is that `TyCtxt::fn_arg_names()` now returns `&[Option<Ident>]` instead of `&[Ident]`, meaning we now need to handle the `Option`.