### PR TITLE
Make `--no-default-features` be a toggle instead of option

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,18 @@ To actually install the new version of the CLI, please see [the docs] and [the r
 [the releases page]: https://github.com/TheBevyFlock/bevy_cli/releases
 [submit an issue]: https://github.com/TheBevyFlock/bevy_cli/issues
 
-> **Note**
->
-> This document is empty for now, and will be until v0.2.0 of the CLI is released with actual breaking changes. Check back later :)
+## v0.1.0-alpha.1 to v0.1.0-alpha.2 (Unreleased)
+
+### Make `--no-default-features` a Toggle
+
+The `--no-default-features` flag for `bevy build` and `bevy run` is now a toggle instead of an option. If you previously were using `--no-default-features true`, replace it with just `--no-default-features`. If you were using `--no-default-features false`, remove it.
+
+```sh
+# v0.1.0-alpha.1
+bevy build --no-default-features true
+bevy run --no-default-features false
+
+# v0.1.0-alpha.2
+bevy build --no-default-features
+bevy run
+```

--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -96,12 +96,10 @@ impl BuildArgs {
             .feature_args
             .features
             .extend(config.features().iter().cloned());
-        self.cargo_args.feature_args.is_no_default_features = Some(
-            self.cargo_args
-                .feature_args
-                .is_no_default_features
-                .unwrap_or(!config.default_features()),
-        );
+        // An explicit `--no-default-features` takes precedence. If `--no-default-features` is not
+        // passed, the config's default features is used instead.
+        self.cargo_args.feature_args.is_no_default_features =
+            self.cargo_args.feature_args.is_no_default_features || !config.default_features();
         self.cargo_args.common_args.rustflags = self
             .cargo_args
             .common_args

--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -25,20 +25,16 @@ pub struct CargoFeatureArgs {
     pub is_all_features: bool,
 
     /// Do not activate the `default` feature
-    #[clap(long = "no-default-features")]
-    pub is_no_default_features: Option<bool>,
+    #[clap(long = "no-default-features", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_no_default_features: bool,
 }
 
 impl CargoFeatureArgs {
-    pub(crate) fn is_no_default_features(&self) -> bool {
-        self.is_no_default_features.unwrap_or(false)
-    }
-
     pub(crate) fn args_builder(&self) -> ArgBuilder {
         ArgBuilder::new()
             .add_value_list("--features", self.features.clone())
             .add_flag_if("--all-features", self.is_all_features)
-            .add_flag_if("--no-default-features", self.is_no_default_features())
+            .add_flag_if("--no-default-features", self.is_no_default_features)
     }
 }
 

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -101,12 +101,10 @@ impl RunArgs {
             .feature_args
             .features
             .extend(config.features().iter().cloned());
-        self.cargo_args.feature_args.is_no_default_features = Some(
-            self.cargo_args
-                .feature_args
-                .is_no_default_features
-                .unwrap_or(!config.default_features()),
-        );
+        // An explicit `--no-default-features` takes precedence. If `--no-default-features` is not
+        // passed, the config's default features is used instead.
+        self.cargo_args.feature_args.is_no_default_features =
+            self.cargo_args.feature_args.is_no_default_features || !config.default_features();
         self.cargo_args.common_args.rustflags = self
             .cargo_args
             .common_args


### PR DESCRIPTION
Fixes #471.

The changes the behavior of the `--no-default-features` flag. Before it required a value to be passed:

```sh
# Disable default features
bevy build --no-default-features true
# Do not disable default features
bevy build --no-default-features false
```

Now the flag is a toggle:

```sh
# Disable default features
bevy build --no-default-features
# Do not disable default features
bevy build
```

This is a breaking change, as passing `true` or `false` is no longer recognized.