### PR TITLE
Improve logging of bevy_cli config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ semver = { version = "1.0.23", features = ["serde"] }
 # Parsing the Cargo manifest
 toml_edit = { version = "0.22.22", default-features = false, features = [
     "parse",
+    "serde",
 ] }
 
 # Logging crates

--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -67,7 +67,11 @@ impl BuildArgs {
     ///
     /// CLI arguments take precedence.
     pub(crate) fn apply_config(&mut self, config: &CliConfig) {
-        tracing::debug!("Using config {config:?}");
+        if config.is_default() {
+            return;
+        }
+
+        tracing::debug!("Using defaults from bevy_cli config:\n{config}");
         if self.cargo_args.compilation_args.target.is_none() {
             self.cargo_args.compilation_args.target = config.target().map(ToOwned::to_owned);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,12 +193,14 @@ impl Display for CliConfig {
             features,
         } = self;
 
+        let mut lines: Vec<String> = Vec::new();
+
         if let Some(target) = target {
-            writeln!(f, r#"target = "{target}""#)?;
+            lines.push(format!(r#"target = "{target}""#));
         }
 
         if let Some(default_features) = default_features {
-            writeln!(f, "default_features = {default_features}")?;
+            lines.push(format!("default_features = {default_features}"));
         }
 
         if !features.is_empty() {
@@ -208,10 +210,10 @@ impl Display for CliConfig {
                 .map(|feature| format!(r#""{feature}""#))
                 .collect::<Vec<String>>()
                 .join(", ");
-            writeln!(f, "features = [{features}]")?;
+            lines.push(format!("features = [{features}]"));
         }
 
-        Ok(())
+        write!(f, "{}", lines.join("\n"))
     }
 }
 

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -72,7 +72,11 @@ impl RunArgs {
     ///
     /// CLI arguments take precedence.
     pub(crate) fn apply_config(&mut self, config: &CliConfig) {
-        tracing::debug!("Using config {config:?}");
+        if config.is_default() {
+            return;
+        }
+
+        tracing::debug!("Using defaults from bevy_cli config:\n{config}");
         if self.cargo_args.compilation_args.target.is_none() {
             self.cargo_args.compilation_args.target = config.target().map(ToOwned::to_owned);
         }


### PR DESCRIPTION
# Objective

Closes #364.

- Don't log if the config doesn't change the default values
- Format the logging to be in a toml syntax

# Solution

New output when there are things specified in the config:

```diff
+DEBUG Using defaults from bevy_cli config:
+default_features = false
+features = ["dev"]
 INFO Compiling to WebAssembly...
DEBUG Running: `cargo build --config profile.web.inherits="dev" --bin bevy_new_2d --features dev --no-default-features --profile web --target wasm32-unknown-unknown`
    Finished `web` profile [optimized + debuginfo] target(s) in 0.20s
 INFO Bundling JavaScript bindings...
DEBUG Running: `wasm-bindgen --no-typescript --out-name bevy_new_2d --out-dir /home/tim/dev/bevyengine/bevy_new_2d/target/wasm32-unknown-unknown/web --target web /home/tim/dev/bevyengine/bevy_new_2d/target/wasm32-unknown-unknown/web/bevy_new_2d.wasm`
 INFO No custom `web` folder found, using defaults.
 INFO Open your app at <http://localhost:4000>!
```

# Testing

- Install CLI from this branch
- Run e.g. `bevy run web --verbose`
- Test on a project with no config (should not log anything for the config) and on a project with some config values (should log with toml syntax)