### PR TITLE
Added a 'host' argument for 'bevy run web'

### DIFF
--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -136,6 +136,10 @@ pub struct RunWebArgs {
     #[arg(short, long, default_value_t = 4000)]
     pub port: u16,
 
+    /// The host address to run the web server on
+    #[arg(long, default_value_t = String::from("127.0.0.1"))]
+    pub host: String,
+
     /// Open the app in the browser.
     #[arg(short = 'o', long = "open", action = ArgAction::SetTrue, default_value_t = false)]
     pub open: bool,
@@ -159,6 +163,7 @@ impl Default for RunWebArgs {
     fn default() -> Self {
         Self {
             port: 4000,
+            host: String::from("127.0.0.1"),
             open: false,
             create_packed_bundle: false,
             headers: Vec::new(),

--- a/src/web/run.rs
+++ b/src/web/run.rs
@@ -1,3 +1,8 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
+
 use anyhow::Context as _;
 use cargo_metadata::Metadata;
 use http::{HeaderMap, HeaderValue};
@@ -42,13 +47,8 @@ pub(crate) fn run_web(
     let web_bundle = build_web(&mut build_args, metadata, bin_target)?;
 
     let port = web_args.port;
-    let host = &web_args.host;
-    // Checking for IPv6, as the syntax for the SocketAddr FromStr representation is different
-    let address = if host.contains(':') {
-        format!("[{host}]:{port}")
-    } else {
-        format!("{host}:{port}")
-    };
+    let host = IpAddr::from_str(&web_args.host).expect("Failed to parse host address");
+    let address = SocketAddr::new(host, port);
     let url = format!("http://{address}");
 
     // Serving the app is blocking, so we open the page first
@@ -65,7 +65,7 @@ pub(crate) fn run_web(
         info!("open your app at <{url}>!");
     }
 
-    serve(web_bundle, &address, header_map)?;
+    serve(web_bundle, address, header_map)?;
 
     Ok(())
 }

--- a/src/web/run.rs
+++ b/src/web/run.rs
@@ -42,7 +42,14 @@ pub(crate) fn run_web(
     let web_bundle = build_web(&mut build_args, metadata, bin_target)?;
 
     let port = web_args.port;
-    let url = format!("http://localhost:{port}");
+    let host = &web_args.host;
+    // Checking for IPv6, as the syntax for the SocketAddr FromStr representation is different
+    let address = if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    };
+    let url = format!("http://{address}");
 
     // Serving the app is blocking, so we open the page first
     if web_args.open {
@@ -58,7 +65,7 @@ pub(crate) fn run_web(
         info!("open your app at <{url}>!");
     }
 
-    serve(web_bundle, port, header_map)?;
+    serve(web_bundle, &address, header_map)?;
 
     Ok(())
 }

--- a/src/web/run.rs
+++ b/src/web/run.rs
@@ -47,7 +47,7 @@ pub(crate) fn run_web(
     let web_bundle = build_web(&mut build_args, metadata, bin_target)?;
 
     let port = web_args.port;
-    let host = IpAddr::from_str(&web_args.host).expect("Failed to parse host address");
+    let host = IpAddr::from_str(&web_args.host).context("failed to parse host address")?;
     let address = SocketAddr::new(host, port);
     let url = format!("http://{address}");
 

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -36,13 +36,9 @@ async fn handle_socket(mut socket: WebSocket) {
 #[tokio::main]
 pub(crate) async fn serve(
     web_bundle: WebBundle,
-    address: &str,
+    addr: SocketAddr,
     header_map: HeaderMap,
 ) -> anyhow::Result<()> {
-    // Using the parse method here allows us to support both IPv4 and IPv6
-    let addr: SocketAddr = address
-        .parse()
-        .expect("Failed to build socket from host and port");
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
 
     // PERF: Leaking necessary to satisfy lifetime bounds

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -36,10 +36,13 @@ async fn handle_socket(mut socket: WebSocket) {
 #[tokio::main]
 pub(crate) async fn serve(
     web_bundle: WebBundle,
-    port: u16,
+    address: &str,
     header_map: HeaderMap,
 ) -> anyhow::Result<()> {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    // Using the parse method here allows us to support both IPv4 and IPv6
+    let addr: SocketAddr = address
+        .parse()
+        .expect("Failed to build socket from host and port");
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
 
     // PERF: Leaking necessary to satisfy lifetime bounds


### PR DESCRIPTION
Added a host argument to allow a different address to be specified to host the web server.
This allows for setting the address to something like 0.0.0.0 to allow connections from all hosts. Or specifying the device's address on a VPN. 

Also changed how we were declaring the address and URL to be displayed to the user to allow for support of IPv6 addresses. 