### PR TITLE
Rename linter binary sources to their executable names

### DIFF
--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -9,17 +9,6 @@ license = "MIT OR Apache-2.0"
 # While there are two binaries available, only `bevy_lint` is intended to be called by users.
 default-run = "bevy_lint"
 
-# The main entrypoint for using Bevy lints. This program is intended to be called by users.
-[[bin]]
-name = "bevy_lint"
-path = "src/bin/main.rs"
-
-# The internal program called by `cargo` instead of `rustc`. While this is where the lints are
-# registered, it is not intended to be called by users.
-[[bin]]
-name = "bevy_lint_driver"
-path = "src/bin/driver.rs"
-
 [[test]]
 name = "ui"
 harness = false

--- a/bevy_lint/src/bin/bevy_lint.rs
+++ b/bevy_lint/src/bin/bevy_lint.rs
@@ -1,3 +1,7 @@
+//! The main entrypoint for using Bevy lints, mimicking the CLI interface of `cargo check`.
+//!
+//! This program is intended to be called by users.
+
 use std::{
     env,
     ffi::OsString,

--- a/bevy_lint/src/bin/bevy_lint_driver.rs
+++ b/bevy_lint/src/bin/bevy_lint_driver.rs
@@ -1,3 +1,7 @@
+//! A `rustc` wrapper that does the actual linting, called by the main `bevy_lint` executable.
+//!
+//! While this mostly mimics `rustc`'s CLI interface, it is not intended to be called by users.
+
 // Enables linking to `rustc` crates.
 #![feature(rustc_private)]
 


### PR DESCRIPTION
This is a small change that makes it more clear which file in `bevy_lint/src/bin` compiles to which executable. It also shrinks the linter's `Cargo.toml`, which is a nice bonus!