### PR TITLE
Fix invalid artifact directory when customizing target

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -33,6 +33,15 @@ pub fn build(args: &mut BuildArgs) -> anyhow::Result<()> {
     )?;
 
     args.apply_config(&config);
+    // Re-run the bin target selection, as the config can affect e.g. the path to the artifact
+    let bin_target = select_run_binary(
+        &metadata,
+        args.cargo_args.package_args.package.as_deref(),
+        args.cargo_args.target_args.bin.as_deref(),
+        args.cargo_args.target_args.example.as_deref(),
+        args.target().as_deref(),
+        args.profile(),
+    )?;
 
     #[cfg(feature = "web")]
     if args.is_web() {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -32,6 +32,15 @@ pub fn run(args: &mut RunArgs) -> anyhow::Result<()> {
         args.is_release(),
     )?;
     args.apply_config(&config);
+    // Re-run the bin target selection, as the config can affect e.g. the path to the artifact
+    let bin_target = select_run_binary(
+        &metadata,
+        args.cargo_args.package_args.package.as_deref(),
+        args.cargo_args.target_args.bin.as_deref(),
+        args.cargo_args.target_args.example.as_deref(),
+        args.target().as_deref(),
+        args.profile(),
+    )?;
 
     #[cfg(feature = "web")]
     if args.is_web() {


### PR DESCRIPTION
# Objective

The Bevy CLI allows you to configure a custom compilation target in `Cargo.toml`:

```toml
[package.metadata.bevy_cli.web]
target = "wasm32v1-none"
```

However, `bevy run web` doesn't work with this configuration, because it searches for the Wasm binary in the `wasm32-unknown-unknown` target folder.

# Solution

The cause of this problem is that we have to run the binary selection _before_ loading the `Cargo.toml` config, to know which package to pull the config from.
But the config can then alter the contents of the `BinTarget`, most notably the `artifact_directory`.

As a fix, we run the bin target selection again after loading the config, which fixes the problem.

# Testing

You can test via the [`no_std` package in the bevy_complex_repo](https://github.com/TimJentzsch/bevy_complex_repo/tree/main/no_std).
It doesn't fully work yet, but at least it should compile now without an error.