### PR TITLE
Post-release `bevy_lint` v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_lint"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "anstream",
  "anstyle",

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+**All Changes**: [`lint-v0.4.0...main`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.4.0...main)
+
 ## v0.4.0 - 2025-08-06
 
 **All Changes**: [`lint-v0.3.0...lint-v0.4.0`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.3.0...lint-v0.4.0)

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_lint"
-version = "0.4.0"
+version = "0.5.0-dev"
 authors = ["BD103"]
 edition = "2024"
 description = "A collection of lints for the Bevy game engine"

--- a/docs/src/contribute/linter/how-to/release.md
+++ b/docs/src/contribute/linter/how-to/release.md
@@ -26,10 +26,10 @@
 
 You can find the live documentation for this release [here](https://thebevyflock.github.io/bevy_cli/linter/index.html). You may also be interested in [the changelog] and [the migration guide].
 
-<!-- Make sure to update the tags in these links to point to the correct version. -->
+<!-- Make sure to update these links to point to the correct header (after the `#`). -->
 
-[the changelog]: https://github.com/TheBevyFlock/bevy_cli/blob/lint-vX.Y.Z/bevy_lint/CHANGELOG.md
-[the migration guide]: https://github.com/TheBevyFlock/bevy_cli/blob/lint-vX.Y.Z/bevy_lint/MIGRATION.md
+[the changelog]: https://thebevyflock.github.io/bevy_cli/linter/changelog.html#vXYZ---YYYY-MM-DD
+[the migration guide]: https://thebevyflock.github.io/bevy_cli/linter/migration.html#vXYZ-to-vXYZ
 
 > [!WARNING]
 >
@@ -37,7 +37,7 @@ You can find the live documentation for this release [here](https://thebevyflock
 
 <!-- You can refer to the compatibility table in `bevy_lint/README.md` for the following two values. -->
 
-This release uses the <!-- `nightly-YYYY-MM-DD` --> toolchain, based on Rust <!-- 1.XX.Y -->. You can install it from Git with the following commands:
+This release uses the <!-- `nightly-YYYY-MM-DD` --> toolchain, based on Rust <!-- 1.XX.Y -->, and supports Bevy <!-- X.Y.Z -->. You can install it from Git with the following commands:
 
 <!-- Update `nightly-YYYY-MM-DD` and `lint-vX.Y.Z` in the following code block. -->
 
@@ -72,6 +72,6 @@ rustup run nightly-YYYY-MM-DD cargo install \
 ```
 
 2. Bump the version in `Cargo.toml` to the next `-dev` version, and ensure `Cargo.lock` also updates.
-3. Add a new row to the compatibility table for the new `-dev` version in `README.md`.
+3. Add a new row to the [compatibility table](../../../linter/compatibility.md) for the new `-dev` version.
 4. Commit all of these changes and open a pull request.
 5. Merge the PR after it has been approved, unblocking frozen pull requests.

--- a/docs/src/linter/compatibility.md
+++ b/docs/src/linter/compatibility.md
@@ -2,6 +2,7 @@
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
+|0.5.0-dev|1.90.0|`nightly-2025-06-26`|0.16|
 |0.4.0|1.90.0|`nightly-2025-06-26`|0.16|
 |0.3.0|1.88.0|`nightly-2025-04-03`|0.16|
 |0.2.0|1.87.0|`nightly-2025-02-20`|0.15|


### PR DESCRIPTION
This PR lifts the merge-freeze, following [the post-release process](https://thebevyflock.github.io/bevy_cli/contribute/linter/how-to/release.html#post-release). I also made some minor changes to the release template and a small fix to the post-release instructions!