### PR TITLE
Fix website 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
       - name: Run rustfmt
         run: cargo fmt --all --check
 
-  docs:
-    name: Build docs
+  rustdoc:
+    name: Build with `rustdoc`
     needs: extract-rust-version
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,8 @@ jobs:
     name: Extract Rust version
     uses: ./.github/workflows/extract-rust-version.yml
 
-  build-lint-docs:
-    name: Build `bevy_lint` docs
+  build-docs:
+    name: Build docs
     runs-on: ubuntu-latest
     needs: extract-rust-version
     steps:
@@ -93,7 +93,7 @@ jobs:
     # `publish-website`.
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.publish-website) }}
     runs-on: ubuntu-latest
-    needs: build-lint-docs
+    needs: build-docs
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,12 +80,12 @@ jobs:
 
           # Move the outputs of `rustdoc` into the `api` folder.
           mkdir docs/book/api
-          mv target/doc/* docs/book/api
+          mv target/doc/* docs/book/html/api
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/book
+          path: docs/book/html
 
   deploy:
     name: Deploy docs


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fa0e334c-872d-4f86-970d-76ba66bcb80d)

Whoops, I broke our website by introducing the linkcheck `mdbook` backend in #436! This PR fixes it (see the commit description) and also improves the names of some things in our CI.