### PR TITLE
Allow custom web assets to be defined at package level

### DIFF
--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -131,9 +131,7 @@ pub fn create_web_bundle(
         wasm_file_name,
         js_file_name,
         assets_path: assets_path.exists().then(|| assets_path.to_owned()),
-        web_assets: web_assets_folder
-            .exists()
-            .then(|| web_assets_folder.to_owned()),
+        web_assets,
         index: Index::Content(index.clone()),
     };
 
@@ -191,7 +189,7 @@ pub fn create_web_bundle(
     }
 
     // Custom web assets
-    if let Some(web_assets) = web_assets {
+    if let Some(web_assets) = &linked.web_assets {
         tracing::debug!(
             "copying custom web assets from file://{}",
             web_assets.to_string_lossy()


### PR DESCRIPTION
# Objective

Closes #440.

We allow the user to provide custom web assets to fully control how the Bevy app is loaded.
However, it's currently only possible to provide the `web` folder for the whole workspace, providing custom assets for an individual package doesn't work.

# Solution

Search for the web folder first at the package level, then the workspace level.

# Testing

The [bevy_complex_repo](https://github.com/TimJentzsch/bevy_complex_repo) `workspace` folder has a `custom_web_folder` package where this can be tested.

Run `bevy run -p custom_web_folder web` in the `workspace` folder, with the CLI installed from this branch.

In the logs you should see that it's using the package-level web assets. The app itself should have an added "bevy" test in the HTML

# Future Work

The user might also want to customize the name of the folder / the entire path. This will be tackled in <https://github.com/TheBevyFlock/bevy_cli/issues/484>