### PR TITLE
Validate that package name starts with an alphabetic character

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -22,6 +22,15 @@ struct Repository {
 ///
 /// [TheBevyFlock/bevy_new_minimal]: https://github.com/TheBevyFlock/bevy_new_miminal
 pub fn generate_template(name: &str, template: &str, branch: &str) -> anyhow::Result<PathBuf> {
+    // Validate that the package name starts with an alphabetic character
+    if let Some(first_char) = name.chars().next() {
+        if !first_char.is_alphabetic() {
+            return Err(anyhow::anyhow!(
+                "invalid character `{first_char}` in package name: {name}"
+            ));
+        }
+    }
+
     cargo_generate::generate(GenerateArgs {
         template_path: template_path(template, branch)?,
         name: Some(name.to_string()),


### PR DESCRIPTION
# Objective

In #450 we had the issue that we created an empty directory with an error message like 

```
    Runtime error: System command `cargo update --package 2d-game` failed to execute: error: invalid character `2` in package name: `2d-game`, the name cannot start with a digit
     --> Cargo.toml:2:8
      |
    2 | name = "2d-game"
      |        ^^^^^^^^^
      |
```

This is no longer the case since now the template is created correctly, but we should still try to remove easy pitfalls like packages that start with a non-alphabetic character.


# Solution

The simplest (but not exhaustive) solution is to just check if the starting character is alphabetic. This does not prevent package names like `a2%d-game` (they get created correctly):

```sh
a2%d-game on  main is 📦 v0.1.0 via 🦀 v1.86.0
❯ ls
assets  Cargo.lock  Cargo.toml  clippy.toml  README.md  src
```

and the `cargo` error message is very clear:

```sh
❯ cargo run
error: invalid character `%` in package name: `a2%d-game`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
 --> Cargo.toml:2:8
  |
2 | name = "a2%d-game"
  |        ^^^^^^^^^^^
  |
```

# Alternatives

We could also use `https://github.com/dtolnay/unicode-ident`, but it feels a bit much for a very niche use case that has a very good error message from `cargo`.  In my opinion, as long as `cargo generate` can create the template correctly, we are good.

Closes #450 