### PR TITLE
Linter troubleshooting section + small docs changes

### DIFF
--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -31,7 +31,7 @@ see <https://linebender.org/blog/doc-include/>.
 
 You can install the toolchain with:
 
-```bash
+```sh
 rustup toolchain install $TOOLCHAIN_VERSION \
     --component rustc-dev \
     --component llvm-tools-preview
@@ -43,7 +43,7 @@ For example, you would replace `$TOOLCHAIN_VERSION` with `nightly-2024-11-14` if
 
 Once you have the toolchain installed, you can compile and install `bevy_lint` through `cargo`:
 
-```bash
+```sh
 rustup run $TOOLCHAIN_VERSION cargo install \
     --git https://github.com/TheBevyFlock/bevy_cli.git \
     --tag $TAG \
@@ -57,13 +57,13 @@ Make sure to replace `$TOOLCHAIN_VERSION` and `$TAG` in the above command. The t
 
 `bevy_lint` has the same API as the `cargo check` command:
 
-```bash
+```sh
 bevy_lint --help
 ```
 
 If you have the [Bevy CLI](https://github.com/TheBevyFlock/bevy_cli) installed, the linter is also available through the `lint` subcommand:
 
-```bash
+```sh
 bevy lint --help
 ```
 

--- a/bevy_lint/tests/ui_cargo.rs
+++ b/bevy_lint/tests/ui_cargo.rs
@@ -11,7 +11,7 @@ use ui_test::{CommandBuilder, status_emitter};
 mod test_utils;
 /// This [`Config`] will run the `bevy_lint` command for all paths that end in `Cargo.toml`
 /// # Example:
-/// ```bash
+/// ```sh
 /// bevy_lint" "--quiet" "--target-dir"
 /// "../target/ui/0/tests/ui-cargo/duplicate_bevy_dependencies/fail" "--manifest-path"
 /// "tests/ui-cargo/duplicate_bevy_dependencies/fail/Cargo.toml"```

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,6 +26,7 @@
     - [Toggling Lints in Code](linter/usage/toggling-lints-code.md)
 - [Compatibility](linter/compatibility.md)
 - [Github Actions](linter/github-actions.md)
+- [Troubleshooting](linter/troubleshooting.md)
 
 ---
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -12,7 +12,7 @@
     - [Default `index.html`](cli/web/default-index-html.md)
 - [Linter](cli/linter.md)
 - [Configuration](cli/configuration.md)
-- [Configuration Reference](cli/configuration/reference.md)
+    - [Configuration Reference](cli/configuration/reference.md)
 - [Troubleshooting](cli/troubleshooting.md)
 
 # Linter User Guide

--- a/docs/src/contribute/linter/how-to/release.md
+++ b/docs/src/contribute/linter/how-to/release.md
@@ -41,7 +41,7 @@ This release uses the <!-- `nightly-YYYY-MM-DD` --> toolchain, based on Rust <!-
 
 <!-- Update `nightly-YYYY-MM-DD` and `lint-vX.Y.Z` in the following code block. -->
 
-```bash
+```sh
 rustup toolchain install nightly-YYYY-MM-DD \
     --component rustc-dev \
     --component llvm-tools-preview

--- a/docs/src/linter/install.md
+++ b/docs/src/linter/install.md
@@ -27,7 +27,7 @@ bevy lint --yes
 
 You can install the toolchain with:
 
-```bash
+```sh
 rustup toolchain install $TOOLCHAIN_VERSION \
     --component rustc-dev \
     --component llvm-tools-preview
@@ -39,7 +39,7 @@ For example, you would replace `$TOOLCHAIN_VERSION` with `nightly-2024-11-14` if
 
 Once you have the toolchain installed, you can compile and install `bevy_lint` through `cargo`:
 
-```bash
+```sh
 rustup run $TOOLCHAIN_VERSION cargo install \
     --git https://github.com/TheBevyFlock/bevy_cli.git \
     --tag $TAG \

--- a/docs/src/linter/troubleshooting.md
+++ b/docs/src/linter/troubleshooting.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+## Using with `cranelift`
+
+If you have `cranelift` setup as a custom codegen backend, you may run into the following error when running the linter:
+
+```
+error: failed to find a `codegen-backends` folder in the sysroot candidates:
+       * ~/.rustup/toolchains/nightly-2025-04-03-x86_64-unknown-linux-gnu
+       * ~/.rustup/toolchains/nightly-2025-04-03-x86_64-unknown-linux-gnu
+```
+
+This error occurs because you do not have `cranelift` installed for the specific nightly toolchain that the linter uses. You can fix this by installing `rustc-codegen-cranelift-preview` for the linter's toolchain:
+
+```sh
+rustup component add rustc-codegen-cranelift-preview --toolchain $TOOLCHAIN_VERSION
+```
+
+You can find the value of `$TOOLCHAIN_VERSION` by looking at the [compatibility table](compatibility.md) for the version of the linter you have installed.

--- a/docs/src/linter/usage.md
+++ b/docs/src/linter/usage.md
@@ -2,13 +2,13 @@
 
 `bevy_lint` has the same API as the `cargo check` command:
 
-```bash
+```sh
 bevy_lint --help
 ```
 
 If you have the [Bevy CLI](https://github.com/TheBevyFlock/bevy_cli) installed, the linter is also available through the `lint` subcommand:
 
-```bash
+```sh
 bevy lint --help
 ```
 


### PR DESCRIPTION
Closes #428.

This PR adds a "Troubleshooting" page for the linter with a guide on how to use `cranelift` with the linter.

I also included 2 drive-by fixes: one where I made our code blocks consistently use `sh` instead of mixing `bash` and `sh`, and the second where I indented the "Configuration Reference" page for the CLI.