### PR TITLE
Align logging to match `cargo`'s style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +391,7 @@ dependencies = [
 name = "bevy_cli"
 version = "0.1.0-dev"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ toml_edit = { version = "0.22.22", default-features = false, features = [
 # Logging crates
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+ansi_term = "0.12.1"
 
 # Web dependencies
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,3 +1,4 @@
+use ansi_term::Color::{Blue, Green, Purple, Red, Yellow};
 use anyhow::Result;
 use bevy_cli::{build::args::BuildArgs, run::RunArgs};
 use clap::{Args, CommandFactory, Parser, Subcommand};
@@ -132,15 +133,23 @@ where
         event: &tracing::Event<'_>,
     ) -> std::fmt::Result {
         let meta = event.metadata();
-        let level_str = match *meta.level() {
-            tracing::Level::ERROR => "error",
-            tracing::Level::WARN => "warning",
-            tracing::Level::INFO => "info",
-            tracing::Level::DEBUG => "debug",
-            tracing::Level::TRACE => "trace",
+
+        let (color, level) = match *meta.level() {
+            tracing::Level::ERROR => (Red, "error"),
+            tracing::Level::WARN => (Yellow, "warning"),
+            tracing::Level::INFO => (Green, "info"),
+            tracing::Level::DEBUG => (Blue, "debug"),
+            tracing::Level::TRACE => (Purple, "trace"),
         };
 
-        write!(writer, "{}: ", level_str)?;
+        // Apply color if desired
+        let level = if writer.has_ansi_escapes() {
+            color.bold().paint(level).to_string()
+        } else {
+            level.to_string()
+        };
+
+        write!(writer, "{level}: ",)?;
         ctx.format_fields(writer.by_ref(), event)?;
         writeln!(writer)
     }

--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -71,7 +71,7 @@ impl BuildArgs {
             return;
         }
 
-        tracing::debug!("Using defaults from bevy_cli config:\n{config}");
+        tracing::debug!("using defaults from bevy_cli config:\n{config}");
         if self.cargo_args.compilation_args.target.is_none() {
             self.cargo_args.compilation_args.target = config.target().map(ToOwned::to_owned);
         }

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -119,7 +119,7 @@ impl CommandExt {
 
         if self.package.is_some() || self.target.is_some() {
             tracing::warn!(
-                "Failed to run {}, trying to find automatic fix...",
+                "failed to run {}, trying to find automatic fix...",
                 self.inner.get_program().to_string_lossy()
             )
         }
@@ -211,10 +211,10 @@ impl CommandExt {
             .collect::<Vec<_>>()
             .join(",");
 
-        self.log(format!("Running: `{self}`").as_str());
+        self.log(format!("running: `{self}`").as_str());
 
         if !envs.is_empty() {
-            self.log(&format!("With env: {envs}"));
+            self.log(&format!("with env: {envs}"));
         }
     }
 
@@ -236,7 +236,7 @@ impl CommandExt {
 
         anyhow::ensure!(
             status.success(),
-            "Command `{self}` exited with status code {}",
+            "command `{self}` exited with status code {}",
             status
         );
 
@@ -261,7 +261,7 @@ impl CommandExt {
 
         anyhow::ensure!(
             output.status.success(),
-            "Command `{self}` exited with status code {}",
+            "command `{self}` exited with status code {}",
             output.status
         );
 

--- a/src/external_cli/rustup.rs
+++ b/src/external_cli/rustup.rs
@@ -55,10 +55,10 @@ pub(crate) fn install_target_if_needed<T: AsRef<OsStr>>(
     if !auto_install.confirm(format!(
         "Compilation target `{target_str}` is missing, should I install it for you?",
     ))? {
-        anyhow::bail!("User does not want to install target `{target_str}`.");
+        anyhow::bail!("user does not want to install target `{target_str}`.");
     }
 
-    info!("Installing missing target: `{target_str}`");
+    info!("installing missing target: `{target_str}`");
 
     CommandExt::new(program())
         .arg("target")

--- a/src/external_cli/wasm_opt.rs
+++ b/src/external_cli/wasm_opt.rs
@@ -20,7 +20,7 @@ pub(crate) fn optimize_path(
         .artifact_directory
         .clone()
         .join(format!("{}_bg.wasm", bin_target.bin_name));
-    info!("Optimizing with wasm-opt...");
+    info!("optimizing with wasm-opt...");
 
     let start = Instant::now();
     let size_before = fs::metadata(&path)?.len();
@@ -39,7 +39,7 @@ pub(crate) fn optimize_path(
     let duration = start.elapsed();
 
     info!(
-        "Finished in {duration:.2?}. Size reduced by {:.0}%.",
+        "finished in {duration:.2?}. Size reduced by {:.0}%.",
         size_reduction * 100.
     );
 

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -89,7 +89,7 @@ impl RunArgs {
             return;
         }
 
-        tracing::debug!("Using defaults from bevy_cli config:\n{config}");
+        tracing::debug!("using defaults from bevy_cli config:\n{config}");
         if self.cargo_args.compilation_args.target.is_none() {
             self.cargo_args.compilation_args.target = config.target().map(ToOwned::to_owned);
         }

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -45,7 +45,7 @@ pub fn build_web(
 
     let cargo_args = args.cargo_args_builder();
 
-    info!("Compiling to WebAssembly...");
+    info!("compiling to WebAssembly...");
 
     cargo::build::command()
         // Wasm targets are not installed by default
@@ -54,7 +54,7 @@ pub fn build_web(
         .env("RUSTFLAGS", args.cargo_args.common_args.rustflags.clone())
         .ensure_status(args.auto_install())?;
 
-    info!("Bundling JavaScript bindings...");
+    info!("bundling JavaScript bindings...");
     wasm_bindgen::bundle(metadata, bin_target, args.auto_install())?;
 
     #[cfg(feature = "wasm-opt")]
@@ -68,10 +68,10 @@ pub fn build_web(
         bin_target,
         web_args.create_packed_bundle,
     )
-    .context("Failed to create web bundle")?;
+    .context("failed to create web bundle")?;
 
     if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
-        info!("Created bundle at file://{}", path.display());
+        info!("created bundle at file://{}", path.display());
     }
 
     Ok(web_bundle)

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -84,7 +84,7 @@ pub fn create_web_bundle(
     let index = if index_path.exists() {
         Index::File(index_path)
     } else {
-        info!("No custom `web` folder found, using defaults.");
+        info!("no custom `web` folder found, using defaults.");
         Index::Content(default_index(bin_target))
     };
 
@@ -119,7 +119,7 @@ pub fn create_web_bundle(
 
     // Build artifacts
     tracing::debug!(
-        "Copying build artifacts from file://{}",
+        "copying build artifacts from file://{}",
         linked.build_artifact_path.to_string_lossy()
     );
     fs::create_dir_all(base_path.join("build"))?;
@@ -137,7 +137,7 @@ pub fn create_web_bundle(
     // Assets
     if let Some(assets_path) = linked.assets_path {
         tracing::debug!(
-            "Copying assets from file://{}",
+            "copying assets from file://{}",
             assets_path.to_string_lossy()
         );
         fs_extra::dir::copy(
@@ -154,7 +154,7 @@ pub fn create_web_bundle(
     // Custom web assets
     if custom_web_folder.exists() {
         tracing::debug!(
-            "Copying custom web assets from file://{}",
+            "copying custom web assets from file://{}",
             custom_web_folder.to_string_lossy()
         );
         fs_extra::dir::copy(
@@ -170,7 +170,7 @@ pub fn create_web_bundle(
     }
 
     // Index (pre-processed)
-    tracing::debug!("Writing index.html");
+    tracing::debug!("writing index.html");
     fs::write(base_path.join("index.html"), &index)
         .context("failed to write processed index.html")?;
 

--- a/src/web/run.rs
+++ b/src/web/run.rs
@@ -43,15 +43,15 @@ pub(crate) fn run_web(
     // Serving the app is blocking, so we open the page first
     if web_args.open {
         match webbrowser::open(&url) {
-            Ok(()) => info!("Your app is running at <{url}>!"),
+            Ok(()) => info!("your app is running at <{url}>!"),
             Err(error) => {
                 error!(
-                    "Failed to open the browser automatically, open the app at <{url}>. (Error: {error:?})"
+                    "failed to open the browser automatically, open the app at <{url}>. (Error: {error:?})"
                 );
             }
         }
     } else {
-        info!("Open your app at <{url}>!");
+        info!("open your app at <{url}>!");
     }
 
     serve(web_bundle, port, header_map)?;

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -48,7 +48,7 @@ pub(crate) async fn serve(
     let mut router = Router::new();
 
     if !header_map.is_empty() {
-        tracing::debug!("Adding response headers {header_map:?}");
+        tracing::debug!("adding response headers {header_map:?}");
     }
 
     match web_bundle.clone() {


### PR DESCRIPTION
# Objective

Closes #360.

Where possible, we should provide a familiar experience to users, matching what they are used to from `cargo`.
Our log message format currently looks quite different.

# Solution

Use a custom formatter for `tracing` logging.

- Use lower-case log levels with a colon
- Adjust log messages to start with a lowercase letter, similar to what cargo does

![Preview of the new log format](https://github.com/user-attachments/assets/11dc0302-0bd1-41cc-a2fb-87afd4767f58)

# Future Work

Some of our messages are part of the build process and will be adjusted to look closer to the `Finished` messages `cargo` generates. See #362.