### PR TITLE
Release linter v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_lint"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ### Fixed
 
-- The linter will no longer emit the `Plugin` / `SystemSet` span twice in `unconvetional_naming` ([#495](https://github.com/TheBevyFlock/bevy_cli/pull/495))
+- The linter will no longer emit the `Plugin` / `SystemSet` span twice in `unconventional_naming` ([#495](https://github.com/TheBevyFlock/bevy_cli/pull/495))
 - Some lints now support auto-dereference receiver methods ([#504](https://github.com/TheBevyFlock/bevy_cli/pull/504))
     - For example, `panicking_methods` now catches `Box<World>::resource()` where before it would silently pass.
 

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -22,8 +22,10 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 - The Bevy CLI (Alpha) can now automatically install the linter for you ([#406](https://github.com/TheBevyFlock/bevy_cli/pull/406))
 - It is now possible to use the linter without Rustup by specifying the `BEVY_LINT_SYSROOT` environmental variable ([#478](https://github.com/TheBevyFlock/bevy_cli/pull/478))
     - This should make it easier to use the linter with NixOS.
+- Added opt-in support for caching `bevy_lint` in Github Actions ([#530](https://github.com/TheBevyFlock/bevy_cli/pull/530))
+    - This can double the speed at which `bevy_lint` is installed in CI, so it is highly recommended to enable it [by following these instructions](https://thebevyflock.github.io/bevy_cli/linter/github-actions.html#caching)!
 - Added docs on how to use `bevy_lint` with Rust-Analyzer ([#503](https://github.com/TheBevyFlock/bevy_cli/pull/503))
-- Added docs for troubleshooting issues with `cranelift` ([#453](https://github.com/TheBevyFlock/bevy_cli/pull/453))
+- Added docs for troubleshooting issues with `cranelift` and `sccache` ([#453](https://github.com/TheBevyFlock/bevy_cli/pull/453), [#522](https://github.com/TheBevyFlock/bevy_cli/pull/522))
 
 ### Changed
 

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## v0.4.0 - TODO: Enter the date here :)
 
-**All Changes**: [`lint-v0.3.0...lint-v0.4.0`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.3.0...main)
+**All Changes**: [`lint-v0.3.0...lint-v0.4.0`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.3.0...lint-v0.4.0)
 
 ### Added
 

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -7,9 +7,42 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-## Unreleased
+## v0.4.0 - TODO: Enter the date here :)
 
-**All Changes**: [`lint-v0.3.0...main`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.3.0...main)
+**All Changes**: [`lint-v0.3.0...lint-v0.4.0`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.3.0...main)
+
+### Added
+
+- You can now run `bevy_lint --fix` to auto-fix lints ([#505](https://github.com/TheBevyFlock/bevy_cli/pull/505))
+- `bevy_lint` now has a custom `--help` screen to display options specific to the linter ([#505](https://github.com/TheBevyFlock/bevy_cli/pull/505))
+- Added lints `update_schedule` and `fixed_update_schedule` to `restriction` ([#463](https://github.com/TheBevyFlock/bevy_cli/pull/463))
+    - These can help restrict modules to only use the `Update` or `FixedUpdate` schedules. Useful for separating game and rendering logic!
+- Added lint `camera_modification_in_fixed_update` to `nursery` ([#417](https://github.com/TheBevyFlock/bevy_cli/pull/417))
+    - This catches cases where a camera is modified during `FixedUpdate`, which can cause laggy visuals.
+- The Bevy CLI (Alpha) can now automatically install the linter for you ([#406](https://github.com/TheBevyFlock/bevy_cli/pull/406))
+- It is now possible to use the linter without Rustup by specifying the `BEVY_LINT_SYSROOT` environmental variable ([#478](https://github.com/TheBevyFlock/bevy_cli/pull/478))
+    - This should make it easier to use the linter with NixOS.
+- Added docs on how to use `bevy_lint` with Rust-Analyzer ([#503](https://github.com/TheBevyFlock/bevy_cli/pull/503))
+- Added docs for troubleshooting issues with `cranelift` ([#453](https://github.com/TheBevyFlock/bevy_cli/pull/453))
+
+### Changed
+
+- The lint `insert_unit_bundle` has been renamed to `unit_in_bundle` because it now supports many more cases, not just `Commands::spawn()` ([#502](https://github.com/TheBevyFlock/bevy_cli/pull/502))
+- Improved `unconventional_naming`'s diagnostics when encountering a `Plugin` ([#495](https://github.com/TheBevyFlock/bevy_cli/pull/495))
+- The linter documentation has been moved to use `mdbook` instead of `rustdoc` ([#420](https://github.com/TheBevyFlock/bevy_cli/pull/420), [#436](https://github.com/TheBevyFlock/bevy_cli/pull/436))
+    - You can find the [new docs here](https://thebevyflock.github.io/bevy_cli/linter).
+    - The list of all lints is still generated using `rustdoc`, which you can find [here](https://thebevyflock.github.io/bevy_cli/api/bevy_lint/lints/).
+- Bumped nightly toolchain to `nightly-2025-06-26` ([#507](https://github.com/TheBevyFlock/bevy_cli/pull/507))
+    - This adds support for the latest Rust features, such as let-chains!
+- You can now copy-and-paste most commands in the docs, without having to lookup the compatibility table ([#475](https://github.com/TheBevyFlock/bevy_cli/pull/475))
+- You can now install specific commits of the linter with the Github Action ([#501](https://github.com/TheBevyFlock/bevy_cli/pull/501))
+    - This will only work for commits newer than [`f38247d`](https://github.com/TheBevyFlock/bevy_cli/commit/f38247daea376c64919e1d09527acbbadb6df14b).
+
+### Fixed
+
+- The linter will no longer emit the `Plugin` / `SystemSet` span twice in `unconvetional_naming` ([#495](https://github.com/TheBevyFlock/bevy_cli/pull/495))
+- Some lints now support auto-dereference receiver methods ([#504](https://github.com/TheBevyFlock/bevy_cli/pull/504))
+    - For example, `panicking_methods` now catches `Box<World>::resource()` where before it would silently pass.
 
 ## v0.3.0 - 2025-04-30
 

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_lint"
-version = "0.4.0-dev"
+version = "0.4.0"
 authors = ["BD103"]
 edition = "2024"
 description = "A collection of lints for the Bevy game engine"

--- a/bevy_lint/MIGRATION.md
+++ b/bevy_lint/MIGRATION.md
@@ -8,6 +8,24 @@ To actually install the new version of the linter, please see [the docs] and [th
 [the releases page]: https://github.com/TheBevyFlock/bevy_cli/releases
 [submit an issue]: https://github.com/TheBevyFlock/bevy_cli/issues
 
+## v0.3.0 to v0.4.0
+
+### [Bumped Nightly Toolchain to `nightly-2025-06-26`](https://github.com/TheBevyFlock/bevy_cli/pull/507)
+
+`bevy_lint` now requires the `nightly-2025-06-26` toolchain, which supports Rust 1.90.0. You may uninstall the old `nightly-2025-04-03` toolchain and install the new toolchain using Rustup:
+
+```sh
+rustup toolchain uninstall nightly-2025-04-03
+
+rustup toolchain install nightly-2025-06-26 \
+    --component rustc-dev \
+    --component llvm-tools-preview
+```
+
+### [`insert_unit_bundle` Has Been Renamed to `unit_in_bundle`](https://github.com/TheBevyFlock/bevy_cli/pull/502)
+
+The `unit_in_bundle` lint is a much more powerful version of the older `insert_unit_bundle` lint, as it now works for many more functions instead of just `Commands::spawn()`. If you reference `insert_unit_bundle` in your project, you will need to rename it to `unit_in_bundle`.
+
 ## v0.2.0 to v0.3.0
 
 ### [Bevy 0.16 Support](https://github.com/TheBevyFlock/bevy_cli/pull/323)

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -46,7 +46,7 @@ Once you have the toolchain installed, you can compile and install `bevy_lint` t
 ```sh
 rustup run nightly-2025-06-26 cargo install \
     --git https://github.com/TheBevyFlock/bevy_cli.git \
-    --tag lint-v0.3.0 \
+    --tag lint-v0.4.0 \
     --locked \
     bevy_lint
 ```

--- a/docs/src/linter/compatibility.md
+++ b/docs/src/linter/compatibility.md
@@ -2,7 +2,7 @@
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
-|0.4.0-dev|1.90.0|`nightly-2025-06-26`|0.16|
+|0.4.0|1.90.0|`nightly-2025-06-26`|0.16|
 |0.3.0|1.88.0|`nightly-2025-04-03`|0.16|
 |0.2.0|1.87.0|`nightly-2025-02-20`|0.15|
 |0.1.0|1.84.0|`nightly-2024-11-14`|0.14|

--- a/docs/src/linter/github-actions.md
+++ b/docs/src/linter/github-actions.md
@@ -8,11 +8,11 @@
 
 ## Latest Release
 
-The following steps will install v0.3.0 of the linter and run it for all crates in a workspace:
+The following steps will install v0.4.0 of the linter and run it for all crates in a workspace:
 
 ```yml
 - name: Install `bevy_lint`
-  uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.3.0
+  uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.4.0
 
 - name: Run `bevy_lint`
   run: bevy_lint --workspace
@@ -27,7 +27,7 @@ Note that this action overrides the default toolchain and configures it to be th
 
 # Overrides the default toolchain to be nightly Rust.
 - name: Install `bevy_lint`
-  uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.3.0
+  uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.4.0
 
 # Resets the default toolchain back to stable Rust.
 - name: Configure the default Rust toolchain
@@ -60,7 +60,7 @@ By default, using the provided action will cause the linter to be recompiled for
 
 ```yml
 - name: Install `bevy_lint`
-  uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.3.0
+  uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.4.0
   with:
     cache: true
 ```
@@ -69,7 +69,7 @@ You can also configure whether a new cache can be saved with the `save-cache-if`
 
 ```yml
 - name: Install `bevy_lint`
-  uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.3.0
+  uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.4.0
   with:
     cache: true
     save-cache-if: ${{ github.ref == 'refs/heads/main' }}

--- a/docs/src/linter/install.md
+++ b/docs/src/linter/install.md
@@ -40,7 +40,7 @@ Once you have the toolchain installed, you can compile and install `bevy_lint` t
 ```sh
 rustup run nightly-2025-06-26 cargo install \
     --git https://github.com/TheBevyFlock/bevy_cli.git \
-    --tag lint-v0.3.0 \
+    --tag lint-v0.4.0 \
     --locked \
     bevy_lint
 ```
@@ -56,7 +56,7 @@ Once you've installed the toolchain and components, use that toolchain's `cargo`
 ```sh
 my-toolchain/bin/cargo install \
     --git https://github.com/TheBevyFlock/bevy_cli.git \
-    --tag lint-v0.3.0 \
+    --tag lint-v0.4.0 \
     --locked \
     bevy_lint
 ```

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -52,7 +52,7 @@ pub fn lint(args: LintArgs) -> anyhow::Result<()> {
     use crate::external_cli::Package;
 
     const RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain.toml");
-    const BEVY_LINT_TAG: &str = "lint-v0.3.0";
+    const BEVY_LINT_TAG: &str = "lint-v0.4.0";
     const PACKAGE: &str = "bevy_lint";
     const GIT_URL: &str = "https://github.com/TheBevyFlock/bevy_cli.git";
 


### PR DESCRIPTION
It's been just about 4 months since we released v0.3.0 of the linter, and there are several new features and useful changes that have been introduced since then! Additionally, with Bevy 0.17 heading towards the release track, we thought it best to release these features now so existing users can benefit from them.

# Useful Links

- [Changelog](https://github.com/TheBevyFlock/bevy_cli/blob/release-v0.4.0/bevy_lint/CHANGELOG.md)
  - [All Changes](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.3.0...release-v0.4.0) (also includes changes to the CLI)
- [Migration Guide](https://github.com/TheBevyFlock/bevy_cli/blob/release-v0.4.0/bevy_lint/MIGRATION.md)
- Linter Documentation
  - [Updated, not rendered](https://github.com/TheBevyFlock/bevy_cli/tree/release-v0.4.0/docs/src/linter)
  - [Out of date, rendered](https://thebevyflock.github.io/bevy_cli/linter/index.html)
  - (You can run `mdbook serve` to view the updated, rendered version locally!)
- [Linter Release Process](https://thebevyflock.github.io/bevy_cli/contribute/linter/how-to/release.html)

# For Reviewers

Please take the chance to install the linter and run it on your favorite Bevy projects! Look for crashes, false-positives, bad diagnostics, and other papercuts.

```sh
rustup toolchain install nightly-2025-06-26 \
    --component rustc-dev \
    --component llvm-tools-preview

rustup run nightly-2025-06-26 cargo install \
    --git https://github.com/TheBevyFlock/bevy_cli.git \
    --branch release-v0.4.0 \
    --locked \
    bevy_lint
```

While testing, make sure to also excercise the lints that are disabled by default (`pedantic`, `restriction`, `nursery`). You can enable these lints [through `Cargo.toml`](https://thebevyflock.github.io/bevy_cli/linter/usage/toggling-lints-cargo-toml.html) or [directly in your code](https://thebevyflock.github.io/bevy_cli/linter/usage/toggling-lints-code.html).

# Next Steps

Once this PR has received at least 1 approval from a Bevy maintainer with no outstanding requests, it will be merged. No other PRs will be merged until [a Github Release is made](https://github.com/TheBevyFlock/bevy_cli/releases) and the [post-release PR is merged](https://thebevyflock.github.io/bevy_cli/contribute/linter/how-to/release.html#post-release). Once released, I plan on announcing it on Discord, Mastodon, and my personal blog!

After the dust has settled, my tentative plan is to:

1. Review the [PR backlog](https://github.com/TheBevyFlock/bevy_cli/pulls)
2. Draft a proposal laying out the plan for upstreaming the CLI and linter
3. Update the linter to support Bevy 0.17 (once the first release candidate is published)
4. Add the linter to [the engine's CI](https://github.com/bevyengine/bevy/actions)