### PR TITLE
Make linter action more ergonomic

### DIFF
--- a/.github/workflows/linter-action.yml
+++ b/.github/workflows/linter-action.yml
@@ -3,10 +3,11 @@ name: Test linter action
 on:
   push:
     branches: [main]
-  # Only run for pull requests when the action is modified.
+  # Only run for pull requests when the action or toolchain is modified.
   pull_request:
     paths:
       - bevy_lint/action.yml
+      - rust-toolchain.toml
   workflow_dispatch:
 
 jobs:

--- a/bevy_lint/action.yml
+++ b/bevy_lint/action.yml
@@ -12,20 +12,39 @@ description: |
 runs:
   using: composite
   steps:
+    # Used to read `rust-toolchain.toml`.
+    - name: Install Taplo
+      uses: taiki-e/install-action@v2
+      with:
+        tool: taplo
+
+    # Read `rust-toolchain.toml` to find the exact nightly toolchain the linter needs.
+    - name: Extract toolchain
+      id: toolchain
+      shell: bash
+      run: |
+        CHANNEL=$(taplo get --file-path="${RUST_TOOLCHAIN_PATH}" 'toolchain.channel')
+        COMPONENTS=$(taplo get --file-path="${RUST_TOOLCHAIN_PATH}" --separator=', ' 'toolchain.components')
+
+        echo "channel=${CHANNEL}" >> "${GITHUB_OUTPUT}"
+        echo "components=${COMPONENTS}" >> "${GITHUB_OUTPUT}"
+      env:
+        RUST_TOOLCHAIN_PATH: ${{ github.action_path }}/../rust-toolchain.toml
+
     - name: Install Rust toolchain and components
       uses: dtolnay/rust-toolchain@master
       with:
-        # This must be kept in sync with `rust-toolchain.toml`.
-        toolchain: nightly-2025-05-14
-        components: rustc-dev, llvm-tools-preview
+        toolchain: ${{ steps.toolchain.outputs.channel }}
+        components: ${{ steps.toolchain.outputs.components }}
 
     - name: Install `bevy_lint`
       shell: bash
       run: |
-        # The toolchain must be kept in sync with `rust-toolchain.toml`. The `--branch main` should
-        # be swapped with `--tag lint-vX.Y.Z` for releases.
-        rustup run nightly-2025-05-14 cargo install \
-          --git https://github.com/TheBevyFlock/bevy_cli.git \
-          --branch main \
-          --locked \
-          bevy_lint
+        rustup run "${RUST_CHANNEL}" cargo install \
+          --path "${BEVY_LINT_PATH}" \
+          --locked
+      env:
+        RUST_CHANNEL: ${{ steps.toolchain.outputs.channel }}
+        # As the full contents of `TheBevyFlock/bevy_cli` is included alongside this action, we can
+        # install the linter relative to the action path.
+        BEVY_LINT_PATH: ${{ github.action_path }}

--- a/docs/src/contribute/linter/how-to/release.md
+++ b/docs/src/contribute/linter/how-to/release.md
@@ -8,11 +8,9 @@
 4. Review the migration guide (`bevy_lint/MIGRATION.md`) and ensure all breaking / significant changes from the previous version are documented.
 5. Remove the `-dev` suffix from the version in `Cargo.toml` and the compatibility table in `bevy_lint/README.md`.
     - Please ensure that `Cargo.lock` also updates!
-6. Replace `--branch main` in `action.yml` with `--tag lint-vX.Y.Z`.
-    - The `linter-action.yml` workflow may fail as the tag does not exist yet. This is fine!
-7. Update the toolchain install, `bevy_lint` install, and `bevy_lint` uninstall commands in both `README.md` and the [install page](../../../linter/install.md) to use the latest version and toolchain.
-8. Commit all of these changes and open a pull request.
-9. Merge the PR once a core Bevy maintainer approves it with no outstanding issues from other contributors.
+6. Update the toolchain install, `bevy_lint` install, and `bevy_lint` uninstall commands in both `README.md` and the [install page](../../../linter/install.md) to use the latest version and toolchain.
+7. Commit all of these changes and open a pull request.
+8. Merge the PR once a core Bevy maintainer approves it with no outstanding issues from other contributors.
     - This starts the release process, enacting a freeze on all other changes until the release has finished. While maintainers need to be aware of this so they do not merge PRs during this time, the release process should take less than an hour, so it's unlikely to ever be an issue.
 
 ## Release on Github
@@ -74,6 +72,5 @@ rustup run nightly-YYYY-MM-DD cargo install \
 
 2. Bump the version in `Cargo.toml` to the next `-dev` version, and ensure `Cargo.lock` also updates.
 3. Add a new row to the compatibility table for the new `-dev` version in `README.md`.
-4. Replace `--tag lint-vX.Y.Z` in `action.yml` with `--branch main`.
-5. Commit all of these changes and open a pull request.
-6. Merge the PR after it has been approved, unblocking frozen pull requests.
+4. Commit all of these changes and open a pull request.
+5. Merge the PR after it has been approved, unblocking frozen pull requests.

--- a/docs/src/contribute/linter/how-to/upgrade-rust-toolchain.md
+++ b/docs/src/contribute/linter/how-to/upgrade-rust-toolchain.md
@@ -13,7 +13,6 @@
 2. Change the `channel` field in `rust-toolchain.toml` to the version specified by `clippy_utils`.
 3. Update the [compatibility table](../../../linter/compatibility.md) for the latest `-dev` version.
 4. Increase the version of `clippy_utils` in `Cargo.toml` to the latest version.
-5. Change the two occurrences of the toolchain in `action.yml` to the new version.
 
 Once you've finished upgrading the Rust toolchain and `clippy_utils`, there are a few extra steps that can verify `bevy_lint` still functions the same.
 


### PR DESCRIPTION
# Context

The [Github Action we provide for the linter](https://thebevyflock.github.io/bevy_cli/linter/github-actions.html) isn't great. It works well for installing from a release or from `main`, but breaks down when installing a specific commit. This is because we currently hardcode values in `action.yml`:

https://github.com/TheBevyFlock/bevy_cli/blob/ff8d39aba29f6f04aecd7f8ec429d173649646ee/bevy_lint/action.yml#L18-L19

https://github.com/TheBevyFlock/bevy_cli/blob/ff8d39aba29f6f04aecd7f8ec429d173649646ee/bevy_lint/action.yml#L25-L31

This is an extra maintenance burden that we shouldn't have to do! If the user wants to install a specific commit of the linter, it should work as expected instead of installing the `main` branch:

```yml
# Should install this specific commit of the linter, but installs `main` instead.
- name: Install `bevy_lint`
  uses: TheBevyFlock/bevy_cli/bevy_lint@ff8d39a
```

# Solution

Thankfully, the fix is easier than expected. `action.yml` is a composite action, meaning it's a single YAML file that slings around other actions and shell scripts to do things. The great thing about this is that, when an action runner downloads a composite action, it downloads **the entire repository**. That means `rust-toolchain.toml` and the correct source code for `bevy_lint` already exist, we just have to install them!

This PR does just that. It uses the venerable [Taplo](https://taplo.tamasfe.dev/) to read `rust-toolchain.toml` and then runs `cargo install --path ...` to install the linter. The action especially uses the `${{ github.action_path }}` variable to locate the `bevy_lint` folder.

# Testing

[`linter-action.yml`](https://github.com/TheBevyFlock/bevy_cli/blob/ff8d39aba29f6f04aecd7f8ec429d173649646ee/.github/workflows/linter-action.yml) is doing a lot of the heavy-lifting here by testing the linter action in CI. I'll also spin up a separate repository to prove it works for others as well!