### PR TITLE
Improve error message for failed `cargo metadata`

### DIFF
--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -34,9 +34,12 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let output = command().args(additional_args).output(AutoInstall::Never)?;
+    let output = command()
+        .args(additional_args)
+        .output(AutoInstall::Never)
+        .context("failed to obtain package metadata, are you in a cargo workspace?")?;
     let metadata = serde_json::from_slice(&output.stdout)
-        .context("Failed to parse `cargo metadata` output")?;
+        .context("failed to parse `cargo metadata` output")?;
     Ok(metadata)
 }
 


### PR DESCRIPTION
# Objective

We always run `cargo metadata` at the start of a CLI command to obtain more information about workspace and package as well as constructing the appropriate CLI config.

If this command fails, e.g. because you're not in a cargo workspace, the output is currently very unhelpful:

```
bevy run web              
Error: Command cargo exited with status code exit status: 101
```

# Solution

- Add more context to the `cargo metadata` error to hint the user what may have gone wrong
- Log the full command when it errors instead of just the program name

```
bevy-dev run web
Error: failed to obtain package metadata, are you in a cargo workspace?

Caused by:
    Command `cargo metadata --format-version 1` exited with status code exit status: 101
```

# Testing

- Install the CLI from this branch
- Navigate to a non-cargo directory
- Run any `build` or `run` bevy command