### PR TITLE
Use Regex instead of `taplo` to extract channel in linter action

### DIFF
--- a/bevy_lint/action.yml
+++ b/bevy_lint/action.yml
@@ -17,23 +17,15 @@ runs:
       id: channel
       shell: bash
       run: |
-        # Read the contents of `rust-toolchain.toml`.
-        RUST_TOOLCHAIN=$(< "${RUST_TOOLCHAIN_PATH}")
-
         # This Regex will capture the channel specified in `rust-toolchain.toml`.
         REGEX='^channel = "(.+)"$'
 
-        if [[ "${RUST_TOOLCHAIN}" =~ $REGEX ]]; then
-          # The `$BASH_REMATCH` variable stores the captured results. In this case,
-          # `${BASH_REMATCH[1]}` gives us the value of the first group, which is usually
-          # `nightly-YYYY-MM-DD`.
-          CHANNEL="${BASH_REMATCH[1]}"
+        # Match the Regex pattern against the contents of `rust-toolchain.toml`, then store the
+        # captured channel in the variable. `-E` enables Regex capture groups, while `-n` and `/p`
+        # tells `sed` to only print lines that match the Regex.
+        CHANNEL=$(sed -nE "s/${REGEX}/\1/p" < "${RUST_TOOLCHAIN_PATH}")
 
-          echo "channel=${CHANNEL}" >> "${GITHUB_OUTPUT}"
-        else
-          echo "::error title=Could not extract channel::The Regex ${REGEX} did not match the contents of ${RUST_TOOLCHAIN_PATH}."
-          exit 1
-        fi
+        echo "channel=${CHANNEL}" >> "${GITHUB_OUTPUT}"
       env:
         RUST_TOOLCHAIN_PATH: ${{ github.action_path }}/../rust-toolchain.toml
 

--- a/bevy_lint/action.yml
+++ b/bevy_lint/action.yml
@@ -50,7 +50,7 @@ runs:
           --path "${BEVY_LINT_PATH}" \
           --locked
       env:
-        RUST_CHANNEL: ${{ steps.channel.outputs.channel }}
+        RUST_CHANNEL: ${{ steps.toolchain.outputs.channel }}
         # As the full contents of `TheBevyFlock/bevy_cli` is included alongside this action, we can
         # install the linter relative to the action path.
         BEVY_LINT_PATH: ${{ github.action_path }}

--- a/bevy_lint/action.yml
+++ b/bevy_lint/action.yml
@@ -12,30 +12,36 @@ description: |
 runs:
   using: composite
   steps:
-    # Use Regex to extract the `toolchain.channel` field in `rust-toolchain.toml`.
-    - name: Extract channel
-      id: channel
+    # Use Regex to extract the `channel` and `components` fields in `rust-toolchain.toml`.
+    - name: Extract toolchain
+      id: toolchain
       shell: bash
       run: |
-        # This Regex will capture the channel specified in `rust-toolchain.toml`.
-        REGEX='^channel = "(.+)"$'
+        # These Regex patterns will capture the channel and component lines specified in
+        # `rust-toolchain.toml`.
+        CHANNEL_REGEX='^channel = "(.+)"$'
+        COMPONENTS_REGEX='^components = \[(.*)\]$'
 
         # Match the Regex pattern against the contents of `rust-toolchain.toml`, then store the
         # captured channel in the variable. `-E` enables Regex capture groups, while `-n` and `/p`
         # tells `sed` to only print lines that match the Regex.
-        CHANNEL=$(sed -nE "s/${REGEX}/\1/p" < "${RUST_TOOLCHAIN_PATH}")
+        CHANNEL=$(sed -nE "s/${CHANNEL_REGEX}/\1/p" < "${RUST_TOOLCHAIN_PATH}")
+
+        # This does the same thing, but also strips out double quotes. In practice, this converts
+        # `components = ["rustc-dev", "llvm-tools-preview"]` to `"rustc-dev", "llvm-tools-preview"`
+        # to `rustc-dev, llvm-tools-preview`.
+        COMPONENTS=$(sed -nE "s/${COMPONENTS_REGEX}/\1/p" < "${RUST_TOOLCHAIN_PATH}" | tr -d '"')
 
         echo "channel=${CHANNEL}" >> "${GITHUB_OUTPUT}"
+        echo "components=${COMPONENTS}" >> "${GITHUB_OUTPUT}"
       env:
         RUST_TOOLCHAIN_PATH: ${{ github.action_path }}/../rust-toolchain.toml
 
     - name: Install Rust toolchain and components
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ steps.channel.outputs.channel }}
-        # These components are hard-coded because they are unlikely to change. They should match
-        # `rust-toolchain.toml`.
-        components: rustc-dev, llvm-tools-preview
+        toolchain: ${{ steps.toolchain.outputs.channel }}
+        components: ${{ steps.toolchain.outputs.components }}
 
     - name: Install `bevy_lint`
       shell: bash

--- a/bevy_lint/action.yml
+++ b/bevy_lint/action.yml
@@ -23,7 +23,7 @@ runs:
         # This Regex will capture the channel specified in `rust-toolchain.toml`.
         REGEX='^channel = "(.+)"$'
 
-        if [[ "${RUST_TOOLCHAIN}" =~ "${REGEX}" ]]; then
+        if [[ "${RUST_TOOLCHAIN}" =~ $REGEX ]]; then
           # The `$BASH_REMATCH` variable stores the captured results. In this case,
           # `${BASH_REMATCH[1]}` gives us the value of the first group, which is usually
           # `nightly-YYYY-MM-DD`.

--- a/bevy_lint/action.yml
+++ b/bevy_lint/action.yml
@@ -12,30 +12,38 @@ description: |
 runs:
   using: composite
   steps:
-    # Used to read `rust-toolchain.toml`.
-    - name: Install Taplo
-      uses: taiki-e/install-action@v2
-      with:
-        tool: taplo
-
-    # Read `rust-toolchain.toml` to find the exact nightly toolchain the linter needs.
-    - name: Extract toolchain
-      id: toolchain
+    # Use Regex to extract the `toolchain.channel` field in `rust-toolchain.toml`.
+    - name: Extract channel
+      id: channel
       shell: bash
       run: |
-        CHANNEL=$(taplo get --file-path="${RUST_TOOLCHAIN_PATH}" 'toolchain.channel')
-        COMPONENTS=$(taplo get --file-path="${RUST_TOOLCHAIN_PATH}" --separator=', ' 'toolchain.components')
+        # Read the contents of `rust-toolchain.toml`.
+        RUST_TOOLCHAIN=$(< "${RUST_TOOLCHAIN_PATH}")
 
-        echo "channel=${CHANNEL}" >> "${GITHUB_OUTPUT}"
-        echo "components=${COMPONENTS}" >> "${GITHUB_OUTPUT}"
+        # This Regex will capture the channel specified in `rust-toolchain.toml`.
+        REGEX='^channel = "(.+)"$'
+
+        if [[ "${RUST_TOOLCHAIN}" =~ "${REGEX}" ]]; then
+          # The `$BASH_REMATCH` variable stores the captured results. In this case,
+          # `${BASH_REMATCH[1]}` gives us the value of the first group, which is usually
+          # `nightly-YYYY-MM-DD`.
+          CHANNEL="${BASH_REMATCH[1]}"
+
+          echo "channel=${CHANNEL}" >> "${GITHUB_OUTPUT}"
+        else
+          echo "::error title=Could not extract channel::The Regex ${REGEX} did not match the contents of ${RUST_TOOLCHAIN_PATH}."
+          exit 1
+        fi
       env:
         RUST_TOOLCHAIN_PATH: ${{ github.action_path }}/../rust-toolchain.toml
 
     - name: Install Rust toolchain and components
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ steps.toolchain.outputs.channel }}
-        components: ${{ steps.toolchain.outputs.components }}
+        toolchain: ${{ steps.channel.outputs.channel }}
+        # These components are hard-coded because they are unlikely to change. They should match
+        # `rust-toolchain.toml`.
+        components: rustc-dev, llvm-tools-preview
 
     - name: Install `bevy_lint`
       shell: bash
@@ -44,7 +52,7 @@ runs:
           --path "${BEVY_LINT_PATH}" \
           --locked
       env:
-        RUST_CHANNEL: ${{ steps.toolchain.outputs.channel }}
+        RUST_CHANNEL: ${{ steps.channel.outputs.channel }}
         # As the full contents of `TheBevyFlock/bevy_cli` is included alongside this action, we can
         # install the linter relative to the action path.
         BEVY_LINT_PATH: ${{ github.action_path }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,6 +7,6 @@
 # line, so be wary when changing its formatting.
 channel = "nightly-2025-06-26"
 
-# These components are required to use `rustc` crates. Note that if you change these, you may need
-# to also update `bevy_lint/action.yml`.
+# These components are required to use `rustc` crates. Note that we use the Regex
+# `^components = \[(.*)\]$` to match this line, so be wary when changing its formatting.
 components = ["rustc-dev", "llvm-tools-preview"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,12 @@
-# If you modify this file, please also update the `clippy_utils` version in `bevy_lint/Cargo.toml`
-# and the compatibility table in `bevy_lint/README.md`.
+# If you wish to update this file, please read
+# <https://thebevyflock.github.io/bevy_cli/contribute/linter/how-to/upgrade-rust-toolchain.html>.
 
 [toolchain]
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version
-# so that builds are reproducible.
+# so that builds are reproducible. Note that we use the Regex `^channel = "(.+)"$` to match this
+# line, so be wary when changing its formatting.
 channel = "nightly-2025-06-26"
-# These components are required to use `rustc` crates.
+
+# These components are required to use `rustc` crates. Note that if you change these, you may need
+# to also update `bevy_lint/action.yml`.
 components = ["rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
Fixes #510.

This PR modifies `bevy_lint`'s action to use Regex to capture the toolchain channel in `rust-toolchain.toml`. Specifically, it uses this pattern:

```regex
^channel = "(.+)"$
```

I recommend [looking at this in Regex101](https://regex101.com/r/zIQPCg/1) to understand what its doing. In short, it looks for the line `channel = "..."` and captures everything between the double quotes.

Additionally, I switched the toolchain components to be completely hard-coded within the action. As these components are unlikely to ever change, I figured it was far simpler than trying to use _more_ Regex to extract them from `rust-toolchain.toml`. This can be changed in the future!