### PR TITLE
Fix running web app with bundle option

### DIFF
--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -118,6 +118,10 @@ pub fn create_web_bundle(
     let _ = fs::remove_dir_all(&base_path);
 
     // Build artifacts
+    tracing::debug!(
+        "Copying build artifacts from file://{}",
+        linked.build_artifact_path.to_string_lossy()
+    );
     fs::create_dir_all(base_path.join("build"))?;
     fs::copy(
         linked.build_artifact_path.join(&linked.wasm_file_name),
@@ -132,6 +136,10 @@ pub fn create_web_bundle(
 
     // Assets
     if let Some(assets_path) = linked.assets_path {
+        tracing::debug!(
+            "Copying assets from file://{}",
+            assets_path.to_string_lossy()
+        );
         fs_extra::dir::copy(
             assets_path,
             &base_path,
@@ -145,6 +153,10 @@ pub fn create_web_bundle(
 
     // Custom web assets
     if custom_web_folder.exists() {
+        tracing::debug!(
+            "Copying custom web assets from file://{}",
+            custom_web_folder.to_string_lossy()
+        );
         fs_extra::dir::copy(
             custom_web_folder,
             &base_path,
@@ -158,6 +170,7 @@ pub fn create_web_bundle(
     }
 
     // Index (pre-processed)
+    tracing::debug!("Writing index.html");
     fs::write(base_path.join("index.html"), &index)
         .context("failed to write processed index.html")?;
 

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -53,10 +53,7 @@ pub(crate) async fn serve(
 
     match web_bundle.clone() {
         WebBundle::Packed(PackedBundle { path }) => {
-            router = router.route_service(
-                &format!("/{}", path.display()),
-                ServeFile::new("index.html"),
-            );
+            router = router.route_service("/", ServeDir::new(path));
         }
         WebBundle::Linked(LinkedBundle {
             build_artifact_path,

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -7,7 +7,7 @@ use axum::{
     },
     middleware::map_response,
     response::Response,
-    routing::{any, get},
+    routing::{any, get, get_service},
 };
 use http::HeaderMap;
 use std::net::SocketAddr;
@@ -53,7 +53,9 @@ pub(crate) async fn serve(
 
     match web_bundle.clone() {
         WebBundle::Packed(PackedBundle { path }) => {
-            router = router.route_service("/", ServeDir::new(path));
+            // Using `fallback_service` instead of `route_service`
+            // to recursively serve the directory with correct MIME types
+            router = router.fallback_service(get_service(ServeDir::new(path)));
         }
         WebBundle::Linked(LinkedBundle {
             build_artifact_path,


### PR DESCRIPTION
# Objective

Fixes #365.

The `bevy run web --bundle` command didn't work correctly, the web server failed to serve the bundle.

# Solution

- Add more logging to the bundling process
- Fix serving packed bundles by correctly serving the entire folder

Note that I'm quite new to `axum` and had to ask Chat GPT for a bit of help here.
I initially tried something like this:

```rs
router.route_service("/", ServeDir::new(path)
```

We already use this in another place of the app.

But this approach caused issues with nested folders, e.g. the `build` directory containing the WASM and JS bindings.

With this `fallback_service` approach it seems to work as expected, but if you know of a better way to do this please let me know!

# Testing

- Install the CLI from this branch:
  ```
  cargo install --git https://github.com/TheBevyFlock/bevy_cli --branch 365-fix-running-bundled-web-folder --locked bevy_cli
  ```
- Run `bevy run web --bundle --verbose` in any web-compatible Bevy package