### PR TITLE
Support custom linter sysroot

### DIFF
--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -78,15 +78,12 @@ fn show_version() {
 fn driver_path() -> anyhow::Result<PathBuf> {
     // The `bevy_lint` lives in the same folder as `bevy_lint_driver`, so we can easily find it
     // using the path of the current executable.
-    #[cfg_attr(not(target_os = "windows"), expect(unused_mut))]
-    let mut driver_path = env::current_exe()
+    let driver_path = env::current_exe()
         .context("Failed to retrieve the path to the current executable.")?
         .parent()
         .ok_or(anyhow!("Path to file must have a parent."))?
-        .join("bevy_lint_driver");
-
-    #[cfg(target_os = "windows")]
-    driver_path.set_extension("exe");
+        .join("bevy_lint_driver")
+        .with_extension(env::consts::EXE_EXTENSION);
 
     ensure!(
         driver_path.exists(),
@@ -94,8 +91,6 @@ fn driver_path() -> anyhow::Result<PathBuf> {
         driver_path.display(),
     );
 
-    // Convert the local path to the absolute path. We don't want `rustc` getting
-    // confused! `canonicalize()` requires for the path to exist, so we do it after the nice error
-    // message.
+    // Convert the local path to the absolute path. We don't want `rustc` getting confused!
     driver_path.canonicalize().map_err(anyhow::Error::from)
 }

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -142,7 +142,7 @@ fn driver_path() -> anyhow::Result<PathBuf> {
         .with_extension(env::consts::EXE_EXTENSION);
 
     ensure!(
-        driver_path.exists(),
+        driver_path.is_file(),
         "Could not find `bevy_lint_driver` at {}, please ensure it is installed!",
         driver_path.display(),
     );
@@ -160,9 +160,8 @@ fn custom_sysroot() -> anyhow::Result<Option<PathBuf>> {
     // If the user specified `BEVY_LINT_SYSROOT`, verify it exists.
     if let Some(ref path) = sysroot {
         ensure!(
-            // TODO: Use `is_dir()` instead.
-            path.exists(),
-            "the path specified by `BEVY_LINT_SYSROOT`, {}, does not exist",
+            path.is_dir(),
+            "the path specified by `BEVY_LINT_SYSROOT`, {}, is not a folder",
             path.display(),
         );
     }

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -1,6 +1,8 @@
+//! TODO: Use lowercase error messages.
+
 use anyhow::{Context, anyhow, ensure};
 use std::{
-    env,
+    env, iter,
     path::PathBuf,
     process::{Command, ExitCode},
 };
@@ -21,24 +23,78 @@ fn main() -> anyhow::Result<ExitCode> {
     // Find the path to `bevy_lint_driver`.
     let driver_path = driver_path()?;
 
-    // Run `rustup run nightly-YYYY-MM-DD cargo check`.
-    let status = Command::new("rustup")
-        .arg("run")
-        .arg(RUST_TOOLCHAIN_CHANNEL)
-        .arg("cargo")
+    // Find the path to the custom sysroot, if specified.
+    let custom_sysroot = custom_sysroot()?;
+
+    let mut cargo = match custom_sysroot {
+        // When there's a custom sysroot, run `$SYSROOT/bin/cargo`.
+        Some(sysroot) => {
+            let mut c = Command::new(sysroot.join("bin/cargo"));
+
+            let path_name = match env::consts::OS {
+                "windows" => "PATH",
+                "macos" => "DYLD_LIBRARY_PATH",
+                // Fallback to assuming the platform is Unix-based and uses `LD_LIBRARY_PATH`.
+                _ => "LD_LIBRARY_PATH",
+            };
+
+            let library_path = match env::consts::OS {
+                // `librustc_driver.dll` is in the `bin` folder on Windows.
+                "windows" => sysroot.join("bin"),
+                _ => sysroot.join("lib"),
+            };
+
+            let original_paths = env::var_os(path_name).unwrap_or_default();
+            let original_paths =
+                env::split_paths(&original_paths).filter(|path| !path.as_os_str().is_empty());
+
+            let appended_paths = original_paths.chain(iter::once(library_path));
+            let appended_paths = env::join_paths(appended_paths).with_context(|| {
+                format!("error constructing new {path_name} environmental variable")
+            })?;
+
+            // Make `librustc_driver.so` discoverable by appending its folder to the correct path
+            // environmental variable. Rustup (mostly) does this by default, but since we're using
+            // a custom sysroot we have to do it ourselves.
+            c.env(path_name, appended_paths);
+
+            c
+        }
+        // When using Rustup, run `rustup run $TOOLCHAIN cargo`.
+        None => {
+            let mut c = Command::new("rustup");
+
+            c.arg("run")
+                .arg(RUST_TOOLCHAIN_CHANNEL)
+                .arg("cargo")
+                // Between 1.27.1 and 1.28.2, Rustup by default wouldn't modify the `PATH` variable
+                // on Windows in order so a toolchain-specific version of `cargo` or `rustc` is not
+                // accidentally run instead of Rustup's proxy version. This isn't desired for us,
+                // however, because we need the `PATH` modified to discover and link to
+                // `rustc_driver.dll`. Setting `RUSTUP_WINDOWS_PATH_ADD_BIN=1` forces Rustup
+                // prepend the sysroot `bin` folder to the `PATH`.
+                //
+                // From 1.28.2 onwards, Rustup will append the `bin` folder to the `PATH` by
+                // default (which is also what we do when there's a custom sysroot). Once 1.28.2
+                // gets enough adoption (late 2025), we can remove this line and say the minimum
+                // supported Rustup version is 1.28.2.
+                //
+                // For more info, please see <https://github.com/rust-lang/rustup/pull/3703> and
+                // <https://github.com/rust-lang/rustup/pull/4249>.
+                .env("RUSTUP_WINDOWS_PATH_ADD_BIN", "1");
+
+            c
+        }
+    };
+
+    let status = cargo
         .arg("check")
         // Forward all arguments to `cargo check` except for the first, which is the path to the
         // current executable.
         .args(std::env::args().skip(1))
-        // This instructs `rustc` to call `bevy_lint_driver` instead of its default routine.
-        // This lets us register custom lints.
+        // This instructs Cargo to call `bevy_lint_driver` instead of `rustc`, which lets us use
+        // custom lints.
         .env("RUSTC_WORKSPACE_WRAPPER", driver_path)
-        // Rustup on Windows does not modify the `PATH` variable by default so a toolchain-specific
-        // version of `cargo` or `rustc` is not accidentally run instead of Rustup's proxy version.
-        // This isn't desired for us, however, because we need the `PATH` modified to discover and
-        // link to `rustc_driver.dll`. Setting `RUSTUP_WINDOWS_PATH_ADD_BIN=1` forces Rustup to
-        // modify the path. For more info, please see <https://github.com/rust-lang/rustup/pull/3703>.
-        .env("RUSTUP_WINDOWS_PATH_ADD_BIN", "1")
         .status()
         .context("Failed to spawn `cargo check`.")?;
 
@@ -93,4 +149,23 @@ fn driver_path() -> anyhow::Result<PathBuf> {
 
     // Convert the local path to the absolute path. We don't want `rustc` getting confused!
     driver_path.canonicalize().map_err(anyhow::Error::from)
+}
+
+/// Returns the path to the custom sysroot used by `bevy_lint_driver`, if specified by the user.
+///
+/// If the result is [`Some`], the path is guaranteed to exist.
+fn custom_sysroot() -> anyhow::Result<Option<PathBuf>> {
+    let sysroot = env::var_os("BEVY_LINT_SYSROOT").map(PathBuf::from);
+
+    // If the user specified `BEVY_LINT_SYSROOT`, verify it exists.
+    if let Some(ref path) = sysroot {
+        ensure!(
+            // TODO: Use `is_dir()` instead.
+            path.exists(),
+            "the path specified by `BEVY_LINT_SYSROOT`, {}, does not exist",
+            path.display(),
+        );
+    }
+
+    Ok(sysroot)
 }

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -28,7 +28,9 @@ fn main() -> anyhow::Result<ExitCode> {
     let mut cargo = match custom_sysroot {
         // When there's a custom sysroot, run `$SYSROOT/bin/cargo`.
         Some(sysroot) => {
-            let cargo = sysroot.join("bin/cargo");
+            let cargo = sysroot
+                .join("bin/cargo")
+                .with_extension(env::consts::EXE_EXTENSION);
 
             ensure!(
                 cargo.exists(),

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -1,6 +1,4 @@
-//! TODO: Use lowercase error messages.
-
-use anyhow::{Context, anyhow, ensure};
+use anyhow::{Context, ensure};
 use std::{
     env, iter,
     path::PathBuf,
@@ -96,7 +94,7 @@ fn main() -> anyhow::Result<ExitCode> {
         // custom lints.
         .env("RUSTC_WORKSPACE_WRAPPER", driver_path)
         .status()
-        .context("Failed to spawn `cargo check`.")?;
+        .context("failed to spawn `cargo check`")?;
 
     let code = if status.success() {
         // Exit status of 0, success!
@@ -135,15 +133,15 @@ fn driver_path() -> anyhow::Result<PathBuf> {
     // The `bevy_lint` lives in the same folder as `bevy_lint_driver`, so we can easily find it
     // using the path of the current executable.
     let driver_path = env::current_exe()
-        .context("Failed to retrieve the path to the current executable.")?
+        .context("failed to retrieve the path to the current executable")?
         .parent()
-        .ok_or(anyhow!("Path to file must have a parent."))?
+        .expect("path to file must have a parent")
         .join("bevy_lint_driver")
         .with_extension(env::consts::EXE_EXTENSION);
 
     ensure!(
         driver_path.is_file(),
-        "Could not find `bevy_lint_driver` at {}, please ensure it is installed!",
+        "could not find `bevy_lint_driver` at {}, please ensure it is installed alongside `bevy_lint`",
         driver_path.display(),
     );
 

--- a/bevy_lint/src/bin/main.rs
+++ b/bevy_lint/src/bin/main.rs
@@ -28,7 +28,15 @@ fn main() -> anyhow::Result<ExitCode> {
     let mut cargo = match custom_sysroot {
         // When there's a custom sysroot, run `$SYSROOT/bin/cargo`.
         Some(sysroot) => {
-            let mut c = Command::new(sysroot.join("bin/cargo"));
+            let cargo = sysroot.join("bin/cargo");
+
+            ensure!(
+                cargo.exists(),
+                "path to sysroot cargo executable, {}, does not exist",
+                cargo.display(),
+            );
+
+            let mut c = Command::new(cargo);
 
             let path_name = match env::consts::OS {
                 "windows" => "PATH",

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -27,6 +27,7 @@
     - [Registering `bevy` as a Tool](linter/usage/register-bevy-tool.md)
     - [Toggling Lints in Code](linter/usage/toggling-lints-code.md)
 - [Compatibility](linter/compatibility.md)
+- [Environmental Variables](linter/environmental-variables.md)
 - [Github Actions](linter/github-actions.md)
 - [Troubleshooting](linter/troubleshooting.md)
 - [Changelog](linter/changelog.md)

--- a/docs/src/linter/environmental-variables.md
+++ b/docs/src/linter/environmental-variables.md
@@ -1,0 +1,13 @@
+# Environmental Variables
+
+You can configure `bevy_lint`'s behavior using environmental variables. While the default behavior is usually good enough for most users, these variables may be useful if you have a non-standard setup.
+
+## `BEVY_LINT_SYSROOT`
+
+By default, the linter assumes you've installed [its required toolchain](compatibility.md) using Rustup. As such, when `BEVY_LINT_SYSROOT` is unset or is empty, the linter will use Rustup to locate the path to the toolchain's system root. (On some platforms, this may be `~/.rustup/toolchains/nightly-YYYY-MM-DD-TARGET`.)
+
+If you do not use Rustup, you must set `BEVY_LINT_SYSROOT` to the path to the toolchain's folder:
+
+```sh
+BEVY_LINT_SYSROOT="/path/to/nightly-YYYY-MM-DD-TARGET" bevy_lint
+```

--- a/docs/src/linter/environmental-variables.md
+++ b/docs/src/linter/environmental-variables.md
@@ -1,6 +1,6 @@
 # Environmental Variables
 
-You can configure `bevy_lint`'s behavior using environmental variables. While the default behavior is usually good enough for most users, these variables may be useful if you have a non-standard setup.
+You can configure `bevy_lint`'s behavior using environmental variables. While the default behavior is usually desired, these variables may be useful if you have a non-standard environment.
 
 ## `BEVY_LINT_SYSROOT`
 

--- a/docs/src/linter/install.md
+++ b/docs/src/linter/install.md
@@ -8,7 +8,7 @@ The CLI supports automatically installing the latest released version of the lin
 bevy lint
 ```
 
-The CLI will prompt you if you wish to install the linter. Type `y` and press enter to accept:
+The CLI will prompt you if you wish to install the linter. Note that it will assume you are using Rustup, and if that isn't the case you should [install the linter manually instead](#manual-without-rustup). Type `y` and press enter to accept:
 
 ```
 warning: failed to run bevy_lint, trying to find automatic fix...
@@ -21,11 +21,9 @@ If you want to auto-confirm the prompt, you may pass `--yes` to the command. Not
 bevy lint --yes
 ```
 
-## Manual
+## Manual with Rustup
 
-`bevy_lint` depends on a pinned nightly version of Rust with the `rustc-dev` Rustup component. This is because `bevy_lint` uses [internal `rustc` crates](https://doc.rust-lang.org/nightly/nightly-rustc/) that can only be imported with the permanently-unstable [`rustc_private` feature](https://doc.rust-lang.org/nightly/unstable-book/language-features/rustc-private.html). You can refer to the [compatibility table](compatibility.md) to see which version of the linter requires which toolchain.
-
-You can install the toolchain required for the latest release with:
+`bevy_lint` requires a specific nightly Rust toolchain with the `rustc-dev` and `llvm-tools-preview` components. You can install the toolchain required for the latest release with:
 
 ```sh
 rustup toolchain install nightly-2025-04-03 \
@@ -35,9 +33,9 @@ rustup toolchain install nightly-2025-04-03 \
 
 If you are installing a different version of the linter, you may need to install a different nightly toolchain as specified by the [compatibility table](compatibility.md). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].
 
-[^keep-toolchain-installed]: `bevy_lint` imports internal `rustc` libraries in order to hook into the compiler process. These crates are stored in a [dynamic library](https://en.wikipedia.org/wiki/Dynamic_linker) that is installed with the `rustc-dev` component and loaded by `bevy_lint` at runtime. Uninstalling the nightly toolchain would remove this dynamic library, causing `bevy_lint` to fail.
+[^keep-toolchain-installed]: `bevy_lint` imports internal `rustc` libraries in order to hook into the compiler process. These crates are stored in a [dynamic library](https://en.wikipedia.org/wiki/Dynamic_linker) that is loaded by `bevy_lint` at runtime. Uninstalling the nightly toolchain would remove this dynamic library, causing `bevy_lint` to fail.
 
-Once you have the toolchain installed, you can compile and install `bevy_lint` through `cargo`:
+Once you have the toolchain installed, you can compile and install `bevy_lint` through Cargo:
 
 ```sh
 rustup run nightly-2025-04-03 cargo install \
@@ -49,17 +47,48 @@ rustup run nightly-2025-04-03 cargo install \
 
 If you're installing a different version of the linter, you may need to switch the toolchain and tag in the above command.
 
+## Manual without Rustup
+
+It is possible to use the linter without Rustup, however it requires some extra steps. First, you'll need to install the required nightly Rust toolchain (check the [compatibility table](compatibility.md)) through some other means. If you're using Nix, for example, you would use a [Rust overlay](https://nixos.wiki/wiki/Rust#Unofficial_overlays) to do this. Make sure to also install the `rustc-dev` and `llvm-tools-preview` components for the toolchain.
+
+Once you've installed the toolchain and components, use that toolchain's `cargo` to build the linter:
+
+```sh
+my-toolchain/bin/cargo install \
+    --git https://github.com/TheBevyFlock/bevy_cli.git \
+    --tag lint-v0.3.0 \
+    --locked \
+    bevy_lint
+```
+
+Next, you'll need to note down the absolute path the toolchain was installed at. You can easily find it by running:
+
+```sh
+my-toolchain/bin/rustc --print sysroot
+```
+
+Finally, you will need to set the [`BEVY_LINT_SYSROOT` environmental variable](environmental-variables.md#bevy_lint_sysroot) any time you run `bevy_lint`. The easiest way to do this on Unix-based systems is to set it in a startup script like `.bashrc` or `.profile`:
+
+```sh
+export BEVY_LINT_SYSROOT=/absolute/path/to/sysroot
+```
+
+If you're using Nix, you would set `BEVY_LINT_SYSROOT` using [`environment.variables` or one of its siblings](https://nixos.wiki/wiki/Environment_variables).
+
 ## Uninstall
 
-If you wish to uninstall the linter at any time, you may use Cargo and Rustup to do so:
+If you wish to uninstall the linter at any time, you may use Cargo to do so:
 
 ```sh
 cargo uninstall bevy_lint
+```
+
+You may also wish to uninstall the Rustup toolchain. The following command will uninstall the toolchain required by the latest version of the linter, but you may need to specify a different toolchain from the [compatibility table](compatibility.md):
+
+```sh
 rustup toolchain uninstall nightly-2025-04-03
 ```
 
-If you're uninstalling an older version of the linter, such as when you are [upgrading](#upgrade), you may need to uninstall a different toolchain version than the one in the above command. Check out the [compatibility table](compatibility.md) to see which version uses which toolchain.
-
 ## Upgrade
 
-To upgrade to a newer version of the linter, first [uninstall it](#uninstall) then follow the [CLI](#cli) or [manual](#manual) installation instructions.
+To upgrade to a newer version of the linter, first [uninstall it](#uninstall) then follow the [CLI](#cli) or [manual](#manual-with-rustup) installation instructions.

--- a/docs/src/linter/install.md
+++ b/docs/src/linter/install.md
@@ -73,8 +73,6 @@ Finally, you will need to set the [`BEVY_LINT_SYSROOT` environmental variable](e
 export BEVY_LINT_SYSROOT=/absolute/path/to/sysroot
 ```
 
-If you're using Nix, you would set `BEVY_LINT_SYSROOT` using [`environment.variables` or one of its siblings](https://nixos.wiki/wiki/Environment_variables).
-
 ## Uninstall
 
 If you wish to uninstall the linter at any time, you may use Cargo to do so:


### PR DESCRIPTION
Closes #338 and closes #336!

`bevy_lint` requires a custom nightly Rust toolchain, and it by default assumes that you have it installed through Rustup. This is an issue for users who don't have Rustup or prefer something else (such as Nix).

This PR makes it possible to support alternative toolchain installation methods. If you set `BEVY_LINT_SYSROOT` to the path to the toolchain folder (known as the sysroot), the linter will use that instead of going through Rustup.

## Testing

```
# Install the linter.
cargo install --git https://github.com/TheBevyFlock/bevy_cli --branch linter-sysroot-var --locked bevy_lint

# Use Rustup to locate the sysroot.
bevy_lint

# Manually specify sysroot (you will need to change the folder name).
BEVY_LINT_SYSROOT="/Users/username/.rustup/toolchains/nightly-2025-04-03-TARGET" bevy_lint
```

Using a custom sysroot will need testing on all of our supported platforms, since there's some platform-specific logic.

- [x] Linux
- [x] Windows
- [x] MacOS

Additionally, please see how the linter behaves when you use different values for `PATH`, `DYLD_LIBRARY_PATH`, or `LD_LIBRARY_PATH` (depending on your platform), as the linter tries to parse and modify it.