### PR TITLE
Link directly to `all lints`

### DIFF
--- a/docs/src/linter/index.md
+++ b/docs/src/linter/index.md
@@ -2,6 +2,6 @@
 
 `bevy_lint` is a custom linter for the [Bevy game engine](https://bevyengine.org), similar to [Clippy](https://doc.rust-lang.org/stable/clippy).
 
-- [**All Lints**](../api/bevy_lint)
+- [**All Lints**](../api/bevy_lint/lints/index.html)
 - [**Repository**](https://github.com/TheBevyFlock/bevy_cli)
 - [**Issue Tracker**](https://github.com/TheBevyFlock/bevy_cli/issues?q=is%3Aopen+is%3Aissue+label%3AA-Linter)


### PR DESCRIPTION
Instead of linking to: https://thebevyflock.github.io/bevy_cli/api/bevy_lint/ we should link to: https://thebevyflock.github.io/bevy_cli/api/bevy_lint/lints/index.html