### PR TITLE
Linter v0.3.0 post-release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_lint"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "bevy",

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+**All Changes**: [`lint-v0.3.0...main`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.3.0...main)
+
 ## [v0.3.0] - 2025-04-30
 
 **All Changes**: [`lint-v0.2.0...lint-v0.3.0`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.2.0...lint-v0.3.0)

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_lint"
-version = "0.3.0"
+version = "0.4.0-dev"
 authors = ["BD103"]
 edition = "2024"
 description = "A collection of lints for the Bevy game engine"

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -187,6 +187,7 @@ There are several other ways to toggle lints, although some have varying levels 
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
+|0.4.0-dev|1.88.0|`nightly-2025-04-03`|0.16|
 |0.3.0|1.88.0|`nightly-2025-04-03`|0.16|
 |0.2.0|1.87.0|`nightly-2025-02-20`|0.15|
 |0.1.0|1.84.0|`nightly-2024-11-14`|0.14|

--- a/bevy_lint/action.yml
+++ b/bevy_lint/action.yml
@@ -26,6 +26,6 @@ runs:
         # be swapped with `--tag lint-vX.Y.Z` for releases.
         rustup run nightly-2025-04-03 cargo install \
           --git https://github.com/TheBevyFlock/bevy_cli.git \
-          --tag lint-v0.3.0 \
+          --branch main \
           --locked \
           bevy_lint


### PR DESCRIPTION
Woohoo, v0.3.0 is out!

Merging this PR will finish [the post-release process](https://github.com/TheBevyFlock/bevy_cli/blob/7005713baea786014ff1351ad8bea05e40db22b3/bevy_lint/docs/how-to/release.md#post-release), letting other PRs be merged again :)