### PR TITLE
Mark `plugin_not_ending_in_plugin` as a renamed lint

### DIFF
--- a/bevy_lint/src/lints/style/mod.rs
+++ b/bevy_lint/src/lints/style/mod.rs
@@ -22,4 +22,16 @@ impl LintGroup for Style {
             Box::new(unconventional_naming::UnconventionalNaming::default())
         });
     }
+
+    fn register_lints(store: &mut LintStore) {
+        store.register_lints(Self::LINTS);
+
+        // `plugin_not_ending_in_plugin` was merged into `unconventional_naming` in v0.3.0. This
+        // helps users of v0.2.0 migrate to v0.3.0, but should be removed before v0.4.0 is
+        // released.
+        store.register_renamed(
+            "bevy::plugin_not_ending_in_plugin",
+            "bevy::unconventional_naming",
+        );
+    }
 }


### PR DESCRIPTION
`LintStore::register_renamed()` provides an easy method for migrating from `plugin_not_ending_in_plugin` to `unconventional_naming`. If the linter ever runs into code referencing `plugin_not_ending_in_plugin`:

```rust
#![warn(bevy::plugin_not_ending_in_plugin)]
```

It will now emit a warning that the lint has been renamed, but still correctly configure `unconventional_naming`:

```sh
warning: lint `bevy::plugin_not_ending_in_plugin` has been renamed to `bevy::unconventional_naming`
 --> bevy_lint/examples/lint_example.rs:3:9
  |
3 | #![warn(bevy::plugin_not_ending_in_plugin)]
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `bevy::unconventional_naming`
  |
  = note: `#[warn(renamed_and_removed_lints)]` on by default
```

Since all of `plugin_not_ending_in_plugin` was merged into `unconventional_naming`, this proposes we market it as a rename instead of a complete removal.