### PR TITLE
Switch to `cargo_metadata` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "assert_cmd",
  "axum",
  "cargo-generate",
+ "cargo_metadata 0.20.0",
  "clap",
  "clap-cargo",
  "clap_complete",
@@ -905,7 +906,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "auth-git2",
- "cargo-util-schemas",
+ "cargo-util-schemas 0.8.1",
  "clap",
  "console",
  "dialoguer",
@@ -948,6 +949,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo-util-schemas"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver",
  "serde",
  "serde_json",
@@ -984,7 +1010,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
+dependencies = [
+ "camino",
+ "cargo-platform 0.2.0",
+ "cargo-util-schemas 0.2.0",
  "semver",
  "serde",
  "serde_json",
@@ -4469,7 +4510,7 @@ dependencies = [
  "annotate-snippets",
  "anyhow",
  "bstr",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "cargo_metadata 0.18.1",
  "color-eyre",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ regex = "1.10.6"
 # Understanding package versions
 semver = { version = "1.0.23", features = ["serde"] }
 
+# `cargo metadata` command helpers and types
+cargo_metadata = "0.20.0"
+
 # Parsing the Cargo manifest
 toml_edit = { version = "0.22.22", default-features = false, features = [
     "parse",

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,11 +2,10 @@
 use std::fmt::Display;
 
 use anyhow::{Context, bail};
+use cargo_metadata::{Metadata, Package};
 use serde::Serialize;
 use serde_json::{Map, Value};
 use tracing::warn;
-
-use crate::external_cli::cargo::metadata::{Metadata, Package};
 
 /// Configuration for the `bevy_cli`.
 ///

--- a/src/external_cli/cargo/metadata.rs
+++ b/src/external_cli/cargo/metadata.rs
@@ -1,22 +1,16 @@
-#![expect(dead_code, reason = "Will be used for bevy bump and perhaps bevy run")]
-use std::{ffi::OsStr, path::PathBuf};
-
-use anyhow::Context;
-use semver::{Version, VersionReq};
-use serde::Deserialize;
-use tracing::Level;
+use std::{ffi::OsStr, str::from_utf8};
 
 use crate::external_cli::CommandExt;
+use anyhow::Context;
+use cargo_metadata::{Metadata, MetadataCommand};
+use tracing::Level;
 
-use super::{install::AutoInstall, program};
+use super::install::AutoInstall;
 
 /// Create a command to run `cargo metadata`.
 pub(crate) fn command() -> CommandExt {
-    let mut command = CommandExt::new(program());
-    // The format version needs to be fixed for compatibility and to avoid a warning log
-    command
-        .args(["metadata", "--format-version", "1"])
-        .log_level(Level::TRACE);
+    let mut command = CommandExt::from_command(MetadataCommand::new().cargo_command());
+    command.log_level(Level::TRACE);
     command
 }
 
@@ -38,141 +32,13 @@ where
         .args(additional_args)
         .output(AutoInstall::Never)
         .context("failed to obtain package metadata, are you in a cargo workspace?")?;
-    let metadata = serde_json::from_slice(&output.stdout)
-        .context("failed to parse `cargo metadata` output")?;
-    Ok(metadata)
-}
 
-/// Metadata information about the current package.
-///
-/// See the [`cargo metadata` specification](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html#json-format).
-#[derive(Debug, Deserialize)]
-pub struct Metadata {
-    /// List of all packages in the workspace.
-    ///
-    /// It also includes all feature-enabled dependencies unless `--no-deps` is used.
-    pub packages: Vec<Package>,
-    /// List of members of the workspace.
-    ///
-    /// Each entry is the Package ID for the package.
-    pub workspace_members: Vec<String>,
-    /// List of default members of the workspace.
-    ///
-    /// Each entry is the Package ID for the package.
-    pub workspace_default_members: Vec<String>,
-    /// The absolute path to the build directory where Cargo places its output.
-    pub target_directory: PathBuf,
-    /// The absolute path to the root of the workspace.
-    /// This will be the root of the package if no workspace is used.
-    pub workspace_root: PathBuf,
-    /// Workspace metadata.
-    /// This is `null` if no metadata is specified.
-    pub metadata: serde_json::Value,
-}
+    let stdout = from_utf8(&output.stdout)?
+        .lines()
+        .find(|line| line.starts_with('{'))
+        .ok_or(anyhow::anyhow!("stdout is not valid json"))?;
 
-#[derive(Debug, Deserialize, Clone)]
-pub struct Package {
-    /// The name of the package.
-    pub name: String,
-    /// The version of the package.
-    pub version: Version,
-    /// The Package ID for referring to the package within the document and as the `--package`
-    /// argument to many commands.
-    pub id: String,
-    /// List of Cargo targets.
-    pub targets: Vec<Target>,
-    /// Absolute path to this package's manifest.
-    pub manifest_path: PathBuf,
-    /// Optional string that is the default binary picked by cargo run.
-    pub default_run: Option<String>,
-    /// Package metadata.
-    /// This is `null` if no metadata is specified.
-    pub metadata: serde_json::Value,
-}
-
-impl Package {
-    /// Check if the package has an executable binary.
-    pub fn has_bin(&self) -> bool {
-        self.targets
-            .iter()
-            .any(|target| target.kind.contains(&TargetKind::Bin))
-    }
-
-    /// An iterator over all binary targets contained in this package.
-    pub fn bin_targets(&self) -> impl Iterator<Item = &Target> {
-        self.targets
-            .iter()
-            .filter(|target| target.kind.contains(&TargetKind::Bin))
-    }
-
-    /// An iterator over all example targets contained in this package.
-    pub fn example_targets(&self) -> impl Iterator<Item = &Target> {
-        self.targets
-            .iter()
-            .filter(|target| target.kind.contains(&TargetKind::Example))
-    }
-}
-
-impl PartialEq for Package {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Dependency {
-    /// The name of the dependency.
-    pub name: String,
-    /// The version requirement for the dependency.
-    ///
-    /// Dependencies without a version requirement have a value of `*`.
-    #[serde(default)]
-    pub req: VersionReq,
-    /// The dependency kind.
-    ///
-    /// `"dev"`, `"build"`, or `null` for a normal dependency.
-    #[serde(default)]
-    pub kind: DependencyKind,
-    /// The file system path for a local path dependency.
-    ///
-    /// Not present if not a path dependency.
-    pub path: Option<PathBuf>,
-}
-
-#[derive(Debug, Deserialize, Default, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum DependencyKind {
-    #[default]
-    Normal,
-    Dev,
-    Build,
-    #[serde(untagged)]
-    Unknown(String),
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Target {
-    pub kind: Vec<TargetKind>,
-    /// The name of the target.
-    ///
-    /// For lib targets, dashes will be replaced with underscores.
-    pub name: String,
-}
-
-#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
-#[serde(rename_all = "kebab-case")]
-pub enum TargetKind {
-    Lib,
-    Rlib,
-    Dylib,
-    ProcMacro,
-    Bin,
-    Example,
-    Test,
-    Bench,
-    CustomBuild,
-    #[serde(untagged)]
-    Unknown(String),
+    Ok(cargo_metadata::MetadataCommand::parse(stdout)?)
 }
 
 #[cfg(test)]
@@ -189,7 +55,7 @@ mod tests {
             metadata
                 .packages
                 .iter()
-                .any(|package| package.name == "bevy_cli")
+                .any(|package| package.name.as_str() == "bevy_cli")
         );
     }
 }

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -57,6 +57,16 @@ impl CommandExt {
         }
     }
 
+    /// Create a new [`CommandExt`] from the given command
+    pub fn from_command(cmd: Command) -> Self {
+        Self {
+            package: None,
+            target: None,
+            inner: cmd,
+            log_level: Level::DEBUG,
+        }
+    }
+
     /// Define the package that allows installation of the program.
     ///
     /// If the command fails and the package is missing,

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -1,12 +1,9 @@
+use cargo_metadata::Metadata;
 use semver::{Comparator, Version, VersionReq};
 
 use crate::bin_target::BinTarget;
 
-use super::{
-    CommandExt, Package,
-    arg_builder::ArgBuilder,
-    cargo::{install::AutoInstall, metadata::Metadata},
-};
+use super::{CommandExt, Package, arg_builder::ArgBuilder, cargo::install::AutoInstall};
 
 pub(crate) const PACKAGE: &str = "wasm-bindgen-cli";
 pub(crate) const PROGRAM: &str = "wasm-bindgen";
@@ -31,7 +28,7 @@ pub(crate) fn bundle(
     } = metadata
         .packages
         .iter()
-        .find(|package| package.name == "wasm-bindgen")
+        .find(|package| package.name.as_str() == "wasm-bindgen")
         .map(|package| package.version.clone())
         .ok_or_else(|| anyhow::anyhow!("Failed to find wasm-bindgen"))?;
 

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -6,10 +6,7 @@ use tracing::info;
 use crate::{
     bin_target::BinTarget,
     build::args::{BuildArgs, BuildSubcommands},
-    external_cli::{
-        cargo::{self},
-        wasm_bindgen,
-    },
+    external_cli::{cargo, wasm_bindgen},
     web::{
         bundle::{PackedBundle, create_web_bundle},
         profiles::configure_default_web_profiles,

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -1,12 +1,13 @@
 use crate::external_cli::wasm_opt;
 use anyhow::Context as _;
+use cargo_metadata::Metadata;
 use tracing::info;
 
 use crate::{
     bin_target::BinTarget,
     build::args::{BuildArgs, BuildSubcommands},
     external_cli::{
-        cargo::{self, metadata::Metadata},
+        cargo::{self},
         wasm_bindgen,
     },
     web::{

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -127,14 +127,14 @@ pub fn create_web_bundle(
         linked.build_artifact_path.join(&linked.wasm_file_name),
         base_path
             .join("build")
-            .join(&linked.wasm_file_name.to_string_lossy().as_ref()),
+            .join(linked.wasm_file_name.to_string_lossy().as_ref()),
     )
     .context("failed to copy WASM artifact")?;
     fs::copy(
         linked.build_artifact_path.join(&linked.js_file_name),
         base_path
             .join("build")
-            .join(&linked.js_file_name.to_string_lossy().as_ref()),
+            .join(linked.js_file_name.to_string_lossy().as_ref()),
     )
     .context("failed to copy JS artifact")?;
 

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -5,9 +5,8 @@ use std::{
 };
 
 use anyhow::Context;
+use cargo_metadata::Metadata;
 use tracing::info;
-
-use crate::external_cli::cargo::metadata::Metadata;
 
 use crate::bin_target::BinTarget;
 
@@ -126,12 +125,16 @@ pub fn create_web_bundle(
     fs::create_dir_all(base_path.join("build"))?;
     fs::copy(
         linked.build_artifact_path.join(&linked.wasm_file_name),
-        base_path.join("build").join(&linked.wasm_file_name),
+        base_path
+            .join("build")
+            .join(&linked.wasm_file_name.to_string_lossy().as_ref()),
     )
     .context("failed to copy WASM artifact")?;
     fs::copy(
         linked.build_artifact_path.join(&linked.js_file_name),
-        base_path.join("build").join(&linked.js_file_name),
+        base_path
+            .join("build")
+            .join(&linked.js_file_name.to_string_lossy().as_ref()),
     )
     .context("failed to copy JS artifact")?;
 
@@ -175,7 +178,9 @@ pub fn create_web_bundle(
     fs::write(base_path.join("index.html"), &index)
         .context("failed to write processed index.html")?;
 
-    Ok(WebBundle::Packed(PackedBundle { path: base_path }))
+    Ok(WebBundle::Packed(PackedBundle {
+        path: base_path.into(),
+    }))
 }
 
 /// Apply pre-processing to the provided `index.html`.

--- a/src/web/profiles.rs
+++ b/src/web/profiles.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, fs};
 
 use anyhow::Context as _;
+use cargo_metadata::Metadata;
 use toml_edit::DocumentMut;
-
-use crate::external_cli::cargo::metadata::Metadata;
 
 /// Create `--config` args to configure the default profiles to use when compiling for the web.
 pub(crate) fn configure_default_web_profiles(metadata: &Metadata) -> anyhow::Result<Vec<String>> {

--- a/src/web/run.rs
+++ b/src/web/run.rs
@@ -1,11 +1,11 @@
 use anyhow::Context as _;
+use cargo_metadata::Metadata;
 use http::{HeaderMap, HeaderValue};
 use tracing::{error, info};
 
 use crate::{
     bin_target::BinTarget,
     build::args::BuildArgs,
-    external_cli::cargo::metadata::Metadata,
     run::{
         RunArgs,
         args::{RunSubcommands, RunWebArgs},


### PR DESCRIPTION
# Objective

While working on #467 I was missing the `resolve` fields and noticed that we implemented all the `cargo metadata` logic ourselves. We already use [`cargo_metadta`](https://crates.io/crates/cargo_metadata) for the `cargo` lints, so I think it makes sense also to use it for the CLI.

# Testing

Tested the different apps in: https://github.com/TimJentzsch/bevy_complex_repo