### PR TITLE
Make lint items `pub(crate)`, hiding them from docs

### DIFF
--- a/bevy_lint/src/lints/cargo.rs
+++ b/bevy_lint/src/lints/cargo.rs
@@ -9,7 +9,7 @@ use rustc_session::{config::Input, utils::was_invoked_from_cargo};
 use rustc_span::Symbol;
 
 declare_bevy_lint_pass! {
-    pub Cargo => [DUPLICATE_BEVY_DEPENDENCIES],
+    pub(crate) Cargo => [DUPLICATE_BEVY_DEPENDENCIES],
     @default = {
         bevy: Symbol = sym!(bevy),
     },

--- a/bevy_lint/src/lints/nursery/duplicate_bevy_dependencies.rs
+++ b/bevy_lint/src/lints/nursery/duplicate_bevy_dependencies.rs
@@ -78,7 +78,7 @@ use serde::Deserialize;
 use toml::Spanned;
 
 declare_bevy_lint! {
-    pub DUPLICATE_BEVY_DEPENDENCIES,
+    pub(crate) DUPLICATE_BEVY_DEPENDENCIES,
     super::Nursery,
     "multiple versions of the `bevy` crate found",
     @crate_level_only = true,
@@ -98,7 +98,7 @@ fn toml_span(range: Range<usize>, file: &SourceFile) -> Span {
     )
 }
 
-pub fn check(cx: &LateContext<'_>, metadata: &Metadata, bevy_symbol: Symbol) {
+pub(crate) fn check(cx: &LateContext<'_>, metadata: &Metadata, bevy_symbol: Symbol) {
     // no reason to continue the check if there is only one instance of `bevy` required
     if find_crates(cx.tcx, bevy_symbol).len() == 1 {
         return;

--- a/bevy_lint/src/lints/nursery/zst_query.rs
+++ b/bevy_lint/src/lints/nursery/zst_query.rs
@@ -67,7 +67,7 @@ use rustc_middle::ty::{
 };
 
 declare_bevy_lint! {
-    pub ZST_QUERY,
+    pub(crate) ZST_QUERY,
     // This will eventually be a `RESTRICTION` lint, but due to
     // <https://github.com/TheBevyFlock/bevy_cli/issues/279> it is not yet ready for production.
     super::Nursery,
@@ -75,7 +75,7 @@ declare_bevy_lint! {
 }
 
 declare_bevy_lint_pass! {
-    pub ZstQuery => [ZST_QUERY],
+    pub(crate) ZstQuery => [ZST_QUERY],
 }
 
 impl<'tcx> LateLintPass<'tcx> for ZstQuery {

--- a/bevy_lint/src/lints/pedantic/borrowed_reborrowable.rs
+++ b/bevy_lint/src/lints/pedantic/borrowed_reborrowable.rs
@@ -111,13 +111,13 @@ use rustc_middle::ty::{Interner, Ty, TyKind, TypeVisitable, TypeVisitor};
 use rustc_span::{Span, def_id::LocalDefId, symbol::kw};
 
 declare_bevy_lint! {
-    pub BORROWED_REBORROWABLE,
+    pub(crate) BORROWED_REBORROWABLE,
     super::Pedantic,
     "function parameter takes a mutable reference to a re-borrowable type",
 }
 
 declare_bevy_lint_pass! {
-    pub BorrowedReborrowable => [BORROWED_REBORROWABLE],
+    pub(crate) BorrowedReborrowable => [BORROWED_REBORROWABLE],
 }
 
 impl<'tcx> LateLintPass<'tcx> for BorrowedReborrowable {

--- a/bevy_lint/src/lints/pedantic/main_return_without_appexit.rs
+++ b/bevy_lint/src/lints/pedantic/main_return_without_appexit.rs
@@ -45,13 +45,13 @@ use rustc_span::{Span, Symbol};
 use std::ops::ControlFlow;
 
 declare_bevy_lint! {
-    pub MAIN_RETURN_WITHOUT_APPEXIT,
+    pub(crate) MAIN_RETURN_WITHOUT_APPEXIT,
     super::Pedantic,
     "an entrypoint that calls `App::run()` does not return `AppExit`",
 }
 
 declare_bevy_lint_pass! {
-    pub MainReturnWithoutAppExit => [MAIN_RETURN_WITHOUT_APPEXIT],
+    pub(crate) MainReturnWithoutAppExit => [MAIN_RETURN_WITHOUT_APPEXIT],
     @default = {
         run: Symbol = sym!(run),
     },

--- a/bevy_lint/src/lints/restriction/missing_reflect.rs
+++ b/bevy_lint/src/lints/restriction/missing_reflect.rs
@@ -72,7 +72,7 @@ use rustc_middle::{span_bug, ty::TyCtxt};
 use rustc_span::Span;
 
 declare_bevy_lint! {
-    pub MISSING_REFLECT,
+    pub(crate) MISSING_REFLECT,
     super::Restriction,
     "defined a component, resource, or event without a `Reflect` implementation",
     // We only override `check_crate()`.
@@ -80,7 +80,7 @@ declare_bevy_lint! {
 }
 
 declare_bevy_lint_pass! {
-    pub MissingReflect => [MISSING_REFLECT],
+    pub(crate) MissingReflect => [MISSING_REFLECT],
 }
 
 impl<'tcx> LateLintPass<'tcx> for MissingReflect {

--- a/bevy_lint/src/lints/restriction/panicking_methods.rs
+++ b/bevy_lint/src/lints/restriction/panicking_methods.rs
@@ -63,13 +63,13 @@ use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 
 declare_bevy_lint! {
-    pub PANICKING_METHODS,
+    pub(crate) PANICKING_METHODS,
     super::Restriction,
     "called a method that can panic when a non-panicking alternative exists",
 }
 
 declare_bevy_lint_pass! {
-    pub PanickingMethods => [PANICKING_METHODS],
+    pub(crate) PanickingMethods => [PANICKING_METHODS],
 }
 
 impl<'tcx> LateLintPass<'tcx> for PanickingMethods {

--- a/bevy_lint/src/lints/style/unconventional_naming.rs
+++ b/bevy_lint/src/lints/style/unconventional_naming.rs
@@ -58,13 +58,13 @@ use rustc_span::symbol::Ident;
 use crate::{declare_bevy_lint, declare_bevy_lint_pass, utils::hir_parse::impls_trait};
 
 declare_bevy_lint! {
-    pub UNCONVENTIONAL_NAMING,
+    pub(crate) UNCONVENTIONAL_NAMING,
     super::Style,
     "unconventional type name for a `Plugin` or `SystemSet`",
 }
 
 declare_bevy_lint_pass! {
-    pub UnconventionalNaming => [UNCONVENTIONAL_NAMING],
+    pub(crate) UnconventionalNaming => [UNCONVENTIONAL_NAMING],
 }
 
 impl<'tcx> LateLintPass<'tcx> for UnconventionalNaming {

--- a/bevy_lint/src/lints/suspicious/insert_event_resource.rs
+++ b/bevy_lint/src/lints/suspicious/insert_event_resource.rs
@@ -57,13 +57,13 @@ use rustc_span::Symbol;
 use std::borrow::Cow;
 
 declare_bevy_lint! {
-    pub INSERT_EVENT_RESOURCE,
+    pub(crate) INSERT_EVENT_RESOURCE,
     super::Suspicious,
     "called `App::insert_resource(Events<T>)` or `App::init_resource::<Events<T>>()` instead of `App::add_event::<T>()`",
 }
 
 declare_bevy_lint_pass! {
-    pub InsertEventResource => [INSERT_EVENT_RESOURCE],
+    pub(crate) InsertEventResource => [INSERT_EVENT_RESOURCE],
     @default = {
         insert_resource: Symbol = sym!(insert_resource),
         init_resource: Symbol = sym!(init_resource),

--- a/bevy_lint/src/lints/suspicious/insert_unit_bundle.rs
+++ b/bevy_lint/src/lints/suspicious/insert_unit_bundle.rs
@@ -60,13 +60,13 @@ use rustc_span::Symbol;
 use crate::{declare_bevy_lint, declare_bevy_lint_pass, utils::hir_parse::MethodCall};
 
 declare_bevy_lint! {
-    pub INSERT_UNIT_BUNDLE,
+    pub(crate) INSERT_UNIT_BUNDLE,
     super::Suspicious,
     "inserted a `Bundle` containing a unit `()` type",
 }
 
 declare_bevy_lint_pass! {
-    pub InsertUnitBundle => [INSERT_UNIT_BUNDLE],
+    pub(crate) InsertUnitBundle => [INSERT_UNIT_BUNDLE],
     @default = {
         spawn: Symbol = sym!(spawn),
     },

--- a/bevy_lint/src/lints/suspicious/iter_current_update_events.rs
+++ b/bevy_lint/src/lints/suspicious/iter_current_update_events.rs
@@ -46,13 +46,13 @@ use rustc_span::Symbol;
 use crate::{declare_bevy_lint, declare_bevy_lint_pass, utils::hir_parse::MethodCall};
 
 declare_bevy_lint! {
-    pub ITER_CURRENT_UPDATE_EVENTS,
+    pub(crate) ITER_CURRENT_UPDATE_EVENTS,
     super::Suspicious,
     "called `Events::<T>::iter_current_update_events()`",
 }
 
 declare_bevy_lint_pass! {
-    pub IterCurrentUpdateEvents => [ITER_CURRENT_UPDATE_EVENTS],
+    pub(crate) IterCurrentUpdateEvents => [ITER_CURRENT_UPDATE_EVENTS],
 
     @default = {
         iter_current_update_events: Symbol = Symbol::intern("iter_current_update_events"),


### PR DESCRIPTION
Right now the lint static and lint pass type are visible in the documentation:

<img width="528" alt="image" src="https://github.com/user-attachments/assets/bbc7b754-6c1d-44e3-9b1f-72b585e0d62d" />

This originally was because these items had extra documentation useful to users. Since that's no longer the case, and these items now have no documentation, they can be made `pub(crate)` and hidden from the docs.