### PR TITLE
Fix docs redirects

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -17,32 +17,32 @@ site-url = "/bevy_cli/"
 # which should give most users apt time to update their URLs.
 [output.html.redirect]
 # Those trying to find the old linter docs will be redirected to the new docs.
-"/bevy_lint/index.html" = "/linter/index.html"
+"/bevy_lint/index.html" = "../linter/index.html"
 
 # Those trying to find the list of lints will be redirected to the new location.
-"/bevy_lint/lints/index.html" = "/api/bevy_lint/lints/index.html"
+"/bevy_lint/lints/index.html" = "../../api/bevy_lint/lints/index.html"
 
 # Those trying to find the docs on a specific lint group will be redirected to the new location.
-"/bevy_lint/lints/complexity/index.html" = "/api/bevy_lint/lints/complexity/index.html"
-"/bevy_lint/lints/correctness/index.html" = "/api/bevy_lint/lints/correctness/index.html"
-"/bevy_lint/lints/nursery/index.html" = "/api/bevy_lint/lints/nursery/index.html"
-"/bevy_lint/lints/pedantic/index.html" = "/api/bevy_lint/lints/pedantic/index.html"
-"/bevy_lint/lints/performance/index.html" = "/api/bevy_lint/lints/performance/index.html"
-"/bevy_lint/lints/restriction/index.html" = "/api/bevy_lint/lints/restriction/index.html"
-"/bevy_lint/lints/style/index.html" = "/api/bevy_lint/lints/style/index.html"
-"/bevy_lint/lints/suspicious/index.html" = "/api/bevy_lint/lints/suspicious/index.html"
+"/bevy_lint/lints/complexity/index.html" = "../../../api/bevy_lint/lints/complexity/index.html"
+"/bevy_lint/lints/correctness/index.html" = "../../../api/bevy_lint/lints/correctness/index.html"
+"/bevy_lint/lints/nursery/index.html" = "../../../api/bevy_lint/lints/nursery/index.html"
+"/bevy_lint/lints/pedantic/index.html" = "../../../api/bevy_lint/lints/pedantic/index.html"
+"/bevy_lint/lints/performance/index.html" = "../../../api/bevy_lint/lints/performance/index.html"
+"/bevy_lint/lints/restriction/index.html" = "../../../api/bevy_lint/lints/restriction/index.html"
+"/bevy_lint/lints/style/index.html" = "../../../api/bevy_lint/lints/style/index.html"
+"/bevy_lint/lints/suspicious/index.html" = "../../../api/bevy_lint/lints/suspicious/index.html"
 
 # Those trying to find the docs on a specific lint will be redirected to the new location.
-"/bevy_lint/lints/nursery/duplicate_bevy_dependencies/index.html" = "/api/bevy_lint/lints/nursery/duplicate_bevy_dependencies/index.html"
-"/bevy_lint/lints/nursery/zst_query/index.html" = "/api/bevy_lint/lints/nursery/zst_query/index.html"
-"/bevy_lint/lints/pedantic/borrowed_reborrowable/index.html" = "/api/bevy_lint/lints/pedantic/borrowed_reborrowable/index.html"
-"/bevy_lint/lints/pedantic/main_return_without_appexit/index.html" = "/api/bevy_lint/lints/pedantic/main_return_without_appexit/index.html"
-"/bevy_lint/lints/restriction/missing_reflect/index.html" = "/api/bevy_lint/lints/restriction/missing_reflect/index.html"
-"/bevy_lint/lints/restriction/panicking_methods/index.html" = "/api/bevy_lint/lints/restriction/panicking_methods/index.html"
-"/bevy_lint/lints/style/unconventional_naming/index.html" = "/api/bevy_lint/lints/style/unconventional_naming/index.html"
-"/bevy_lint/lints/suspicious/insert_event_resource/index.html" = "/api/bevy_lint/lints/suspicious/insert_event_resource/index.html"
-"/bevy_lint/lints/suspicious/insert_unit_bundle/index.html" = "/api/bevy_lint/lints/suspicious/insert_unit_bundle/index.html"
-"/bevy_lint/lints/suspicious/iter_current_update_events/index.html" = "/api/bevy_lint/lints/suspicious/iter_current_update_events/index.html"
+"/bevy_lint/lints/nursery/duplicate_bevy_dependencies/index.html" = "../../../../api/bevy_lint/lints/nursery/duplicate_bevy_dependencies/index.html"
+"/bevy_lint/lints/nursery/zst_query/index.html" = "../../../../api/bevy_lint/lints/nursery/zst_query/index.html"
+"/bevy_lint/lints/pedantic/borrowed_reborrowable/index.html" = "../../../../api/bevy_lint/lints/pedantic/borrowed_reborrowable/index.html"
+"/bevy_lint/lints/pedantic/main_return_without_appexit/index.html" = "../../../../api/bevy_lint/lints/pedantic/main_return_without_appexit/index.html"
+"/bevy_lint/lints/restriction/missing_reflect/index.html" = "../../../../api/bevy_lint/lints/restriction/missing_reflect/index.html"
+"/bevy_lint/lints/restriction/panicking_methods/index.html" = "../../../../api/bevy_lint/lints/restriction/panicking_methods/index.html"
+"/bevy_lint/lints/style/unconventional_naming/index.html" = "../../../../api/bevy_lint/lints/style/unconventional_naming/index.html"
+"/bevy_lint/lints/suspicious/insert_event_resource/index.html" = "../../../../api/bevy_lint/lints/suspicious/insert_event_resource/index.html"
+"/bevy_lint/lints/suspicious/insert_unit_bundle/index.html" = "../../../../api/bevy_lint/lints/suspicious/insert_unit_bundle/index.html"
+"/bevy_lint/lints/suspicious/iter_current_update_events/index.html" = "../../../../api/bevy_lint/lints/suspicious/iter_current_update_events/index.html"
 
 # `mdbook-linkcheck` <https://github.com/Michael-F-Bryan/mdbook-linkcheck> is a backend that
 # verifies links are correct.


### PR DESCRIPTION
When we migrated to `mdbook`, I added redirect pages to send people to the new page. For example, <https://thebevyflock.github.io/bevy_cli/bevy_lint/> should redirect to <https://thebevyflock.github.io/bevy_cli/linter/index.html>.

Unfortunately, I made these redirects absolute paths, which don't work because everything in the website is prefixed with `/bevy_cli`. This PR switches the redirects to relative paths, so they work both with `mdbook serve` and when published through Github Pages.

While they're ugly, in a month we should be good to completely remove most of these redirects.