### PR TITLE
Make install commands copy-pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-v0.1.0-al
 The CLI is precompiled for Linux, Windows, and macOS. You may install the latest precompiled binary using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
 
 ```sh
-cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version v0.1.0-alpha.1 --locked bevy_cli
+cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version 0.1.0-alpha.1 --locked bevy_cli
 ```
 
 You can manually download the precompiled binaries from the [release page](https://github.com/TheBevyFlock/bevy_cli/releases).

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ If you need assistance or want to help, reach out to the [`bevy_cli` working gro
 
 As the CLI is currently an unofficial tool, it is not yet published to <https://crates.io>. It is available [on Github](https://github.com/TheBevyFlock/bevy_cli), however.
 
-You may compile the CLI from scratch using `cargo install`. To install the latest release, make sure to specify the version you wish in the tag (ex. `--tag cli-v0.1.0-alpha.1`).
+You may compile the latest version of the CLI from scratch using `cargo install`:
 
 ```sh
-cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-vX.Y.Z --locked bevy_cli
+cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-v0.1.0-alpha.1 --locked bevy_cli
 ```
 
 <details>
@@ -32,7 +32,7 @@ cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-vX.Y.Z --
 The CLI is precompiled for Linux, Windows, and macOS. You may install the latest precompiled binary using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
 
 ```sh
-cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version vX.Y.Z --locked bevy_cli
+cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version v0.1.0-alpha.1 --locked bevy_cli
 ```
 
 You can manually download the precompiled binaries from the [release page](https://github.com/TheBevyFlock/bevy_cli/releases).

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -27,31 +27,31 @@ see <https://linebender.org/blog/doc-include/>.
 
 ## Installation
 
-`bevy_lint` depends on a pinned nightly version of Rust with the `rustc-dev` Rustup component. This is because `bevy_lint` uses [internal `rustc` crates](https://doc.rust-lang.org/nightly/nightly-rustc/) that can only be imported with the permanently-unstable [`rustc_private` feature](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html). You can refer to the [compatibility table](#compatibility) to see which version of the linter requires which toolchain.
+`bevy_lint` depends on a pinned nightly version of Rust with the `rustc-dev` Rustup component. This is because `bevy_lint` uses [internal `rustc` crates](https://doc.rust-lang.org/nightly/nightly-rustc/) that can only be imported with the permanently-unstable [`rustc_private` feature](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html). You can refer to the [compatibility table](https://thebevyflock.github.io/bevy_cli/linter/compatibility.html) to see which version of the linter requires which toolchain.
 
-You can install the toolchain with:
+You can install the toolchain required for the latest release with:
 
 ```sh
-rustup toolchain install $TOOLCHAIN_VERSION \
+rustup toolchain install nightly-2025-04-03 \
     --component rustc-dev \
     --component llvm-tools-preview
 ```
 
-For example, you would replace `$TOOLCHAIN_VERSION` with `nightly-2024-11-14` if you were installing `bevy_lint` v0.1.0, based on the [compatibility table](#compatibility). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].
+If you are installing a different version of the linter, you may need to install a different nightly toolchain as specified by the [compatibility table](https://thebevyflock.github.io/bevy_cli/linter/compatibility.html). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].
 
 [^keep-toolchain-installed]: `bevy_lint` imports internal `rustc` libraries in order to hook into the compiler process. These crates are stored in a [dynamic library](https://en.wikipedia.org/wiki/Dynamic_linker) that is installed with the `rustc-dev` component and loaded by `bevy_lint` at runtime. Uninstalling the nightly toolchain would remove this dynamic library, causing `bevy_lint` to fail.
 
 Once you have the toolchain installed, you can compile and install `bevy_lint` through `cargo`:
 
 ```sh
-rustup run $TOOLCHAIN_VERSION cargo install \
+rustup run nightly-2025-04-03 cargo install \
     --git https://github.com/TheBevyFlock/bevy_cli.git \
-    --tag $TAG \
+    --tag lint-v0.3.0 \
     --locked \
     bevy_lint
 ```
 
-Make sure to replace `$TOOLCHAIN_VERSION` and `$TAG` in the above command. The tag for a specific release can be found in the [releases tab](https://github.com/TheBevyFlock/bevy_cli/releases). For example, the tag for v0.1.0 is `lint-v0.1.0`.
+If you're installing a different version of the linter, you may need to switch the toolchain and tag in the above command.
 
 ## Getting Started
 

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -16,7 +16,7 @@ cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-v0.1.0-al
 The CLI is precompiled for Linux, Windows, and macOS. You may install the latest precompiled binary using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
 
 ```sh
-cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version v0.1.0-alpha.1 --locked bevy_cli
+cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version 0.1.0-alpha.1 --locked bevy_cli
 ```
 
 You can manually download the precompiled binaries from the [release page](https://github.com/TheBevyFlock/bevy_cli/releases).

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -4,10 +4,10 @@
 
 As the CLI is currently an unofficial tool, it is not yet published to <https://crates.io>. It is available [on Github](https://github.com/TheBevyFlock/bevy_cli), however.
 
-You may compile the CLI from scratch using `cargo install`. To install the latest release, make sure to specify the version you wish in the tag (ex. `--tag cli-v0.1.0-alpha.1`).
+You may compile the latest version of the CLI from scratch using `cargo install`:
 
 ```sh
-cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-vX.Y.Z --locked bevy_cli
+cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-v0.1.0-alpha.1 --locked bevy_cli
 ```
 
 <details>
@@ -16,7 +16,7 @@ cargo install --git https://github.com/TheBevyFlock/bevy_cli --tag cli-vX.Y.Z --
 The CLI is precompiled for Linux, Windows, and macOS. You may install the latest precompiled binary using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
 
 ```sh
-cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version vX.Y.Z --locked bevy_cli
+cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version v0.1.0-alpha.1 --locked bevy_cli
 ```
 
 You can manually download the precompiled binaries from the [release page](https://github.com/TheBevyFlock/bevy_cli/releases).

--- a/docs/src/contribute/cli/release.md
+++ b/docs/src/contribute/cli/release.md
@@ -9,8 +9,9 @@
 5. Remove the `-dev` suffix from the version in `Cargo.toml`.
     - Please ensure that `Cargo.lock` also updates!
 6. Update both instances of hard-coded version in the URL under `[package.metadata.binstall]` in `Cargo.toml` to be the new version.
-7. Commit your changes and open a pull request.
-8. Merge the PR once a core Bevy maintainer approves it with no outstanding issues from other contributors.
+7. Update the `cargo install` and `cargo binstall` commands in the `README.md` and the [install page](../../cli/install.md) to use the latest version.
+8. Commit your changes and open a pull request.
+9. Merge the PR once a core Bevy maintainer approves it with no outstanding issues from other contributors.
     - This starts the release process, enacting a freeze on all other changes until the release has finished. While maintainers need to be aware of this so they do not merge PRs during this time, the release process should take less than an hour, so it's unlikely to ever be an issue.
 
 ## Release on Github

--- a/docs/src/contribute/linter/how-to/release.md
+++ b/docs/src/contribute/linter/how-to/release.md
@@ -10,8 +10,9 @@
     - Please ensure that `Cargo.lock` also updates!
 6. Replace `--branch main` in `action.yml` with `--tag lint-vX.Y.Z`.
     - The `linter-action.yml` workflow may fail as the tag does not exist yet. This is fine!
-7. Commit all of these changes and open a pull request.
-8. Merge the PR once a core Bevy maintainer approves it with no outstanding issues from other contributors.
+7. Update the toolchain install, `bevy_lint` install, and `bevy_lint` uninstall commands in both `README.md` and the [install page](../../../linter/install.md) to use the latest version and toolchain.
+8. Commit all of these changes and open a pull request.
+9. Merge the PR once a core Bevy maintainer approves it with no outstanding issues from other contributors.
     - This starts the release process, enacting a freeze on all other changes until the release has finished. While maintainers need to be aware of this so they do not merge PRs during this time, the release process should take less than an hour, so it's unlikely to ever be an issue.
 
 ## Release on Github

--- a/docs/src/linter/install.md
+++ b/docs/src/linter/install.md
@@ -25,29 +25,29 @@ bevy lint --yes
 
 `bevy_lint` depends on a pinned nightly version of Rust with the `rustc-dev` Rustup component. This is because `bevy_lint` uses [internal `rustc` crates](https://doc.rust-lang.org/nightly/nightly-rustc/) that can only be imported with the permanently-unstable [`rustc_private` feature](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html). You can refer to the [compatibility table](compatibility.md) to see which version of the linter requires which toolchain.
 
-You can install the toolchain with:
+You can install the toolchain required for the latest release with:
 
 ```sh
-rustup toolchain install $TOOLCHAIN_VERSION \
+rustup toolchain install nightly-2025-04-03 \
     --component rustc-dev \
     --component llvm-tools-preview
 ```
 
-For example, you would replace `$TOOLCHAIN_VERSION` with `nightly-2024-11-14` if you were installing `bevy_lint` v0.1.0, based on the [compatibility table](compatibility.md). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].
+If you are installing a different version of the linter, you may need to install a different nightly toolchain as specified by the [compatibility table](compatibility.md). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].
 
 [^keep-toolchain-installed]: `bevy_lint` imports internal `rustc` libraries in order to hook into the compiler process. These crates are stored in a [dynamic library](https://en.wikipedia.org/wiki/Dynamic_linker) that is installed with the `rustc-dev` component and loaded by `bevy_lint` at runtime. Uninstalling the nightly toolchain would remove this dynamic library, causing `bevy_lint` to fail.
 
 Once you have the toolchain installed, you can compile and install `bevy_lint` through `cargo`:
 
 ```sh
-rustup run $TOOLCHAIN_VERSION cargo install \
+rustup run nightly-2025-04-03 cargo install \
     --git https://github.com/TheBevyFlock/bevy_cli.git \
-    --tag $TAG \
+    --tag lint-v0.3.0 \
     --locked \
     bevy_lint
 ```
 
-Make sure to replace `$TOOLCHAIN_VERSION` and `$TAG` in the above command. The tag for a specific release can be found in the [releases tab](https://github.com/TheBevyFlock/bevy_cli/releases). For example, the tag for v0.1.0 is `lint-v0.1.0`.
+If you're installing a different version of the linter, you may need to switch the toolchain and tag in the above command.
 
 ## Uninstall
 
@@ -55,8 +55,10 @@ If you wish to uninstall the linter at any time, you may use Cargo and Rustup to
 
 ```sh
 cargo uninstall bevy_lint
-rustup toolchain uninstall $TOOLCHAIN_VERSION
+rustup toolchain uninstall nightly-2025-04-03
 ```
+
+If you're uninstalling an older version of the linter, such as when you are [upgrading](#upgrade), you may need to uninstall a different toolchain version than the one in the above command. Check out the [compatibility table](compatibility.md) to see which version uses which toolchain.
 
 ## Upgrade
 


### PR DESCRIPTION
This makes it so users getting started can copy-paste the installation commands necessary for both the CLI and the linter, easing onboarding. I also added an extra step in the release checklist so that these values get updated every release, so they don't fall behind.

Addresses [this comment on Discord](https://discord.com/channels/691052431525675048/1278871953721262090/1380381197930074232).