### PR TITLE
Support installing `bevy_lint` via CLI

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+#[cfg(feature = "rustup")]
+use bevy_cli::lint::LintArgs;
 use bevy_cli::{build::args::BuildArgs, run::RunArgs};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use tracing_subscriber::prelude::*;
@@ -33,7 +35,8 @@ fn main() -> Result<()> {
         Subcommands::New(new) => {
             bevy_cli::template::generate_template(&new.name, &new.template, &new.branch)?;
         }
-        Subcommands::Lint { args } => bevy_cli::lint::lint(args)?,
+        #[cfg(feature = "rustup")]
+        Subcommands::Lint(args) => bevy_cli::lint::lint(args)?,
         Subcommands::Build(mut args) => bevy_cli::build::build(&mut args)?,
         Subcommands::Run(mut args) => bevy_cli::run::run(&mut args)?,
         Subcommands::Completions { shell } => {
@@ -75,11 +78,8 @@ pub enum Subcommands {
     /// <https://github.com/TheBevyFlock/bevy_cli> for installation instructions.
     ///
     /// To see the full list of options, run `bevy lint -- --help`.
-    Lint {
-        /// A list of arguments to be passed to `bevy_lint`.
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
+    #[cfg(feature = "rustup")]
+    Lint(LintArgs),
     /// Generate autocompletion for `bevy` CLI tool.
     ///
     /// You can add this or a variant of this to your shells `.profile` by just added

--- a/src/external_cli/cargo/install.rs
+++ b/src/external_cli/cargo/install.rs
@@ -103,7 +103,7 @@ pub(crate) fn if_needed<Pr: AsRef<OsStr>>(
         cmd.arg("run").arg(toolchain).arg(super::program());
     }
 
-    match &package.url {
+    match &package.git {
         // Install from Git
         Some(git_url) => {
             cmd.arg("install").arg("--git").arg(git_url);

--- a/src/external_cli/cargo/install.rs
+++ b/src/external_cli/cargo/install.rs
@@ -2,9 +2,9 @@ use std::{ffi::OsStr, process::exit, str::FromStr as _};
 
 use anyhow::Context;
 use dialoguer::Confirm;
-use semver::{Version, VersionReq};
+use semver::Version;
 
-use crate::external_cli::CommandExt;
+use crate::external_cli::{CommandExt, Package};
 
 /// Whether to automatically install packages.
 #[derive(Debug, Clone, Copy)]
@@ -25,7 +25,7 @@ impl AutoInstall {
     /// Returns `true` if the installation should be performed and `false` if not.
     /// An error is returned when an interactive prompt cannot be shown,
     /// e.g. when used in a non-interactive shell.
-    pub fn confirm<S: Into<String>>(&self, prompt: S) -> anyhow::Result<bool> {
+    pub fn confirm<S: Into<String>>(self, prompt: S) -> anyhow::Result<bool> {
         match self {
             AutoInstall::AskUser => Confirm::new().with_prompt(prompt).interact().context(
                 "failed to show interactive prompt, try using `--yes` to confirm automatically",
@@ -50,32 +50,38 @@ pub fn is_installed<P: AsRef<OsStr>>(program: P) -> Option<Vec<u8>> {
 /// Checks if the program is installed and installs it if it isn't.
 ///
 /// Returns `true` if the program needed to be installed.
-pub(crate) fn if_needed<Pr: AsRef<OsStr>, Pa: AsRef<OsStr>>(
+pub(crate) fn if_needed<Pr: AsRef<OsStr>>(
     program: Pr,
-    package: Pa,
-    package_version: &VersionReq,
+    package: &Package,
     auto_install: AutoInstall,
 ) -> anyhow::Result<bool> {
     let mut prompt: Option<String> = None;
     let program = program.as_ref();
 
     if let Some(stdout) = is_installed(program) {
-        if *package_version == VersionReq::STAR {
-            // If no `package_version` is specified and the program is installed,
-            // there is nothing to do.
-            return Ok(false);
-        };
-
-        if let Some(version) = parse_version(&stdout) {
-            if package_version.matches(&version) {
+        match &package.version {
+            None => {
+                // If no `package_version` is specified and the program is installed,
+                // there is nothing to do.
                 return Ok(false);
             }
+            Some(package_version) => {
+                if let Some(version) = parse_version(&stdout) {
+                    if package
+                        .version
+                        .as_ref()
+                        .is_some_and(|v| v.matches(&version))
+                    {
+                        return Ok(false);
+                    }
 
-            prompt = Some(format!(
-                "`{}@{version}` is installed, but \
+                    prompt = Some(format!(
+                        "`{}@{version}` is installed, but \
                 version `{package_version}` is required. Install and replace?",
-                program.to_string_lossy()
-            ));
+                        program.to_string_lossy()
+                    ));
+                }
+            }
         }
     }
 
@@ -88,12 +94,41 @@ pub(crate) fn if_needed<Pr: AsRef<OsStr>, Pa: AsRef<OsStr>>(
     }))? {
         exit(1);
     }
-
     let mut cmd = CommandExt::new(super::program());
-    cmd.arg("install").arg(package);
 
-    if *package_version != VersionReq::STAR {
-        cmd.arg("--version").arg(package_version.to_string());
+    // If the program needs to be installed with a specific toolchain, switch to `rustup run
+    // <toolchain> cargo install`
+    if let Some(toolchain) = &package.required_toolchain {
+        cmd = CommandExt::new("rustup");
+        cmd.arg("run").arg(toolchain).arg(super::program());
+    }
+
+    match &package.url {
+        // Install from Git
+        Some(git_url) => {
+            cmd.arg("install").arg("--git").arg(git_url);
+
+            // Install either from tag or branch, if none are present install from main branch.
+            // If both a tag and a branch is passed, return an error.
+            match (&package.tag, &package.branch) {
+                (None, None) => cmd.arg("--branch").arg("main"),
+                (None, Some(branch)) => cmd.arg("--branch").arg(branch),
+                (Some(tag), None) => cmd.arg("--tag").arg(tag),
+                (Some(_), Some(_)) => {
+                    anyhow::bail!("cannot install from branch and tag at the same time, choose one")
+                }
+            };
+
+            cmd.arg("--locked").arg(&package.name);
+        }
+        // Install the package from crates.io
+        None => {
+            cmd.arg("install").arg(package.name.clone());
+
+            if let Some(package_version) = &package.version {
+                cmd.arg("--version").arg(package_version.to_string());
+            }
+        }
     }
 
     cmd.ensure_status(auto_install)?;

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -28,7 +28,7 @@ pub(crate) struct Package {
     /// The toolchain that should be used to install this package
     pub(crate) required_toolchain: Option<String>,
     /// Git URL to install the specified package from
-    pub(crate) url: Option<String>,
+    pub(crate) git: Option<String>,
     /// Branch to use when installing from git
     pub(crate) branch: Option<String>,
     /// Tag to use when installing from git

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -283,6 +283,10 @@ impl Display for CommandExt {
             .collect::<Vec<_>>()
             .join(" ");
 
-        write!(f, "{program} {args}")
+        if args.is_empty() {
+            write!(f, "{program}")
+        } else {
+            write!(f, "{program} {args}")
+        }
     }
 }

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -19,12 +19,20 @@ pub(crate) mod wasm_bindgen;
 #[cfg(feature = "wasm-opt")]
 pub(crate) mod wasm_opt;
 
-#[derive(Debug)]
-struct Package {
+#[derive(Debug, Default)]
+pub(crate) struct Package {
     /// The name of the package.
-    name: OsString,
-    /// The version the package needs to match.
-    version: VersionReq,
+    pub(crate) name: OsString,
+    /// A specific [`VersionReq`]
+    pub(crate) version: Option<VersionReq>,
+    /// The toolchain that should be used to install this package
+    pub(crate) required_toolchain: Option<String>,
+    /// Git URL to install the specified package from
+    pub(crate) url: Option<String>,
+    /// Branch to use when installing from git
+    pub(crate) branch: Option<String>,
+    /// Tag to use when installing from git
+    pub(crate) tag: Option<String>,
 }
 
 pub struct CommandExt {
@@ -53,11 +61,9 @@ impl CommandExt {
     ///
     /// If the command fails and the package is missing,
     /// it can be installed automatically via `cargo install`.
-    pub fn require_package<S: AsRef<OsStr>>(&mut self, name: S, version: VersionReq) -> &mut Self {
-        self.package = Some(Package {
-            name: name.as_ref().to_owned(),
-            version,
-        });
+    #[cfg(any(feature = "rustup", feature = "web"))]
+    pub(crate) fn require_package(&mut self, package: Package) -> &mut Self {
+        self.package = Some(package);
         self
     }
 
@@ -81,12 +87,14 @@ impl CommandExt {
     /// Returns `true` if a new version was installed.
     fn install_package_if_needed(&self, auto_install: AutoInstall) -> anyhow::Result<bool> {
         if let Some(package) = &self.package {
-            cargo::install::if_needed(
-                self.inner.get_program(),
-                &package.name,
-                &package.version,
-                auto_install,
-            )
+            // If the package that needs to be installed if needed required a specific toolchain,
+            // check first that the toolchain is installed / install it before checking if the
+            // package needs to be installed.
+            #[cfg(feature = "rustup")]
+            if let Some(toolchain) = &package.required_toolchain {
+                rustup::install_toolchain_if_needed(toolchain, auto_install)?;
+            }
+            cargo::install::if_needed(self.inner.get_program(), package, auto_install)
         } else {
             Ok(false)
         }
@@ -121,13 +129,12 @@ impl CommandExt {
             tracing::warn!(
                 "Failed to run {}, trying to find automatic fix...",
                 self.inner.get_program().to_string_lossy()
-            )
+            );
         }
 
-        if self.install_package_if_needed(auto_install)? {
-            retry = true;
-        }
-        if self.install_target_if_needed(auto_install)? {
+        if self.install_package_if_needed(auto_install)?
+            || self.install_target_if_needed(auto_install)?
+        {
             retry = true;
         }
 
@@ -141,14 +148,9 @@ impl CommandExt {
         status: &Result<ExitStatus, Err>,
         auto_install: AutoInstall,
     ) -> anyhow::Result<bool> {
-        if let Ok(status) = status {
-            if status.success() {
-                Ok(false)
-            } else {
-                self.try_fix_before_retry(auto_install)
-            }
-        } else {
-            self.try_fix_before_retry(auto_install)
+        match status {
+            Ok(status) if status.success() => Ok(false),
+            _ => self.try_fix_before_retry(auto_install),
         }
     }
 

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -84,10 +84,10 @@ pub(crate) fn install_toolchain_if_needed(
         .context("failed to list installed toolchains with rustup list toolchain")?
         .stdout;
 
-    //using a `let` binding to create a longer lived value
+    // using a `let` binding to create a longer lived value
     let installed_toolchains = String::from_utf8_lossy(&rustup_list_toolchain);
 
-    // For more information on the standart toolchain names see: https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
+    // For more information on the standard toolchain names see: https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
     // in practice, this looks like this
     // ❯ rustup toolchain list
     // stable-aarch64-apple-darwin (active, default)
@@ -101,7 +101,7 @@ pub(crate) fn install_toolchain_if_needed(
     // check if the desired toolchain is installed
     if installed_toolchains
         .iter()
-        //ignore <host> part of the toolchain name
+        // ignore <host> part of the toolchain name
         .any(|installed_toolchain| installed_toolchain.starts_with(toolchain))
     {
         return Ok(());

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -69,3 +69,64 @@ pub(crate) fn install_target_if_needed<T: AsRef<OsStr>>(
 
     Ok(true)
 }
+
+/// Install a rust toolchain, if it is not already installed.
+///
+/// Returns `true` if the toolchain was missing and got installed.
+pub(crate) fn install_toolchain_if_needed(
+    toolchain: &str,
+    auto_install: AutoInstall,
+) -> anyhow::Result<()> {
+    let rustup_list_toolchain = CommandExt::new(program())
+        .arg("toolchain")
+        .arg("list")
+        .output(auto_install)
+        .context("failed to list installed toolchains with rustup list toolchain")?
+        .stdout;
+
+    //using a `let` binding to create a longer lived value
+    let installed_toolchains = String::from_utf8_lossy(&rustup_list_toolchain);
+
+    // For more information on the standart toolchain names see: https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
+    // in practice, this looks like this
+    // ❯ rustup toolchain list
+    // stable-aarch64-apple-darwin (active, default)
+    // nightly-2024-11-14-aarch64-apple-darwin
+    // nightly-2024-11-28-aarch64-apple-darwin
+    let installed_toolchains = installed_toolchains
+        .lines()
+        .map(str::trim)
+        .collect::<Vec<&str>>();
+
+    // check if the desired toolchain is installed
+    if installed_toolchains
+        .iter()
+        //ignore <host> part of the toolchain name
+        .any(|installed_toolchain| installed_toolchain.starts_with(toolchain))
+    {
+        return Ok(());
+    }
+
+    if !auto_install.confirm(format!(
+        "rust toolchain `{toolchain}` is missing, should I install it for you?",
+    ))? {
+        anyhow::bail!("User does not want to install rust toolchain `{toolchain}`.");
+    }
+
+    info!("Installing missing rust toolchain: `{toolchain}`");
+
+    CommandExt::new("rustup")
+        .arg("toolchain")
+        .arg("install")
+        .arg(toolchain)
+        .args([
+            "--component",
+            "rustc-dev",
+            "--component",
+            "llvm-tools-preview",
+        ])
+        .ensure_status(auto_install)
+        .context(format!("failed to install toolchain `{toolchain}`"))?;
+
+    Ok(())
+}

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -3,7 +3,7 @@ use semver::{Comparator, Version, VersionReq};
 use crate::bin_target::BinTarget;
 
 use super::{
-    CommandExt,
+    CommandExt, Package,
     arg_builder::ArgBuilder,
     cargo::{install::AutoInstall, metadata::Metadata},
 };
@@ -35,20 +35,23 @@ pub(crate) fn bundle(
         .map(|package| package.version.clone())
         .ok_or_else(|| anyhow::anyhow!("Failed to find wasm-bindgen"))?;
 
+    let package = Package {
+        name: PACKAGE.into(),
+        version: Some(VersionReq {
+            comparators: vec![Comparator {
+                // The wasm-bindgen versions need to match exactly
+                op: semver::Op::Exact,
+                major,
+                minor: Some(minor),
+                patch: Some(patch),
+                pre,
+            }],
+        }),
+        ..Default::default()
+    };
+
     CommandExt::new(PROGRAM)
-        .require_package(
-            PACKAGE,
-            VersionReq {
-                comparators: vec![Comparator {
-                    // The wasm-bindgen versions need to match exactly
-                    op: semver::Op::Exact,
-                    major,
-                    minor: Some(minor),
-                    patch: Some(patch),
-                    pre,
-                }],
-            },
-        )
+        .require_package(package)
         .args(
             ArgBuilder::new()
                 .arg("--no-typescript")

--- a/src/external_cli/wasm_opt.rs
+++ b/src/external_cli/wasm_opt.rs
@@ -1,11 +1,10 @@
 use std::{fs, time::Instant};
 
-use semver::VersionReq;
 use tracing::info;
 
 use crate::{
     bin_target::BinTarget,
-    external_cli::{CommandExt, cargo::install::AutoInstall},
+    external_cli::{CommandExt, Package, cargo::install::AutoInstall},
 };
 
 pub(crate) const PACKAGE: &str = "wasm-opt";
@@ -25,8 +24,13 @@ pub(crate) fn optimize_path(
     let start = Instant::now();
     let size_before = fs::metadata(&path)?.len();
 
+    let package = Package {
+        name: PACKAGE.into(),
+        ..Default::default()
+    };
+
     CommandExt::new(PROGRAM)
-        .require_package(PACKAGE, VersionReq::STAR)
+        .require_package(package)
         .arg("--strip-debug")
         .arg("-Os")
         .arg("-o")

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,109 +1,72 @@
-use anyhow::{anyhow, ensure, Context};
-use std::{env, path::PathBuf};
+use clap::Args;
 
-use crate::external_cli::{cargo::install::AutoInstall, CommandExt};
+use crate::external_cli::cargo::install::AutoInstall;
+
+#[derive(Debug, Args, Clone)]
+pub struct LintArgs {
+    /// Confirm all prompts automatically.
+    #[arg(long = "yes", default_value_t = false)]
+    pub confirm_prompts: bool,
+
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub cargo_check_args: Vec<String>,
+}
+
+impl LintArgs {
+    /// Whether to automatically install missing dependencies.
+    // Only needed with the `rustup` feature
+    #[allow(dead_code)]
+    pub(crate) fn auto_install(&self) -> AutoInstall {
+        if self.confirm_prompts {
+            AutoInstall::Always
+        } else {
+            AutoInstall::AskUser
+        }
+    }
+}
 
 /// Runs `bevy_lint`, if it is installed, with the given arguments.
 ///
 /// Calling `lint(vec!["--workspace"])` is equivalent to calling `bevy_lint --workspace` in the
 /// terminal. This will run [`find_bevy_lint()`] to locate `bevy_lint`.
-pub fn lint(args: Vec<String>) -> anyhow::Result<()> {
-    if let Ok(bevy_lint_path) = find_bevy_lint() {
-        let status = CommandExt::new(bevy_lint_path)
-            .args(args)
-            .ensure_status(AutoInstall::Never)?;
-
-        ensure!(
-            status.success(),
-            "`bevy_lint` exited with a non-zero exit code."
-        );
-        return Ok(());
-    }
-
-    #[cfg(feature = "rustup")]
-    install_linter()?;
-    Ok(())
-}
-
-/// Tries the find the path to `bevy_lint`, if it is installed.
-///
-/// The current strategy will find a file named `bevy_lint(.exe)` within the same directory as the
-/// current executable, which is usually `~/.cargo/bin` or `target/debug`. It will **not** search
-/// the `PATH`.
-fn find_bevy_lint() -> anyhow::Result<PathBuf> {
-    let mut bevy_lint_path = env::current_exe()
-        .context("Failed to retrieve the path to the current executable.")?
-        .parent()
-        .ok_or(anyhow!("Path to file must have a parent."))?
-        .join("bevy_lint");
-
-    #[cfg(target_os = "windows")]
-    bevy_lint_path.set_extension("exe");
-
-    if cfg!(debug_assertions) {
-        ensure!(
-            bevy_lint_path.exists(),
-            "`bevy_lint` could not be found at {}. Please run `cargo build -p bevy_lint` first!",
-            bevy_lint_path.display(),
-        );
-    } else {
-        ensure!(
-            bevy_lint_path.exists(),
-            "`bevy_lint` could not be found at {}. Please follow the instructions at <https://thebevyflock.github.io/bevy_cli/bevy_lint/#installation> to install it.",
-            bevy_lint_path.display(),
-        );
-    }
-
-    bevy_lint_path = bevy_lint_path.canonicalize()?;
-
-    Ok(bevy_lint_path)
-}
-
 #[cfg(feature = "rustup")]
-fn install_linter() -> anyhow::Result<()> {
+pub fn lint(args: LintArgs) -> anyhow::Result<()> {
+    use crate::external_cli::Package;
+    use anyhow::{Context, ensure};
     use toml_edit::DocumentMut;
+
     const RUST_TOOLCHAIN: &str = include_str!("../rust-toolchain.toml");
     const BEVY_LINT_TAG: &str = "lint-v0.3.0";
-
-    // TODO: pass AutoInstall args
-    let auto_install = AutoInstall::Always;
+    const PACKAGE: &str = "bevy_lint";
+    const GIT_URL: &str = "https://github.com/TheBevyFlock/bevy_cli.git";
 
     let rust_toolchain = RUST_TOOLCHAIN
         .parse::<DocumentMut>()
-        .expect("Failed to parse `rust-toolchain.toml`.");
+        .context("Failed to parse `rust-toolchain.toml`.")?;
 
     let channel = rust_toolchain["toolchain"]["channel"]
         .as_str()
-        .expect("Could not find `toolchain.channel` key in `rust-toolchain.toml`.");
+        .context("Could not find `toolchain.channel` key in `rust-toolchain.toml`.")?;
 
-    CommandExt::new("rustup")
-        .arg("toolchain")
-        .arg("install")
-        .arg(channel)
-        .args([
-            "--component",
-            "rustc-dev",
-            "--component",
-            "llvm-tools-preview",
-        ])
-        .ensure_status(auto_install)
-        .context(format!("failed to install toolchain `{channel}`"))?;
+    let package = Package {
+        name: PACKAGE.into(),
+        required_toolchain: Some(channel.to_string()),
+        url: Some(GIT_URL.to_string()),
+        tag: Some(BEVY_LINT_TAG.to_string()),
+        ..Default::default()
+    };
 
-    CommandExt::new("rustup")
-        .arg("run")
-        .arg(channel)
-        .arg("cargo")
-        .arg("install")
-        .args([
-            "--git",
-            "https://github.com/TheBevyFlock/bevy_cli.git",
-            "--tag",
-            BEVY_LINT_TAG,
-            "--locked",
-            "bevy_lint",
-        ])
-        .ensure_status(auto_install)
-        .context(format!("failed to install bevy_lint `{BEVY_LINT_TAG}`"))?;
+    let auto_install = args.auto_install();
+
+    let status = crate::external_cli::CommandExt::new("bevy_lint")
+        .require_package(package)
+        .args(args.cargo_check_args)
+        .ensure_status(auto_install)?;
+
+    ensure!(
+        status.success(),
+        "`bevy_lint` exited with a non-zero exit code."
+    );
 
     Ok(())
 }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -8,6 +8,7 @@ pub struct LintArgs {
     #[arg(long = "yes", default_value_t = false)]
     pub confirm_prompts: bool,
 
+    /// Arguments to forward to `cargo check`.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub cargo_check_args: Vec<String>,
 }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,15 +1,7 @@
-use anyhow::{Context, anyhow, ensure};
+use anyhow::{anyhow, ensure, Context};
 use std::{env, path::PathBuf};
 
-#[cfg(feature = "rustup")]
-use toml_edit::DocumentMut;
-
-use crate::external_cli::{CommandExt, cargo::install::AutoInstall};
-
-#[cfg(feature = "rustup")]
-const RUST_TOOLCHAIN: &str = include_str!("../rust-toolchain.toml");
-
-const BEVY_LINT_TAG: &str = "lint-v0.3.0";
+use crate::external_cli::{cargo::install::AutoInstall, CommandExt};
 
 /// Runs `bevy_lint`, if it is installed, with the given arguments.
 ///
@@ -27,6 +19,7 @@ pub fn lint(args: Vec<String>) -> anyhow::Result<()> {
         );
         return Ok(());
     }
+
     #[cfg(feature = "rustup")]
     install_linter()?;
     Ok(())
@@ -66,7 +59,12 @@ fn find_bevy_lint() -> anyhow::Result<PathBuf> {
     Ok(bevy_lint_path)
 }
 
+#[cfg(feature = "rustup")]
 fn install_linter() -> anyhow::Result<()> {
+    use toml_edit::DocumentMut;
+    const RUST_TOOLCHAIN: &str = include_str!("../rust-toolchain.toml");
+    const BEVY_LINT_TAG: &str = "lint-v0.3.0";
+
     // TODO: pass AutoInstall args
     let auto_install = AutoInstall::Always;
 

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,24 +1,34 @@
 use anyhow::{Context, anyhow, ensure};
 use std::{env, path::PathBuf};
 
+#[cfg(feature = "rustup")]
+use toml_edit::DocumentMut;
+
 use crate::external_cli::{CommandExt, cargo::install::AutoInstall};
+
+#[cfg(feature = "rustup")]
+const RUST_TOOLCHAIN: &str = include_str!("../rust-toolchain.toml");
+
+const BEVY_LINT_TAG: &str = "lint-v0.3.0";
 
 /// Runs `bevy_lint`, if it is installed, with the given arguments.
 ///
 /// Calling `lint(vec!["--workspace"])` is equivalent to calling `bevy_lint --workspace` in the
 /// terminal. This will run [`find_bevy_lint()`] to locate `bevy_lint`.
 pub fn lint(args: Vec<String>) -> anyhow::Result<()> {
-    let bevy_lint_path = find_bevy_lint()?;
+    if let Ok(bevy_lint_path) = find_bevy_lint() {
+        let status = CommandExt::new(bevy_lint_path)
+            .args(args)
+            .ensure_status(AutoInstall::Never)?;
 
-    let status = CommandExt::new(bevy_lint_path)
-        .args(args)
-        .ensure_status(AutoInstall::Never)?;
-
-    ensure!(
-        status.success(),
-        "`bevy_lint` exited with a non-zero exit code."
-    );
-
+        ensure!(
+            status.success(),
+            "`bevy_lint` exited with a non-zero exit code."
+        );
+        return Ok(());
+    }
+    #[cfg(feature = "rustup")]
+    install_linter()?;
     Ok(())
 }
 
@@ -27,7 +37,7 @@ pub fn lint(args: Vec<String>) -> anyhow::Result<()> {
 /// The current strategy will find a file named `bevy_lint(.exe)` within the same directory as the
 /// current executable, which is usually `~/.cargo/bin` or `target/debug`. It will **not** search
 /// the `PATH`.
-pub fn find_bevy_lint() -> anyhow::Result<PathBuf> {
+fn find_bevy_lint() -> anyhow::Result<PathBuf> {
     let mut bevy_lint_path = env::current_exe()
         .context("Failed to retrieve the path to the current executable.")?
         .parent()
@@ -54,4 +64,48 @@ pub fn find_bevy_lint() -> anyhow::Result<PathBuf> {
     bevy_lint_path = bevy_lint_path.canonicalize()?;
 
     Ok(bevy_lint_path)
+}
+
+fn install_linter() -> anyhow::Result<()> {
+    // TODO: pass AutoInstall args
+    let auto_install = AutoInstall::Always;
+
+    let rust_toolchain = RUST_TOOLCHAIN
+        .parse::<DocumentMut>()
+        .expect("Failed to parse `rust-toolchain.toml`.");
+
+    let channel = rust_toolchain["toolchain"]["channel"]
+        .as_str()
+        .expect("Could not find `toolchain.channel` key in `rust-toolchain.toml`.");
+
+    CommandExt::new("rustup")
+        .arg("toolchain")
+        .arg("install")
+        .arg(channel)
+        .args([
+            "--component",
+            "rustc-dev",
+            "--component",
+            "llvm-tools-preview",
+        ])
+        .ensure_status(auto_install)
+        .context(format!("failed to install toolchain `{channel}`"))?;
+
+    CommandExt::new("rustup")
+        .arg("run")
+        .arg(channel)
+        .arg("cargo")
+        .arg("install")
+        .args([
+            "--git",
+            "https://github.com/TheBevyFlock/bevy_cli.git",
+            "--tag",
+            BEVY_LINT_TAG,
+            "--locked",
+            "bevy_lint",
+        ])
+        .ensure_status(auto_install)
+        .context(format!("failed to install bevy_lint `{BEVY_LINT_TAG}`"))?;
+
+    Ok(())
 }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -51,7 +51,7 @@ pub fn lint(args: LintArgs) -> anyhow::Result<()> {
     let package = Package {
         name: PACKAGE.into(),
         required_toolchain: Some(channel.to_string()),
-        url: Some(GIT_URL.to_string()),
+        git: Some(GIT_URL.to_string()),
         tag: Some(BEVY_LINT_TAG.to_string()),
         ..Default::default()
     };


### PR DESCRIPTION
Allows installing `bevy_lint` `lint-v0.3.0`.

# Testing

**`bevy_lint` is already installed**
<details>

```sh
❯ bevy lint -v
debug: running: `bevy_lint`
warning: unconventional type name for a `SystemSet`
  --> src/lib.rs:61:6
   |
61 | enum AppSet {
   |      ^^^^^^ help: rename `AppSet`: `AppSystems`
   |
note: structures that implement `SystemSet` should end in `Systems`
  --> src/lib.rs:61:6
   |
61 | enum AppSet {
   |      ^^^^^^
note: `SystemSet` implemented here
  --> src/lib.rs:60:10
   |
60 | #[derive(SystemSet, Debug, Clone, Copy, Eq, PartialEq, Hash, PartialOrd, Ord)]
   |          ^^^^^^^^^
   = note: `#[warn(bevy::unconventional_naming)]` on by default
   = note: this warning originates in the derive macro `SystemSet` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `bevy_new_2d` (lib) generated 1 warning
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.28s
```
</details>

**`bevy_lint` is not installed but the toolchain is**
<details>

```sh
❯ cargo uninstall bevy_lint
❯ bevy_lint
zsh: command not found: bevy_lint
❯ bevy lint -v
debug: running: `bevy_lint`
warning: failed to run bevy_lint, trying to find automatic fix...
debug: running: `rustup toolchain list`
debug: running: `bevy_lint --version`
`bevy_lint` is missing, should I install it for you? yes
debug: running: `rustup run nightly-2025-04-03 cargo install --git https://github.com/TheBevyFlock/bevy_cli.git --tag lint-v0.3.0 --locked bevy_lint`
   Installed package `bevy_lint v0.3.0 (https://github.com/TheBevyFlock/bevy_cli.git?tag=lint-v0.3.0#7005713b)` (executables `bevy_lint`, `bevy_lint_driver`)
warning: unconventional type name for a `SystemSet`
  --> src/lib.rs:61:6
   |
61 | enum AppSet {
   |      ^^^^^^ help: rename `AppSet`: `AppSystems`
   |
note: structures that implement `SystemSet` should end in `Systems`
  --> src/lib.rs:61:6
   |
61 | enum AppSet {
   |      ^^^^^^
note: `SystemSet` implemented here
  --> src/lib.rs:60:10
   |
60 | #[derive(SystemSet, Debug, Clone, Copy, Eq, PartialEq, Hash, PartialOrd, Ord)]
   |          ^^^^^^^^^
   = note: `#[warn(bevy::unconventional_naming)]` on by default
   = note: this warning originates in the derive macro `SystemSet` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `bevy_new_2d` (lib) generated 1 warning
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.35s
```
</details>

**Both `bevy_lint` and the needed toolchain are not installed**

<details>

```sh
❯ cargo uninstall bevy_lint
❯ rustup toolchain uninstall nightly-2025-04-03-aarch64-apple-darwin
❯ bevy lint -v
debug: running: `bevy_lint`
warning: failed to run bevy_lint, trying to find automatic fix...
debug: running: `rustup toolchain list`
rust toolchain `nightly-2025-04-03` is missing, should I install it for you? yes
info: Installing missing rust toolchain: `nightly-2025-04-03`
debug: running: `rustup toolchain install nightly-2025-04-03 --component rustc-dev --component llvm-tools-preview`
info: syncing channel updates for 'nightly-2025-04-03-aarch64-apple-darwin'
info: latest update on 2025-04-03, rust version 1.88.0-nightly (d5b4c2e4f 2025-04-02)
info: downloading component 'cargo'
  7.4 MiB /   7.4 MiB (100 %)   2.4 MiB/s in  2s
info: downloading component 'clippy'
info: downloading component 'llvm-tools'
 49.9 MiB /  49.9 MiB (100 %)  16.6 MiB/s in  4s
info: downloading component 'rust-docs'
 19.7 MiB /  19.7 MiB (100 %)   7.8 MiB/s in  3s
info: downloading component 'rust-std'
 27.5 MiB /  27.5 MiB (100 %)   2.6 MiB/s in  2s
info: downloading component 'rustc'
 60.4 MiB /  60.4 MiB (100 %)  13.0 MiB/s in  4s
info: downloading component 'rustc-dev'
105.8 MiB / 105.8 MiB (100 %)  20.4 MiB/s in  5s
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'llvm-tools'
 49.9 MiB /  49.9 MiB (100 %)  21.6 MiB/s in  2s
info: installing component 'rust-docs'
 19.7 MiB /  19.7 MiB (100 %)   3.7 MiB/s in  3s
info: installing component 'rust-std'
 27.5 MiB /  27.5 MiB (100 %)  21.2 MiB/s in  1s
info: installing component 'rustc'
 60.4 MiB /  60.4 MiB (100 %)  23.0 MiB/s in  2s
info: installing component 'rustc-dev'
105.8 MiB / 105.8 MiB (100 %)  21.1 MiB/s in  5s
info: installing component 'rustfmt'

  nightly-2025-04-03-aarch64-apple-darwin installed - rustc 1.88.0-nightly (d5b4c2e4f 2025-04-02)

info: checking for self-update
debug: running: `bevy_lint --version`
`bevy_lint` is missing, should I install it for you? yes
debug: running: `rustup run nightly-2025-04-03 cargo install --git https://github.com/TheBevyFlock/bevy_cli.git --tag lint-v0.3.0 --locked bevy_lint`
   Installed package `bevy_lint v0.3.0 (https://github.com/TheBevyFlock/bevy_cli.git?tag=lint-v0.3.0#7005713b)` (executables `bevy_lint`, `bevy_lint_driver`)
warning: unconventional type name for a `SystemSet`
  --> src/lib.rs:61:6
   |
61 | enum AppSet {
   |      ^^^^^^ help: rename `AppSet`: `AppSystems`
   |
note: structures that implement `SystemSet` should end in `Systems`
  --> src/lib.rs:61:6
   |
61 | enum AppSet {
   |      ^^^^^^
note: `SystemSet` implemented here
  --> src/lib.rs:60:10
   |
60 | #[derive(SystemSet, Debug, Clone, Copy, Eq, PartialEq, Hash, PartialOrd, Ord)]
   |          ^^^^^^^^^
   = note: `#[warn(bevy::unconventional_naming)]` on by default
   = note: this warning originates in the derive macro `SystemSet` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `bevy_new_2d` (lib) generated 1 warning
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.37s
```
</details>

# Future Work

I would like to add an `install` subcommand to the `lint` command that you can pass the `toolchain` and the `tag` (or maybe commit / branch), so you could also install more freely.

If we want to be fancy, we could parse this information out ourselves by making an HTTP request first, but not sure if I like that.