### PR TITLE
Allow customization of wasm-opt args

### DIFF
--- a/src/build/args.rs
+++ b/src/build/args.rs
@@ -1,5 +1,7 @@
 use clap::{ArgAction, Args, Subcommand};
 
+#[cfg(feature = "web")]
+use crate::external_cli::external_cli_args::ExternalCliArgs;
 use crate::{
     config::CliConfig,
     external_cli::{
@@ -68,15 +70,15 @@ impl BuildArgs {
         self.cargo_args.args_builder(self.is_web())
     }
 
-    /// Whether to use `wasm-opt`.
-    ///
-    /// Defaults to `true` for release builds.
+    /// The flags to use for `wasm-opt` if building for the web.
     #[cfg(feature = "web")]
-    pub(crate) fn use_wasm_opt(&self) -> bool {
+    pub(crate) fn wasm_opt_args(&self) -> ExternalCliArgs {
+        use crate::external_cli::external_cli_args::ExternalCliArgs;
+
         if let Some(BuildSubcommands::Web(web_args)) = &self.subcommand {
-            web_args.use_wasm_opt.map_or(self.is_release(), |v| v)
+            ExternalCliArgs::from_raw_args(web_args.wasm_opt.clone())
         } else {
-            false
+            ExternalCliArgs::Enabled(false)
         }
     }
 
@@ -109,8 +111,14 @@ impl BuildArgs {
 
         #[cfg(feature = "web")]
         if let Some(BuildSubcommands::Web(web_args)) = self.subcommand.as_mut() {
-            if web_args.use_wasm_opt.is_none() {
-                web_args.use_wasm_opt = config.wasm_opt();
+            if web_args.wasm_opt.is_empty() {
+                if let Some(enabled) = config.wasm_opt() {
+                    if enabled {
+                        web_args.wasm_opt.push("true".to_string());
+                    } else {
+                        web_args.wasm_opt.push("false".to_string());
+                    };
+                }
             }
         }
     }
@@ -127,10 +135,14 @@ pub enum BuildSubcommands {
 /// Additional Arguments for building a Bevy web project.
 #[derive(Debug, Args, Default)]
 pub struct BuildWebArgs {
-    // Bundle all web artifacts into a single folder.
+    /// Bundle all web artifacts into a single folder.
     #[arg(short = 'b', long = "bundle", action = ArgAction::SetTrue, default_value_t = false)]
     pub create_packed_bundle: bool,
-    // Use `wasm-opt` to optimize the wasm binary
-    #[arg(long = "wasm-opt")]
-    pub use_wasm_opt: Option<bool>,
+    /// Use `wasm-opt` to optimize the wasm binary
+    ///
+    /// Defaults to `true` for release builds.
+    /// Can be set to `false` to skip optimization.
+    /// You can also specify custom arguments to use.
+    #[arg(long = "wasm-opt", allow_hyphen_values = true)]
+    pub wasm_opt: Vec<String>,
 }

--- a/src/external_cli/external_cli_args.rs
+++ b/src/external_cli/external_cli_args.rs
@@ -1,0 +1,62 @@
+/// Configure the arguments for an external CLI command.
+///
+/// Can either be disabled, enabled with default arguments, or enabled with custom arguments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalCliArgs {
+    /// Disable the external command if `false`, use default args if `true`.
+    Enabled(bool),
+    /// Enable and use the provided arguments.
+    Args(Vec<String>),
+}
+
+impl ExternalCliArgs {
+    /// Parse the arguments from a list.
+    ///
+    /// `true` and `false` are treated special, to enable or disable the command.
+    pub fn from_raw_args(args: Vec<String>) -> Option<Self> {
+        let mut cur_args = Vec::<String>::new();
+
+        for arg in args {
+            match arg.to_lowercase().as_str() {
+                "true" => return Some(Self::Enabled(true)),
+                "false" => return Some(Self::Enabled(false)),
+                _ => cur_args.push(arg),
+            }
+        }
+
+        if cur_args.is_empty() {
+            None
+        } else {
+            Some(Self::Args(cur_args))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_true() {
+        let args = vec!["true".to_string()];
+        let parsed = ExternalCliArgs::from_raw_args(args).unwrap();
+        assert!(matches!(parsed, ExternalCliArgs::Enabled(true)));
+    }
+
+    #[test]
+    fn should_parse_false() {
+        let args = vec!["false".to_string()];
+        let parsed = ExternalCliArgs::from_raw_args(args).unwrap();
+        assert!(matches!(parsed, ExternalCliArgs::Enabled(false)));
+    }
+
+    #[test]
+    fn should_parse_args() {
+        let args = vec!["arg1".to_string(), "arg2".to_string()];
+        let parsed = ExternalCliArgs::from_raw_args(args).unwrap();
+        assert!(matches!(
+            parsed,
+            ExternalCliArgs::Args(ref args) if args == &["arg1".to_string(), "arg2".to_string()]
+        ));
+    }
+}

--- a/src/external_cli/external_cli_args.rs
+++ b/src/external_cli/external_cli_args.rs
@@ -13,21 +13,21 @@ impl ExternalCliArgs {
     /// Parse the arguments from a list.
     ///
     /// `true` and `false` are treated special, to enable or disable the command.
-    pub fn from_raw_args(args: Vec<String>) -> Option<Self> {
+    pub fn from_raw_args(args: Vec<String>) -> Self {
         let mut cur_args = Vec::<String>::new();
 
         for arg in args {
             match arg.to_lowercase().as_str() {
-                "true" => return Some(Self::Enabled(true)),
-                "false" => return Some(Self::Enabled(false)),
+                "true" => return Self::Enabled(true),
+                "false" => return Self::Enabled(false),
                 _ => cur_args.push(arg),
             }
         }
 
         if cur_args.is_empty() {
-            None
+            Self::Enabled(false)
         } else {
-            Some(Self::Args(cur_args))
+            Self::Args(cur_args)
         }
     }
 }

--- a/src/external_cli/external_cli_args.rs
+++ b/src/external_cli/external_cli_args.rs
@@ -39,21 +39,21 @@ mod tests {
     #[test]
     fn should_parse_true() {
         let args = vec!["true".to_string()];
-        let parsed = ExternalCliArgs::from_raw_args(args).unwrap();
+        let parsed = ExternalCliArgs::from_raw_args(args);
         assert!(matches!(parsed, ExternalCliArgs::Enabled(true)));
     }
 
     #[test]
     fn should_parse_false() {
         let args = vec!["false".to_string()];
-        let parsed = ExternalCliArgs::from_raw_args(args).unwrap();
+        let parsed = ExternalCliArgs::from_raw_args(args);
         assert!(matches!(parsed, ExternalCliArgs::Enabled(false)));
     }
 
     #[test]
     fn should_parse_args() {
         let args = vec!["arg1".to_string(), "arg2".to_string()];
-        let parsed = ExternalCliArgs::from_raw_args(args).unwrap();
+        let parsed = ExternalCliArgs::from_raw_args(args);
         assert!(matches!(
             parsed,
             ExternalCliArgs::Args(ref args) if args == &["arg1".to_string(), "arg2".to_string()]

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -12,6 +12,7 @@ use tracing::{Level, debug, error, info, trace, warn};
 
 pub(crate) mod arg_builder;
 pub(crate) mod cargo;
+pub mod external_cli_args;
 #[cfg(feature = "rustup")]
 pub(crate) mod rustup;
 #[cfg(feature = "web")]

--- a/src/external_cli/wasm_bindgen.rs
+++ b/src/external_cli/wasm_bindgen.rs
@@ -53,9 +53,9 @@ pub(crate) fn bundle(
             ArgBuilder::new()
                 .arg("--no-typescript")
                 .add_with_value("--out-name", &bin_target.bin_name)
-                .add_with_value("--out-dir", bin_target.artifact_directory.to_string_lossy())
+                .add_with_value("--out-dir", bin_target.artifact_directory.as_os_str())
                 .add_with_value("--target", "web")
-                .arg(original_wasm.to_string_lossy()),
+                .arg(original_wasm.as_os_str()),
         )
         .ensure_status(auto_install)?;
 

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -53,10 +53,7 @@ pub fn build_web(
 
     info!("bundling JavaScript bindings...");
     wasm_bindgen::bundle(metadata, bin_target, args.auto_install())?;
-
-    if args.use_wasm_opt() {
-        wasm_opt::optimize_path(bin_target, args.auto_install())?;
-    }
+    wasm_opt::optimize_path(bin_target, args.auto_install(), &args.wasm_opt_args())?;
 
     let web_bundle = create_web_bundle(
         metadata,

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -91,12 +91,6 @@ pub fn create_web_bundle(
     .join(web_assets_folder);
     let workspace_web_assets = Path::new(&metadata.workspace_root).join(web_assets_folder);
 
-    tracing::debug!(
-        "package={:?}, workspace={:?}",
-        &package_web_assets,
-        &workspace_web_assets,
-    );
-
     // Search for custom web assets first in the package, then in the workspace
     let web_assets = if package_web_assets.exists() {
         info!("using custom package web assets.");


### PR DESCRIPTION
# Objective

Closes #442.

For further optimization, the user might want to get full control over the flags that are passed to `wasm-opt`.
At the same time, users also need an easy way to enable or disable `wasm-opt`, e.g. disabling it even in release mode or enabling it in dev mode.

# Solution

- The `--wasm-opt` CLI flag now also accepts multiple string values. These are passed as args to `wasm-opt`. Alternatively, you can still use `true` to enable the default flags or `false` to disable `wasm-opt` entirely.

# TODO

- Configuration via `Cargo.toml`
- Configuration in the book
- Changelog / Migration guide