### PR TITLE
Fix "mdbook-lintcheck" typo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,8 +58,8 @@ jobs:
       # We cannot use `cargo-binstall` for this because the precompiled binary uses too old of an
       # `mdbook` version, and it does't recognize the Rust 2024 edition. The installed binary will
       # be cached, however.
-      - name: Install `mdbook-lintcheck`
-        run: cargo install mdbook-lintcheck
+      - name: Install `mdbook-linkcheck`
+        run: cargo install mdbook-linkcheck
 
       - name: Build `mdbook` docs
         run: mdbook build

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -56,4 +56,4 @@ exclude = ["/api/bevy_lint"]
 # places a burden on those websites when checked constantly, so this should only be enabled
 # manually.
 follow-web-links = false
-user-agent = "mdbook-lintcheck/0.7.7 (https://github.com/TheBevyFlock/bevy_cli)"
+user-agent = "mdbook-linkcheck/0.7.7 (https://github.com/TheBevyFlock/bevy_cli)"


### PR DESCRIPTION
CI [failed to build the docs](https://github.com/TheBevyFlock/bevy_cli/actions/runs/15098836218/job/42437102756) because I misspelled "linkcheck" for "lintcheck". Whoops 🫠