### PR TITLE
Remove `bevy_lint` has to be installed warning

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -91,9 +91,6 @@ pub enum Subcommands {
     Run(RunArgs),
     /// Check the current project using Bevy-specific lints.
     ///
-    /// This command requires `bevy_lint` to be installed, and will fail if it is not. Please see
-    /// <https://github.com/TheBevyFlock/bevy_cli> for installation instructions.
-    ///
     /// To see the full list of options, run `bevy lint -- --help`.
     #[cfg(feature = "rustup")]
     Lint(LintArgs),


### PR DESCRIPTION
# Objective

We used to have a disclaimer in the `lint` subcommand that pointed out that the linter needs to be installed or fail otherwise. This is no longer true, so we should remove it.
I also removed the 
# Before

```sh
❯ bevy lint --help
Check the current project using Bevy-specific lints.

This command requires `bevy_lint` to be installed, and will fail if it is not. Please see <https://github.com/TheBevyFlock/bevy_cli> for
installation instructions.

To see the full list of options, run `bevy lint -- --help`.

Usage: bevy lint [OPTIONS] [CARGO_CHECK_ARGS]...

Arguments:
  [CARGO_CHECK_ARGS]...
          Arguments to forward to `cargo check`

Options:
      --yes
          Confirm all prompts automatically

  -v, --verbose
          Use verbose output.

          Logs commands that are executed and more information on the actions being performed.

  -h, --help
          Print help (see a summary with '-h')
```

# Now

```sh
❯ bevy lint --help
Check the current project using Bevy-specific lints.

To see the full list of options, run `bevy lint -- --help`.

Usage: bevy lint [OPTIONS] [CARGO_CHECK_ARGS]...

Arguments:
  [CARGO_CHECK_ARGS]...
          Arguments to forward to `cargo check`

Options:
      --yes
          Confirm all prompts automatically

  -v, --verbose
          Use verbose output.

          Logs commands that are executed and more information on the actions being performed.

  -h, --help
          Print help (see a summary with '-h')
```


