### PR TITLE
Fix `cargo-binstall` for CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,5 +101,9 @@ assert_cmd = "2.0.16"
 tempfile = "3"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/cli-v{ version }/bevy-{ target }-v{ version }{ archive-suffix }"
+# HACK: We currently hard-code the latest version in the URL. The `{ version }` template uses the
+# version from the `main` branch's `Cargo.toml`, which is usually `X.Y.Z.-dev`, leading to the
+# binary not being found. See <https://github.com/cargo-bins/cargo-binstall/issues/2165> for more
+# information.
+pkg-url = "{ repo }/releases/download/cli-v{ version }/bevy-{ target }-v0.1.0-alpha.1{ archive-suffix }"
 pkg-fmt = "bin"

--- a/README.md
+++ b/README.md
@@ -20,25 +20,26 @@ If you need assistance or want to help, reach out to the [`bevy_cli` working gro
 
 As the CLI is currently an unofficial tool, it is not yet published to <https://crates.io>. It is available [on Github](https://github.com/TheBevyFlock/bevy_cli), however.
 
-### Precompiled Binary
-
-The CLI is precompiled for Linux, Windows, and MacOS. You may install the latest precompiled binary using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
-
-```sh
-cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
-```
-
-You can manually download the precompiled binaries from the [release page](https://github.com/TheBevyFlock/bevy_cli/releases).
-
-### Build from Source
-
 You may compile the CLI from scratch using `cargo install`. To install the latest release, make sure to specify the version you wish in the tag (ex. `--tag cli-v0.1.0-alpha.1`).
 
 ```sh
 cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-vX.Y.Z --locked bevy_cli
 ```
 
-#### Bleeding Edge
+<details>
+    <summary><strong>Precompiled Binaries</strong></summary>
+
+The CLI is precompiled for Linux, Windows, and MacOS. You may install the latest precompiled binary using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```sh
+cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version vX.Y.Z --locked bevy_cli
+```
+
+You can manually download the precompiled binaries from the [release page](https://github.com/TheBevyFlock/bevy_cli/releases).
+
+</details>
+
+### Bleeding Edge
 
 > **Here be dragons! 🐉**
 >

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -4,25 +4,26 @@
 
 As the CLI is currently an unofficial tool, it is not yet published to <https://crates.io>. It is available [on Github](https://github.com/TheBevyFlock/bevy_cli), however.
 
-## Precompiled Binary
-
-The CLI is precompiled for Linux, Windows, and MacOS. You may install the latest precompiled binary using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
-
-```sh
-cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
-```
-
-You can manually download the precompiled binaries from the [release page](https://github.com/TheBevyFlock/bevy_cli/releases).
-
-## Build from Source
-
 You may compile the CLI from scratch using `cargo install`. To install the latest release, make sure to specify the version you wish in the tag (ex. `--tag cli-v0.1.0-alpha.1`).
 
 ```sh
 cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-vX.Y.Z --locked bevy_cli
 ```
 
-### Bleeding Edge
+<details>
+    <summary><strong>Precompiled Binaries</strong></summary>
+
+The CLI is precompiled for Linux, Windows, and MacOS. You may install the latest precompiled binary using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```sh
+cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version vX.Y.Z --locked bevy_cli
+```
+
+You can manually download the precompiled binaries from the [release page](https://github.com/TheBevyFlock/bevy_cli/releases).
+
+</details>
+
+## Bleeding Edge
 
 <div class="warning">
 


### PR DESCRIPTION
#455 revealed a potential bug in `cargo-binstall` where the `{ version }` package URL template did not respect the `--version` flag (see https://github.com/cargo-bins/cargo-binstall/issues/2165).

This PR implements a temporary hack that hard-codes the latest version into the package URL instead of using `{ version }`. This fixes `cargo-binstall` until a better solution is found.

Additionally, as per @cart's [request](https://discord.com/channels/691052431525675048/1278871953721262090/1375561563863257179), this PR minimizes the `cargo-binstall` installation instructions so they are no longer the default, recommended way of doing things. We now suggest `cargo install` by default, and mention that precompiled binaries are available.