### PR TITLE
Add page on Rust Analyzer support for `bevy_lint`

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
     - [Toggling Lints in Code](linter/usage/toggling-lints-code.md)
 - [Compatibility](linter/compatibility.md)
 - [Environmental Variables](linter/environmental-variables.md)
+- [Rust Analyzer Support](linter/rust-analyzer.md)
 - [Github Actions](linter/github-actions.md)
 - [Troubleshooting](linter/troubleshooting.md)
 - [Changelog](linter/changelog.md)

--- a/docs/src/linter/rust-analyzer.md
+++ b/docs/src/linter/rust-analyzer.md
@@ -1,0 +1,20 @@
+# Rust Analyzer Support
+
+If your code editor or IDE supports [Rust Analyzer](https://rust-analyzer.github.io), you can configure it to use `bevy_lint` instead of `cargo check`. This will let you easily see Bevy-specific warnings and quick fixes in your project, alongside the normal checks like `dead_code` and `unexpected_cfgs`.
+
+To do this, you will need to override the `rust-analyzer.check.overrideCommand` configuration value:
+
+```json
+{
+    "rust-analyzer.check.overrideCommand": [
+        "bevy_lint",
+        "--workspace",
+        "--all-targets",
+        "--message-format=json-diagnostic-rendered-ansi",
+    ]
+}
+```
+
+Check Rust Analyzer's and your editor's docs to see where to set this configuration. For example, it is [`.vscode/settings.json` for VSCode](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer#configuration) and [`languages.toml` for Helix](https://github.com/helix-editor/helix/wiki/Language-Server-Configurations#rust).
+
+If your editor does not support colorful diagnostics, you may need to set the message format to `--message-format=json` instead.


### PR DESCRIPTION
I posted this video recently in the Bevy Discord:

https://github.com/user-attachments/assets/a624976c-cfaf-438d-8b83-6bbeed72620c

This PR adds a short little page describing how to set up `bevy_lint` to show diagnostics within your editor. Pretty nifty!