### PR TITLE
Fix serving of custom web folders

### DIFF
--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -39,6 +39,8 @@ pub struct LinkedBundle {
     pub js_file_name: OsString,
     /// The path to the Bevy assets folder, if it exists.
     pub assets_path: Option<PathBuf>,
+    /// The path to the custom `web` folder, if provided by the user.
+    pub web_assets: Option<PathBuf>,
     /// The index file to serve.
     pub index: Index,
 }
@@ -94,11 +96,10 @@ pub fn create_web_bundle(
         build_artifact_path: bin_target.artifact_directory.clone(),
         wasm_file_name,
         js_file_name,
-        assets_path: if assets_path.exists() {
-            Some(assets_path.to_owned())
-        } else {
-            None
-        },
+        assets_path: assets_path.exists().then(|| assets_path.to_owned()),
+        web_assets: custom_web_folder
+            .exists()
+            .then(|| custom_web_folder.to_owned()),
         index: Index::Content(index.clone()),
     };
 

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -97,7 +97,7 @@ pub(crate) async fn serve(
 
             match index {
                 Index::File(path) => {
-                    router = router.route_service("/", ServeDir::new(path));
+                    router = router.route_service("/", ServeFile::new(path));
                 }
                 Index::Content(content) => {
                     // Try to inject the auto reload script in the document body

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -63,6 +63,7 @@ pub(crate) async fn serve(
             js_file_name,
             index,
             assets_path,
+            web_assets,
         }) => {
             router = router
                 .route_service(
@@ -117,6 +118,11 @@ pub(crate) async fn serve(
                         }),
                     );
                 }
+            }
+
+            // Try to serve anything else from the custom web assets, if provided
+            if let Some(web_assets) = web_assets {
+                router = router.fallback_service(ServeDir::new(web_assets));
             }
         }
     }


### PR DESCRIPTION
# Objective

Fixes #421.

If you provided a custom web folder with more than just `index.html`, it wasn't served correctly by the local web server.

# Solution

Always include the custom web folder as a fall-back.

# Testing

Install the CLI from this branch:

```sh
cargo install --git https://github.com/TheBevyFlock/bevy_cli --branch 421-fix-custom-web-folders --locked bevy_cli
```

Then use `bevy run web` on a project with a custom web folder, including other files in that folder. Check that these files are served correctly.

You can also test `bevy run web --bundle`, but that was already working for me on latest `main`.