### PR TITLE
Allow forwarding of args to underlying program

### DIFF
--- a/src/external_cli/arg_builder.rs
+++ b/src/external_cli/arg_builder.rs
@@ -131,6 +131,16 @@ impl ArgBuilder {
         self
     }
 
+    /// Add a list of positional arguments.
+    pub fn args<I, V>(mut self, iter: I) -> Self
+    where
+        V: Into<String>,
+        I: IntoIterator<Item = V>,
+    {
+        self.0.extend(iter.into_iter().map(|value| value.into()));
+        self
+    }
+
     /// Add all arguments from the other builder to this one.
     pub fn append(mut self, mut other: ArgBuilder) -> Self {
         self.0.append(&mut other.0);

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -26,6 +26,12 @@ pub struct RunArgs {
     /// Commands to forward to `cargo run`.
     #[clap(flatten)]
     pub cargo_args: CargoRunArgs,
+
+    /// Arguments to pass to the underlying Bevy app.
+    ///
+    /// Specified after `--`.
+    #[clap(last = true, name = "ARGS")]
+    pub forward_args: Vec<String>,
 }
 
 impl RunArgs {
@@ -65,7 +71,14 @@ impl RunArgs {
 
     /// Generate arguments for `cargo`.
     pub(crate) fn cargo_args_builder(&self) -> ArgBuilder {
-        self.cargo_args.args_builder(self.is_web())
+        let mut arg_builder = self.cargo_args.args_builder(self.is_web());
+
+        if !self.forward_args.is_empty() {
+            // This MUST come last to avoid forwarding other args
+            arg_builder = arg_builder.arg("--").args(self.forward_args.iter());
+        }
+
+        arg_builder
     }
 
     /// Apply the config on top of the CLI arguments.


### PR DESCRIPTION
# Objective

Closes #369.

Some Bevy apps also have a CLI interface that allows passing other options.
It's currently not possible to forward args to the underlying Bevy app when using `bevy run`.
With `cargo run`, you can forward options by putting them after a plain `--`.
This should also be possible for `bevy run`.

# Solution

Use `[clap(last = true)]` to capture args after `--`.
Then forward them to `cargo run` by also putting them after `--`.

Note that this only works for `bevy run` and not `bevy run web`, because you can't really run a Wasm binary with additional arguments (as far as I know...)

# Testing

- Install the CLI from this branch:
  ```
  cargo install --git https://github.com/TheBevyFlock/bevy_cli --branch 369-passing-options-to-bevy-app --locked --force bevy_cli
  ```
- Try e.g. `bevy --verbose run -- --api webgpu`