### PR TITLE
Support running `bevy_lint_driver` without the `rustc` path

### DIFF
--- a/bevy_lint/src/bin/driver.rs
+++ b/bevy_lint/src/bin/driver.rs
@@ -5,7 +5,7 @@ extern crate rustc_driver;
 extern crate rustc_session;
 extern crate rustc_span;
 
-use std::process::ExitCode;
+use std::{ffi::OsStr, path::Path, process::ExitCode};
 
 use bevy_lint::BevyLintCallback;
 use rustc_driver::{catch_with_exit_code, init_rustc_env_logger, install_ice_hook, run_compiler};
@@ -31,12 +31,24 @@ fn main() -> ExitCode {
     // Run the passed closure, but catch any panics and return the respective exit code.
     let exit_code = catch_with_exit_code(move || {
         // Get the arguments passed through the CLI. This is equivalent to `std::env::args()`, but
-        // it returns a `Result` instead of panicking.
+        // it prints a pretty error message instead of panicking when encountering non-UTF-8 args.
         let mut args = rustc_driver::args::raw_args(&early_dcx);
 
-        // The arguments are formatted as `[DRIVER_PATH, RUSTC_PATH, ARGS...]`. We skip the driver
-        // path so that `run_compiler()` just sees `rustc`'s path.
-        args.remove(0);
+        // There are two scenarios we want to catch:
+        // 1. When called by Cargo: `[DRIVER_PATH, RUSTC_PATH, ...ARGS]`
+        // 2. When called by user: `[DRIVER_PATH, ...ARGS]`
+        //
+        // This handles both cases and converts the args to `[RUSTC_PATH, ...ARGS]`, since that is
+        // what `run_compiler()` expects.
+        let args =
+            if args.get(1).map(Path::new).and_then(Path::file_stem) == Some(OsStr::new("rustc")) {
+                // When called by Cargo, remove the driver path.
+                &args[1..]
+            } else {
+                // When called by user, replace the driver path with the `rustc` path.
+                args[0] = "rustc".to_string();
+                &args
+            };
 
         // Call the compiler with our custom callback.
         run_compiler(&args, &mut BevyLintCallback);

--- a/bevy_lint/tests/test_utils/mod.rs
+++ b/bevy_lint/tests/test_utils/mod.rs
@@ -27,11 +27,6 @@ pub fn base_config(test_dir: &str) -> color_eyre::Result<Config> {
     );
 
     let config = Config {
-        // When `host` is `None`, `ui_test` will attempt to auto-discover the host by calling
-        // `program -vV`. Unfortunately, `bevy_lint_driver` does not yet support the version flag,
-        // so we manually specify the host as an empty string. This means that, for now, host-
-        // specific configuration in UI tests will not work.
-        host: Some(String::new()),
         program: CommandBuilder {
             // We call `rustup run` to setup the proper environmental variables, so that
             // `bevy_lint_driver` can link to `librustc_driver.so`.


### PR DESCRIPTION
# Problem

Right now, `bevy_lint_driver` expects itself to be called like:

```sh
$ bevy_lint_driver /path/to/rustc ...ARGUMENTS
```

It expects its first argument to be the path to `rustc`, as [that's what Cargo passes to it](https://doc.rust-lang.org/cargo/reference/config.html#buildrustc-workspace-wrapper). This, however, can lead to confusion when a normal user tries to run `bevy_lint_driver` as if it were `rustc`:

```sh
$ rustc --version
rustc 1.89.0-nightly (414482f6a 2025-05-13)

$ bevy_lint_driver --version
Usage: rustc [OPTIONS] INPUT

Options:
    -h, --help          Display this message
        --cfg <SPEC>    Configure the compilation environment.
                        SPEC supports the syntax `<NAME>[="<VALUE>"]`.
# ...
```

Unbeknownst to them, `bevy_lint_driver` silently ate `--version` because it thought it was the path to `rustc`. Instead, the user should have run:

```sh
$ bevy_lint_driver rustc --version
```

This behavior is problematic because it's undocumented and breaks our UI tests, forcing us to use a workaround.

# Solution

The path to `rustc` is now optional. If it is not specified, `bevy_lint_driver` assume it is simply the string `"rustc"` and fill it in for you. This means this now works:

```sh
$ bevy_lint_driver --version
rustc 1.89.0-nightly (414482f6a 2025-05-13)
```

I use some optimized slice trickery to avoid reallocations when performing this adjustment, so the implementation isn't as simple as described. With this change, we can finally remove the `ui_test` hack, which is super nice!

I still wouldn't recommend using `bevy_lint_driver` directly as a user, which is why it's not documented much, but this removes one of its sharp edges.