### PR TITLE
Make `unconventional_naming` lint smarter 🧑‍🎓🍎🧠

### DIFF
--- a/bevy_lint/src/lints/style/unconventional_naming.rs
+++ b/bevy_lint/src/lints/style/unconventional_naming.rs
@@ -123,6 +123,7 @@ impl<'tcx> LateLintPass<'tcx> for UnconventionalNaming {
                 def_id: struct_local_def_id,
             }
             .into();
+
             span_lint_hir_and_then(
                 cx,
                 UNCONVENTIONAL_NAMING,
@@ -130,14 +131,11 @@ impl<'tcx> LateLintPass<'tcx> for UnconventionalNaming {
                 struct_span,
                 conventional_name_impl.lint_description(),
                 |diag| {
-                    diag.span_note(
-                        struct_span,
-                        format!(
-                            "structures that implement `{}` should end in `{}`",
-                            conventional_name_impl.name(),
-                            conventional_name_impl.suffix()
-                        ),
-                    );
+                    diag.note(format!(
+                        "structures that implement `{}` should end in \"{}\"",
+                        conventional_name_impl.name(),
+                        conventional_name_impl.suffix()
+                    ));
 
                     diag.span_suggestion(
                         struct_span,
@@ -235,7 +233,7 @@ impl TraitConvention {
 
                 // If none of the special cases are matched, simply append the suffix.
                 format!("{struct_name}{}", self.suffix())
-            },
+            }
         }
     }
 }

--- a/bevy_lint/src/lints/style/unconventional_naming.rs
+++ b/bevy_lint/src/lints/style/unconventional_naming.rs
@@ -209,9 +209,7 @@ impl TraitConvention {
                 // "Systems". If a struct was originally named `FooSet`, this suggests `FooSystems`
                 // instead of `FooSetSystems`.
                 for incorrect_suffix in INCORRECT_SUFFIXES {
-                    if struct_name.ends_with(incorrect_suffix) {
-                        let stripped_name =
-                            &struct_name[..(struct_name.len() - incorrect_suffix.len())];
+                    if let Some(stripped_name) = struct_name.strip_suffix(incorrect_suffix) {
                         return format!("{stripped_name}{}", self.suffix());
                     }
                 }
@@ -221,14 +219,13 @@ impl TraitConvention {
             }
             TraitConvention::Plugin => {
                 // If the name is prefixed with "Plugin", remove it and add it to the end.
-                if struct_name.starts_with("Plugin") {
-                    let stripped_name = &struct_name["Plugin".len()..];
+                if let Some(stripped_name) = struct_name.strip_prefix("Plugin") {
                     return format!("{stripped_name}{}", self.suffix());
                 }
 
                 // If "Plugins" is plural instead of singular, remove the "s" to make it singular.
-                if struct_name.ends_with("Plugins") {
-                    return struct_name[..(struct_name.len() - 1)].to_string();
+                if let Some(stripped_name) = struct_name.strip_suffix("Plugins") {
+                    return format!("{stripped_name}{}", self.suffix());
                 }
 
                 // If none of the special cases are matched, simply append the suffix.

--- a/bevy_lint/src/lints/style/unconventional_naming.rs
+++ b/bevy_lint/src/lints/style/unconventional_naming.rs
@@ -213,13 +213,29 @@ impl TraitConvention {
                 for incorrect_suffix in INCORRECT_SUFFIXES {
                     if struct_name.ends_with(incorrect_suffix) {
                         let stripped_name =
-                            &struct_name[0..(struct_name.len() - incorrect_suffix.len())];
+                            &struct_name[..(struct_name.len() - incorrect_suffix.len())];
                         return format!("{stripped_name}{}", self.suffix());
                     }
                 }
+
+                // If none of the special cases are matched, simply append the suffix.
                 format!("{struct_name}{}", self.suffix())
             }
-            TraitConvention::Plugin => format!("{struct_name}{}", self.suffix()),
+            TraitConvention::Plugin => {
+                // If the name is prefixed with "Plugin", remove it and add it to the end.
+                if struct_name.starts_with("Plugin") {
+                    let stripped_name = &struct_name["Plugin".len()..];
+                    return format!("{stripped_name}{}", self.suffix());
+                }
+
+                // If "Plugins" is plural instead of singular, remove the "s" to make it singular.
+                if struct_name.ends_with("Plugins") {
+                    return struct_name[..(struct_name.len() - 1)].to_string();
+                }
+
+                // If none of the special cases are matched, simply append the suffix.
+                format!("{struct_name}{}", self.suffix())
+            },
         }
     }
 }

--- a/bevy_lint/tests/ui/unconventional_naming/plugin.rs
+++ b/bevy_lint/tests/ui/unconventional_naming/plugin.rs
@@ -34,3 +34,23 @@ impl Plugin for Baz {
 fn main() {
     App::new().add_plugins((Foo, BarPlugin, Baz));
 }
+
+struct PluginFoo;
+//~^ ERROR: unconventional type name for a `Plugin`
+//~| NOTE: structures that implement `Plugin` should end in `Plugin`
+//~| HELP: rename `PluginFoo`
+
+//~v NOTE: `Plugin` implemented here
+impl Plugin for PluginFoo {
+    fn build(&self, _app: &mut App) {}
+}
+
+struct FooPlugins;
+//~^ ERROR: unconventional type name for a `Plugin`
+//~| NOTE: structures that implement `Plugin` should end in `Plugin`
+//~| HELP: rename `FooPlugins`
+
+//~v NOTE: `Plugin` implemented here
+impl Plugin for FooPlugins {
+    fn build(&self, _app: &mut App) {}
+}

--- a/bevy_lint/tests/ui/unconventional_naming/plugin.rs
+++ b/bevy_lint/tests/ui/unconventional_naming/plugin.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 // This should raise an error, since it does not end in "Plugin".
 struct Foo;
 //~^ ERROR: unconventional type name for a `Plugin`
-//~| NOTE: structures that implement `Plugin` should end in `Plugin`
+//~| NOTE: structures that implement `Plugin` should end in "Plugin"
 //~| HELP: rename `Foo`
 
 //~v NOTE: `Plugin` implemented here
@@ -37,7 +37,7 @@ fn main() {
 
 struct PluginFoo;
 //~^ ERROR: unconventional type name for a `Plugin`
-//~| NOTE: structures that implement `Plugin` should end in `Plugin`
+//~| NOTE: structures that implement `Plugin` should end in "Plugin"
 //~| HELP: rename `PluginFoo`
 
 //~v NOTE: `Plugin` implemented here
@@ -47,7 +47,7 @@ impl Plugin for PluginFoo {
 
 struct FooPlugins;
 //~^ ERROR: unconventional type name for a `Plugin`
-//~| NOTE: structures that implement `Plugin` should end in `Plugin`
+//~| NOTE: structures that implement `Plugin` should end in "Plugin"
 //~| HELP: rename `FooPlugins`
 
 //~v NOTE: `Plugin` implemented here

--- a/bevy_lint/tests/ui/unconventional_naming/plugin.stderr
+++ b/bevy_lint/tests/ui/unconventional_naming/plugin.stderr
@@ -4,11 +4,7 @@ error: unconventional type name for a `Plugin`
 9  | struct Foo;
    |        ^^^ help: rename `Foo`: `FooPlugin`
    |
-note: structures that implement `Plugin` should end in `Plugin`
-  --> tests/ui/unconventional_naming/plugin.rs:9:8
-   |
-9  | struct Foo;
-   |        ^^^
+   = note: structures that implement `Plugin` should end in "Plugin"
 note: `Plugin` implemented here
   --> tests/ui/unconventional_naming/plugin.rs:15:1
    |
@@ -28,11 +24,7 @@ error: unconventional type name for a `Plugin`
 38 | struct PluginFoo;
    |        ^^^^^^^^^ help: rename `PluginFoo`: `FooPlugin`
    |
-note: structures that implement `Plugin` should end in `Plugin`
-  --> tests/ui/unconventional_naming/plugin.rs:38:8
-   |
-38 | struct PluginFoo;
-   |        ^^^^^^^^^
+   = note: structures that implement `Plugin` should end in "Plugin"
 note: `Plugin` implemented here
   --> tests/ui/unconventional_naming/plugin.rs:44:1
    |
@@ -47,11 +39,7 @@ error: unconventional type name for a `Plugin`
 48 | struct FooPlugins;
    |        ^^^^^^^^^^ help: rename `FooPlugins`: `FooPlugin`
    |
-note: structures that implement `Plugin` should end in `Plugin`
-  --> tests/ui/unconventional_naming/plugin.rs:48:8
-   |
-48 | struct FooPlugins;
-   |        ^^^^^^^^^^
+   = note: structures that implement `Plugin` should end in "Plugin"
 note: `Plugin` implemented here
   --> tests/ui/unconventional_naming/plugin.rs:54:1
    |

--- a/bevy_lint/tests/ui/unconventional_naming/plugin.stderr
+++ b/bevy_lint/tests/ui/unconventional_naming/plugin.stderr
@@ -22,5 +22,43 @@ note: the lint level is defined here
 3  | #![deny(bevy::unconventional_naming)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: unconventional type name for a `Plugin`
+  --> tests/ui/unconventional_naming/plugin.rs:38:8
+   |
+38 | struct PluginFoo;
+   |        ^^^^^^^^^ help: rename `PluginFoo`: `FooPlugin`
+   |
+note: structures that implement `Plugin` should end in `Plugin`
+  --> tests/ui/unconventional_naming/plugin.rs:38:8
+   |
+38 | struct PluginFoo;
+   |        ^^^^^^^^^
+note: `Plugin` implemented here
+  --> tests/ui/unconventional_naming/plugin.rs:44:1
+   |
+44 | / impl Plugin for PluginFoo {
+45 | |     fn build(&self, _app: &mut App) {}
+46 | | }
+   | |_^
+
+error: unconventional type name for a `Plugin`
+  --> tests/ui/unconventional_naming/plugin.rs:48:8
+   |
+48 | struct FooPlugins;
+   |        ^^^^^^^^^^ help: rename `FooPlugins`: `FooPlugin`
+   |
+note: structures that implement `Plugin` should end in `Plugin`
+  --> tests/ui/unconventional_naming/plugin.rs:48:8
+   |
+48 | struct FooPlugins;
+   |        ^^^^^^^^^^
+note: `Plugin` implemented here
+  --> tests/ui/unconventional_naming/plugin.rs:54:1
+   |
+54 | / impl Plugin for FooPlugins {
+55 | |     fn build(&self, _app: &mut App) {}
+56 | | }
+   | |_^
+
+error: aborting due to 3 previous errors
 

--- a/bevy_lint/tests/ui/unconventional_naming/spoofed_name.rs
+++ b/bevy_lint/tests/ui/unconventional_naming/spoofed_name.rs
@@ -12,7 +12,7 @@ mod bar {
     pub mod baz {
         pub struct Foo;
         //~^ ERROR: unconventional type name for a `Plugin`
-        //~| NOTE: structures that implement `Plugin` should end in `Plugin`
+        //~| NOTE: structures that implement `Plugin` should end in "Plugin"
         //~| HELP: rename `Foo`
     }
 }

--- a/bevy_lint/tests/ui/unconventional_naming/spoofed_name.stderr
+++ b/bevy_lint/tests/ui/unconventional_naming/spoofed_name.stderr
@@ -4,11 +4,7 @@ error: unconventional type name for a `Plugin`
 13 |         pub struct Foo;
    |                    ^^^ help: rename `Foo`: `FooPlugin`
    |
-note: structures that implement `Plugin` should end in `Plugin`
-  --> tests/ui/unconventional_naming/spoofed_name.rs:13:20
-   |
-13 |         pub struct Foo;
-   |                    ^^^
+   = note: structures that implement `Plugin` should end in "Plugin"
 note: `Plugin` implemented here
   --> tests/ui/unconventional_naming/spoofed_name.rs:24:1
    |

--- a/bevy_lint/tests/ui/unconventional_naming/system_set.rs
+++ b/bevy_lint/tests/ui/unconventional_naming/system_set.rs
@@ -9,7 +9,7 @@ use bevy::prelude::*;
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 struct MyAudio;
 //~^ ERROR: unconventional type name for a `SystemSet`
-//~| NOTE: structures that implement `SystemSet` should end in `Systems`
+//~| NOTE: structures that implement `SystemSet` should end in "Systems"
 //~| HELP: rename `MyAudio`
 
 // This should not raise an error since the Set ends in `Set`
@@ -20,19 +20,19 @@ struct MyAudioSystems;
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 struct MyAudioSystem;
 //~^ ERROR: unconventional type name for a `SystemSet`
-//~| NOTE: structures that implement `SystemSet` should end in `Systems`
+//~| NOTE: structures that implement `SystemSet` should end in "Systems"
 //~| HELP: rename `MyAudioSystem`
 
 //~v NOTE: `SystemSet` implemented here
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 struct MyAudioSet;
 //~^ ERROR: unconventional type name for a `SystemSet`
-//~| NOTE: structures that implement `SystemSet` should end in `Systems`
+//~| NOTE: structures that implement `SystemSet` should end in "Systems"
 //~| HELP: rename `MyAudioSet`
 
 //~v NOTE: `SystemSet` implemented here
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 struct MyAudioSteps;
 //~^ ERROR: unconventional type name for a `SystemSet`
-//~| NOTE: structures that implement `SystemSet` should end in `Systems`
+//~| NOTE: structures that implement `SystemSet` should end in "Systems"
 //~| HELP: rename `MyAudioSteps`

--- a/bevy_lint/tests/ui/unconventional_naming/system_set.stderr
+++ b/bevy_lint/tests/ui/unconventional_naming/system_set.stderr
@@ -4,11 +4,7 @@ error: unconventional type name for a `SystemSet`
 10 | struct MyAudio;
    |        ^^^^^^^ help: rename `MyAudio`: `MyAudioSystems`
    |
-note: structures that implement `SystemSet` should end in `Systems`
-  --> tests/ui/unconventional_naming/system_set.rs:10:8
-   |
-10 | struct MyAudio;
-   |        ^^^^^^^
+   = note: structures that implement `SystemSet` should end in "Systems"
 note: `SystemSet` implemented here
   --> tests/ui/unconventional_naming/system_set.rs:9:10
    |
@@ -27,11 +23,7 @@ error: unconventional type name for a `SystemSet`
 21 | struct MyAudioSystem;
    |        ^^^^^^^^^^^^^ help: rename `MyAudioSystem`: `MyAudioSystems`
    |
-note: structures that implement `SystemSet` should end in `Systems`
-  --> tests/ui/unconventional_naming/system_set.rs:21:8
-   |
-21 | struct MyAudioSystem;
-   |        ^^^^^^^^^^^^^
+   = note: structures that implement `SystemSet` should end in "Systems"
 note: `SystemSet` implemented here
   --> tests/ui/unconventional_naming/system_set.rs:20:10
    |
@@ -45,11 +37,7 @@ error: unconventional type name for a `SystemSet`
 28 | struct MyAudioSet;
    |        ^^^^^^^^^^ help: rename `MyAudioSet`: `MyAudioSystems`
    |
-note: structures that implement `SystemSet` should end in `Systems`
-  --> tests/ui/unconventional_naming/system_set.rs:28:8
-   |
-28 | struct MyAudioSet;
-   |        ^^^^^^^^^^
+   = note: structures that implement `SystemSet` should end in "Systems"
 note: `SystemSet` implemented here
   --> tests/ui/unconventional_naming/system_set.rs:27:10
    |
@@ -63,11 +51,7 @@ error: unconventional type name for a `SystemSet`
 35 | struct MyAudioSteps;
    |        ^^^^^^^^^^^^ help: rename `MyAudioSteps`: `MyAudioSystems`
    |
-note: structures that implement `SystemSet` should end in `Systems`
-  --> tests/ui/unconventional_naming/system_set.rs:35:8
-   |
-35 | struct MyAudioSteps;
-   |        ^^^^^^^^^^^^
+   = note: structures that implement `SystemSet` should end in "Systems"
 note: `SystemSet` implemented here
   --> tests/ui/unconventional_naming/system_set.rs:34:10
    |


### PR DESCRIPTION
Closes #393.

This PR makes two separate improvements to the `unconventional_naming` lint. The first commit makes the lint suggestion smarter when encountering alternate plugin naming conventions:

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/5d9d316e-9813-4475-bfb0-e7c64d25f496" />

<img width="1123" alt="image" src="https://github.com/user-attachments/assets/ed9159e5-8b10-4ef8-8ec2-5b7e7bd63f25" />

The lint now correctly detects the `PluginFoo` and `FooPlugins` conventions, and correctly suggests the new name. No more `PluginFooPlugin`! 🪄

The second commit shrinks the amount of diagnostics we print per lint warning. Before, we were printing the plugin / system set definition twice! (The red box in the image.) There's no need to print it more than once, so this commit switches from `span_note()` to just `note()`. It also switches from carets `` ` `` to quotes `"` when printing the desired suffix, as it's text and not code.

![image](https://github.com/user-attachments/assets/7eb8ecb7-cb2a-48d7-9464-43d321f0a49c)
