### PR TITLE
Shrink sizes of CI caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  # Only include the debug info necessary for backtraces (file names and line numbers). Any extra
+  # debug info provided by `debuginfo=1` or `debuginfo=2` require an interactive debugger like
+  # `lldb` or `gdb`.
+  RUSTFLAGS: -C debuginfo=line-tables-only
+
 jobs:
   extract-rust-version:
     uses: ./.github/workflows/extract-rust-version.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   extract-rust-version:
     uses: ./.github/workflows/extract-rust-version.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,12 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  # Only include the debug info necessary for backtraces (file names and line numbers). Any extra
+  # debug info provided by `debuginfo=1` or `debuginfo=2` require an interactive debugger like
+  # `lldb` or `gdb`.
+  RUSTFLAGS: -C debuginfo=line-tables-only
+
 jobs:
   extract-rust-version:
     uses: ./.github/workflows/extract-rust-version.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-env:
-  CARGO_TERM_COLOR: always
-
 # Only allow one deployment to run at a time, however do not cancel runs in progress.
 concurrency:
   group: pages

--- a/.github/workflows/linter-action.yml
+++ b/.github/workflows/linter-action.yml
@@ -9,9 +9,6 @@ on:
       - bevy_lint/action.yml
   workflow_dispatch:
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   install-linter:
     name: Install `bevy_lint`


### PR DESCRIPTION
As noticed in @benfrankel in https://github.com/TheBevyFlock/bevy_new_2d/pull/396, a lot of our CI cache size is taken up by debug info that we cannot use, since it requires a debugger like `lldb` or `gdb`. This PR sets `debuginfo=line-tables-only`, which instructs the compiler to only include enough debug information to produce file names and line numbers in backtraces (which can be displayed when a program panics).

Hopefully the end result is that this should cut away a couple 100 MB of cache sizes, speeding up CI times without hurting our ability to read panic backtraces.

(I also removed the `CARGO_TERM_COLOR` variable, since `dtolnay/rust-toolchain` automatically sets it for us.)