### PR TITLE
Use `cargo` styling in main `--help` resources section

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -82,21 +82,22 @@ pub struct Cli {
 fn after_help() -> String {
     let mut message = String::new();
 
-    let header = Style::new().bold().underline();
-    let bold = Style::new().bold();
+    let header = style::HEADER;
+    let literal = style::LITERAL;
+    let underline = Style::new().underline();
 
     _ = writeln!(message, "{header}Resources:{header:#}");
     _ = writeln!(
         message,
-        "  {bold}Bevy Website{bold:#}       https://bevyengine.org"
+        "  {literal}Bevy Website{literal:#}       {underline}https://bevyengine.org{underline:#}"
     );
     _ = writeln!(
         message,
-        "  {bold}Bevy Repository{bold:#}    https://github.com/bevyengine/bevy"
+        "  {literal}Bevy Repository{literal:#}    {underline}https://github.com/bevyengine/bevy{underline:#}"
     );
     _ = writeln!(
         message,
-        "  {bold}CLI Documentation{bold:#}  https://thebevyflock.github.io/bevy_cli"
+        "  {literal}CLI Documentation{literal:#}  {underline}https://thebevyflock.github.io/bevy_cli{underline:#}"
     );
 
     message


### PR DESCRIPTION
In #457 I switched the "after help" messages to use Cargo's styling, but forgot to update the message for `bevy --help`. This PR fixes that so the "Resources" section in `bevy --help` is consistent.

Before and after:

<img width="908" alt="image" src="https://github.com/user-attachments/assets/a9fcc525-66ac-4b15-bc3f-2b2451faae47" />
