### PR TITLE
Rename `default_features` to `default-features`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ features = [
 
 [package.metadata.bevy_cli.web]
 # Disable default features for web builds
-default_features = false
+default-features = false
 ```
 
 ### Usage in CI

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use crate::external_cli::cargo::metadata::{Metadata, Package};
 /// - Whether to enable default features
 /// - Additional Rust compiler flags
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct CliConfig {
     /// The platform to target with the build.
     target: Option<String>,
@@ -197,16 +198,16 @@ fn extract_features(cli_metadata: &Map<String, Value>) -> anyhow::Result<Vec<Str
     }
 }
 
-/// Try to extract whether default_features are enabled from a metadata map for the CLI.
+/// Try to extract whether default-features are enabled from a metadata map for the CLI.
 fn extract_default_features(cli_metadata: &Map<String, Value>) -> anyhow::Result<Option<bool>> {
-    let Some(default_features) = cli_metadata.get("default_features") else {
+    let Some(default_features) = cli_metadata.get("default-features") else {
         return Ok(None);
     };
 
     match default_features {
         Value::Bool(default_features) => Ok(Some(default_features).copied()),
         Value::Null => Ok(None),
-        _ => bail!("default_features must be an array"),
+        _ => bail!("default-features must be an array"),
     }
 }
 
@@ -269,7 +270,7 @@ mod tests {
                 },
                 "web": {
                     "features": ["web"],
-                    "default_features": false,
+                    "default-features": false,
                     "dev": {
                         "features": ["web-dev"],
                         "rustflags": ["--cfg","getrandom_backend=\"wasm_js\""]
@@ -308,7 +309,7 @@ mod tests {
                 },
                 "native": {
                     "features": ["native"],
-                    "default_features": false,
+                    "default-features": false,
                     "release": {
                         "features": ["native-release"],
                         "rustflags": ["-C debuginfo=1"]
@@ -316,7 +317,7 @@ mod tests {
                 },
                 "web": {
                     "features": ["web"],
-                    "default_features": false,
+                    "default-features": false,
                     "rustflags": ["--cfg","getrandom_backend=\"wasm_js\""]
                 }
             });
@@ -348,11 +349,11 @@ mod tests {
                         "bevy/bevy_dev_tools",
                         "bevy/bevy_ui_debug"
                     ],
-                    "default_features": true,
+                    "default-features": true,
                 },
                 "web": {
                     "features": ["web"],
-                    "default_features": false,
+                    "default-features": false,
                     "dev": {
                         "features": ["web-dev"],
                     }
@@ -394,11 +395,11 @@ mod tests {
                 "dev": {
                     "rustflags": ["-C opt-level=2"],
                     "features": ["dev"],
-                    "default_features": true,
+                    "default-features": true,
                 },
                 "web": {
                     "features": ["web"],
-                    "default_features": false,
+                    "default-features": false,
                     "rustflags": ["--cfg","getrandom_backend=\"wasm_js\""],
                     "dev": {
                         "rustflags": ["-C debuginfo=1"],


### PR DESCRIPTION
closes #407 

Cargo.toml:

```toml
[package.metadata.bevy_cli.web.dev]
# Disable native-only debug functionality in web builds.
default-features = false
features = ["dev"]
```
output:

```sh
❯ bevy run web -v
debug: using defaults from bevy_cli config:
      features = ["dev"]
      default-features = false
      rustflags = ["--cfg", 'getrandom_backend="wasm_js"']
```