### PR TITLE
Add `wasm-opt` to default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "bevy"
 path = "src/bin/main.rs"
 
 [features]
-default = ["rustup", "web"]
+default = ["rustup", "web", "wasm-opt"]
 
 # To optimize the Wasm binaries
 wasm-opt = ["web"]


### PR DESCRIPTION
According to @DaAlbrecht this was off by default for compile times, but since now we optionally install it ad-hoc on web release builds, I'd enable it by default. Note that this being disabled currently lead me to mistakenly have none of my web builds `wasm-opt`ed because I just assumed the Bevy CLI would do it for me.