### PR TITLE
change suffix of `SystemSet` from `Set` to `Systems`

### DIFF
--- a/bevy_lint/src/lints/style/unconventional_naming.rs
+++ b/bevy_lint/src/lints/style/unconventional_naming.rs
@@ -22,7 +22,7 @@
 //! # use bevy::prelude::*;
 //! #
 //! #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-//! struct MyAudioSet;
+//! struct MyAudioSystems;
 //! ```
 
 use clippy_utils::{diagnostics::span_lint_hir_and_then, path_res};
@@ -161,7 +161,7 @@ impl TraitConvention {
     /// Returns the suffix that should be used when implementing this trait
     fn suffix(&self) -> &'static str {
         match self {
-            TraitConvention::SystemSet => "Set",
+            TraitConvention::SystemSet => "Systems",
             TraitConvention::Plugin => "Plugin",
         }
     }
@@ -172,10 +172,7 @@ impl TraitConvention {
 
     /// Test if the Structure name matches the naming convention
     fn matches_conventional_name(&self, struct_name: &str) -> bool {
-        match self {
-            TraitConvention::SystemSet => struct_name.ends_with("Set"),
-            TraitConvention::Plugin => struct_name.ends_with("Plugin"),
-        }
+        struct_name.ends_with(self.suffix())
     }
 
     /// Suggest a name for the Structure that matches the naming pattern
@@ -184,11 +181,11 @@ impl TraitConvention {
             TraitConvention::SystemSet => {
                 // There are several competing naming standards. These are a few that we specially
                 // check for.
-                const INCORRECT_SUFFIXES: [&str; 3] = ["System", "Systems", "Steps"];
+                const INCORRECT_SUFFIXES: [&str; 3] = ["System", "Set", "Steps"];
 
                 // If the name ends in one of the other suffixes, strip it out and replace it with
-                // "Set". If a struct was originally named `FooSystem`, this suggests `FooSet`
-                // instead of `FooSystemSet`.
+                // "Systems". If a struct was originally named `FooSet`, this suggests `FooSystems`
+                // instead of `FooSetSystems`.
                 for incorrect_suffix in INCORRECT_SUFFIXES {
                     if struct_name.ends_with(incorrect_suffix) {
                         let stripped_name =

--- a/bevy_lint/tests/ui/unconventional_naming/system_set.rs
+++ b/bevy_lint/tests/ui/unconventional_naming/system_set.rs
@@ -9,30 +9,30 @@ use bevy::prelude::*;
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 struct MyAudio;
 //~^ ERROR: unconventional type name for a `SystemSet`
-//~| NOTE: structures that implement `SystemSet` should end in `Set`
+//~| NOTE: structures that implement `SystemSet` should end in `Systems`
 //~| HELP: rename `MyAudio`
 
 // This should not raise an error since the Set ends in `Set`
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-struct MyAudioSet;
+struct MyAudioSystems;
 
 //~v NOTE: `SystemSet` implemented here
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 struct MyAudioSystem;
 //~^ ERROR: unconventional type name for a `SystemSet`
-//~| NOTE: structures that implement `SystemSet` should end in `Set`
+//~| NOTE: structures that implement `SystemSet` should end in `Systems`
 //~| HELP: rename `MyAudioSystem`
 
 //~v NOTE: `SystemSet` implemented here
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-struct MyAudioSystems;
+struct MyAudioSet;
 //~^ ERROR: unconventional type name for a `SystemSet`
-//~| NOTE: structures that implement `SystemSet` should end in `Set`
-//~| HELP: rename `MyAudioSystems`
+//~| NOTE: structures that implement `SystemSet` should end in `Systems`
+//~| HELP: rename `MyAudioSet`
 
 //~v NOTE: `SystemSet` implemented here
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 struct MyAudioSteps;
 //~^ ERROR: unconventional type name for a `SystemSet`
-//~| NOTE: structures that implement `SystemSet` should end in `Set`
+//~| NOTE: structures that implement `SystemSet` should end in `Systems`
 //~| HELP: rename `MyAudioSteps`

--- a/bevy_lint/tests/ui/unconventional_naming/system_set.stderr
+++ b/bevy_lint/tests/ui/unconventional_naming/system_set.stderr
@@ -2,9 +2,9 @@ error: unconventional type name for a `SystemSet`
   --> tests/ui/unconventional_naming/system_set.rs:10:8
    |
 10 | struct MyAudio;
-   |        ^^^^^^^ help: rename `MyAudio`: `MyAudioSet`
+   |        ^^^^^^^ help: rename `MyAudio`: `MyAudioSystems`
    |
-note: structures that implement `SystemSet` should end in `Set`
+note: structures that implement `SystemSet` should end in `Systems`
   --> tests/ui/unconventional_naming/system_set.rs:10:8
    |
 10 | struct MyAudio;
@@ -25,9 +25,9 @@ error: unconventional type name for a `SystemSet`
   --> tests/ui/unconventional_naming/system_set.rs:21:8
    |
 21 | struct MyAudioSystem;
-   |        ^^^^^^^^^^^^^ help: rename `MyAudioSystem`: `MyAudioSet`
+   |        ^^^^^^^^^^^^^ help: rename `MyAudioSystem`: `MyAudioSystems`
    |
-note: structures that implement `SystemSet` should end in `Set`
+note: structures that implement `SystemSet` should end in `Systems`
   --> tests/ui/unconventional_naming/system_set.rs:21:8
    |
 21 | struct MyAudioSystem;
@@ -42,14 +42,14 @@ note: `SystemSet` implemented here
 error: unconventional type name for a `SystemSet`
   --> tests/ui/unconventional_naming/system_set.rs:28:8
    |
-28 | struct MyAudioSystems;
-   |        ^^^^^^^^^^^^^^ help: rename `MyAudioSystems`: `MyAudioSet`
+28 | struct MyAudioSet;
+   |        ^^^^^^^^^^ help: rename `MyAudioSet`: `MyAudioSystems`
    |
-note: structures that implement `SystemSet` should end in `Set`
+note: structures that implement `SystemSet` should end in `Systems`
   --> tests/ui/unconventional_naming/system_set.rs:28:8
    |
-28 | struct MyAudioSystems;
-   |        ^^^^^^^^^^^^^^
+28 | struct MyAudioSet;
+   |        ^^^^^^^^^^
 note: `SystemSet` implemented here
   --> tests/ui/unconventional_naming/system_set.rs:27:10
    |
@@ -61,9 +61,9 @@ error: unconventional type name for a `SystemSet`
   --> tests/ui/unconventional_naming/system_set.rs:35:8
    |
 35 | struct MyAudioSteps;
-   |        ^^^^^^^^^^^^ help: rename `MyAudioSteps`: `MyAudioSet`
+   |        ^^^^^^^^^^^^ help: rename `MyAudioSteps`: `MyAudioSystems`
    |
-note: structures that implement `SystemSet` should end in `Set`
+note: structures that implement `SystemSet` should end in `Systems`
   --> tests/ui/unconventional_naming/system_set.rs:35:8
    |
 35 | struct MyAudioSteps;


### PR DESCRIPTION
It seems like the preferred suffix for `SystemSet` changed from `Set` to `Systems`. For more information see:  https://discord.com/channels/691052431525675048/1278871953721262090/1364271327866785865