### PR TITLE
parse linter config with cargo metadata

### DIFF
--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -41,6 +41,8 @@ cargo_metadata = "0.19"
 
 # Configuration deserialization.
 serde = { version = "1.0.210", features = ["derive"] }
+# Used to deserialize `--message-format=json` messages from Cargo.
+serde_json = "1.0.140"
 toml = { version = "0.8.19", default-features = false, features = ["parse"] }
 
 [build-dependencies]
@@ -52,10 +54,6 @@ toml_edit = { version = "0.22.22", default-features = false, features = [
 [dev-dependencies]
 # Used when running UI tests.
 bevy = { version = "0.16.0", default-features = false, features = ["std"] }
-
-# Used to deserialize `--message-format=json` messages from Cargo.
-serde_json = "1.0.140"
-
 # Ensures the error messages for lints do not regress.
 ui_test = "0.29.2"
 


### PR DESCRIPTION
Implementation for parsing out the linter config with `cargo-metadata` #334.

I personally prefer deserializing the `Cargo.toml` to `toml` and then parsing the metadata out over this. I can add some performance comparisons if needed, but I expect the `cargo-metadata` implementation to be way slower.

**Some Observations:**

1. We need to create a linter config for each `package` that contains the `workspace` config (if present) merged with that `package`'s config.

But the `bevy_lint_driver` is called for each crate target, meaning we could build the same config multiple times.

2. Its "trickier" to get the `metadata` of the current package because we can not know that package's name.

<details>

In this repository: https://github.com/TimJentzsch/bevy_complex_repo/tree/main

```sh
❯ cargo metadata --no-deps | jq
```

lists all packages in this workspace, but from where do we know which of these we should read the metadata table from?

but with

```sh
 ❯ cargo metadata --format-version 1 | jq -r '
  .packages[] as $pkg
  | select($pkg.id == .resolve.root)
  | $pkg.name'
cplx_demo
```
We always get the "current" package but have additional overhead.
</details>

3. The resulting code in the end is more or less identical, with the difference that in my opinion, toml is easier to work with for us and we need to depend on it anyway