### PR TITLE
Rustup to `nightly-2025-08-07`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,9 +1551,9 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.90"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6443d6730aa762fa493b267f6e024b6823c1d6ea6dae35a2580e2f5052838810"
+checksum = "792491623692bf188d443ef51ff1b82282430bd885af823ec54fe51f21cb75dc"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",

--- a/bevy_lint/CHANGELOG.md
+++ b/bevy_lint/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-## [Unreleased]
+## Unreleased
 
 **All Changes**: [`lint-v0.4.0...main`](https://github.com/TheBevyFlock/bevy_cli/compare/lint-v0.4.0...main)
 

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -21,7 +21,7 @@ harness = false
 # Contains a series of useful utilities when writing lints. The version is chosen to work with the
 # currently pinned nightly Rust version. When the Rust version changes, this too needs to be
 # updated!
-clippy_utils = "=0.1.90"
+clippy_utils = "=0.1.91"
 
 # Easy error propagation and contexts.
 anyhow = "1.0.86"

--- a/bevy_lint/tests/ui-cargo/duplicate_bevy_dependencies/long_version_format/fail/Cargo.stderr
+++ b/bevy_lint/tests/ui-cargo/duplicate_bevy_dependencies/long_version_format/fail/Cargo.stderr
@@ -12,7 +12,7 @@ help: expected all crates to use `bevy` 0.16.0, but `leafwing-input-manager` use
 note: the lint level is defined here
   --> src/main.rs:3:9
    |
-3  | #![deny(bevy::duplicate_bevy_dependencies)]
+ 3 | #![deny(bevy::duplicate_bevy_dependencies)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: could not compile `multiple-bevy-versions` (bin "multiple-bevy-versions") due to 1 previous error

--- a/bevy_lint/tests/ui-cargo/duplicate_bevy_dependencies/short_version_format/fail/Cargo.stderr
+++ b/bevy_lint/tests/ui-cargo/duplicate_bevy_dependencies/short_version_format/fail/Cargo.stderr
@@ -12,7 +12,7 @@ help: expected all crates to use `bevy` 0.16.0, but `leafwing-input-manager` use
 note: the lint level is defined here
   --> src/main.rs:3:9
    |
-3  | #![deny(bevy::duplicate_bevy_dependencies)]
+ 3 | #![deny(bevy::duplicate_bevy_dependencies)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: could not compile `multiple-bevy-versions` (bin "multiple-bevy-versions") due to 1 previous error

--- a/bevy_lint/tests/ui.rs
+++ b/bevy_lint/tests/ui.rs
@@ -1,7 +1,6 @@
 // A convenience feature used in `find_bevy_rlib()` that lets you chain multiple `if let`
 // statements together with `&&`. This feature flag is needed in all integration tests that use the
 // test_utils module, since each integration test is compiled independently.
-#![feature(let_chains)]
 
 use test_utils::base_config;
 use ui_test::run_tests;

--- a/bevy_lint/tests/ui/borrowed_reborrowable/closures.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/closures.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut Commands` instead of a re-borrowed `Commands`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/closures.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/bevy_lint/tests/ui/borrowed_reborrowable/commands.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/commands.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut Commands` instead of a re-borrowed `Commands`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/commands.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut Commands` instead of a re-borrowed `Commands`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/deferred.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/deferred.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut Deferred` instead of a re-borrowed `Deferred`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/deferred.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut Deferred` instead of a re-borrowed `Deferred`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/deferred_world.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/deferred_world.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut DeferredWorld` instead of a re-borrowed `DeferredWo
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/deferred_world.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut DeferredWorld` instead of a re-borrowed `DeferredWorld`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/entity_commands.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/entity_commands.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut EntityCommands` instead of a re-borrowed `EntityCom
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/entity_commands.rs:6:9
    |
-6  | #![deny(bevy::borrowed_reborrowable)]
+ 6 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut EntityCommands` instead of a re-borrowed `EntityCommands`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/entity_mut.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/entity_mut.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut EntityMut` instead of a re-borrowed `EntityMut`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/entity_mut.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut EntityMut` instead of a re-borrowed `EntityMut`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/filtered_entity_mut.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/filtered_entity_mut.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut FilteredEntityMut` instead of a re-borrowed `Filter
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/filtered_entity_mut.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut FilteredEntityMut` instead of a re-borrowed `FilteredEntityMut`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/mut_typed.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/mut_typed.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut Mut` instead of a re-borrowed `Mut`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/mut_typed.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut Mut` instead of a re-borrowed `Mut`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/mut_untyped.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/mut_untyped.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut MutUntyped` instead of a re-borrowed `MutUntyped`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/mut_untyped.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut MutUntyped` instead of a re-borrowed `MutUntyped`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/non_send_mut.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/non_send_mut.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut NonSendMut` instead of a re-borrowed `NonSendMut`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/non_send_mut.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut NonSendMut` instead of a re-borrowed `NonSendMut`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/ptr_mut.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/ptr_mut.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut PtrMut` instead of a re-borrowed `PtrMut`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/ptr_mut.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut PtrMut` instead of a re-borrowed `PtrMut`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/query.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/query.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut Query` instead of a re-borrowed `Query`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/query.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut Query` instead of a re-borrowed `Query`

--- a/bevy_lint/tests/ui/borrowed_reborrowable/resource.stderr
+++ b/bevy_lint/tests/ui/borrowed_reborrowable/resource.stderr
@@ -7,7 +7,7 @@ error: parameter takes `&mut ResMut` instead of a re-borrowed `ResMut`
 note: the lint level is defined here
   --> tests/ui/borrowed_reborrowable/resource.rs:5:9
    |
-5  | #![deny(bevy::borrowed_reborrowable)]
+ 5 | #![deny(bevy::borrowed_reborrowable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter takes `&mut ResMut` instead of a re-borrowed `ResMut`

--- a/bevy_lint/tests/ui/camera_modification_in_fixed_update/main.stderr
+++ b/bevy_lint/tests/ui/camera_modification_in_fixed_update/main.stderr
@@ -8,7 +8,7 @@ error: camera modified in the `FixedUpdate` schedule
 note: the lint level is defined here
   --> tests/ui/camera_modification_in_fixed_update/main.rs:3:9
    |
-3  | #![deny(bevy::camera_modification_in_fixed_update)]
+ 3 | #![deny(bevy::camera_modification_in_fixed_update)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: camera modified in the `FixedUpdate` schedule

--- a/bevy_lint/tests/ui/insert_event_resource/main.stderr
+++ b/bevy_lint/tests/ui/insert_event_resource/main.stderr
@@ -7,7 +7,7 @@ error: called `App::init_resource::<Events<Foo>>()` instead of `App::add_event::
 note: the lint level is defined here
   --> tests/ui/insert_event_resource/main.rs:3:9
    |
-3  | #![deny(bevy::insert_event_resource)]
+ 3 | #![deny(bevy::insert_event_resource)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: inserting an `Events` resource does not fully setup that event
    |

--- a/bevy_lint/tests/ui/iter_current_update_events/plain.stderr
+++ b/bevy_lint/tests/ui/iter_current_update_events/plain.stderr
@@ -8,7 +8,7 @@ error: called `Events::<T>::iter_current_update_events()`
 note: the lint level is defined here
   --> tests/ui/iter_current_update_events/plain.rs:3:9
    |
-3  | #![deny(bevy::iter_current_update_events)]
+ 3 | #![deny(bevy::iter_current_update_events)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/bevy_lint/tests/ui/iter_current_update_events/res.stderr
+++ b/bevy_lint/tests/ui/iter_current_update_events/res.stderr
@@ -8,7 +8,7 @@ error: called `Events::<T>::iter_current_update_events()`
 note: the lint level is defined here
   --> tests/ui/iter_current_update_events/res.rs:3:9
    |
-3  | #![deny(bevy::iter_current_update_events)]
+ 3 | #![deny(bevy::iter_current_update_events)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/bevy_lint/tests/ui/main_return_without_appexit/main.stderr
+++ b/bevy_lint/tests/ui/main_return_without_appexit/main.stderr
@@ -1,7 +1,7 @@
 error: an entrypoint that calls `App::run()` does not return `AppExit`
   --> tests/ui/main_return_without_appexit/main.rs:15:16
    |
-9  | fn main() {
+ 9 | fn main() {
    |          - help: try: `-> AppExit`
 ...
 15 |     App::new().run();
@@ -11,13 +11,13 @@ error: an entrypoint that calls `App::run()` does not return `AppExit`
 note: the lint level is defined here
   --> tests/ui/main_return_without_appexit/main.rs:5:9
    |
-5  | #![deny(bevy::main_return_without_appexit)]
+ 5 | #![deny(bevy::main_return_without_appexit)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: an entrypoint that calls `App::run()` does not return `AppExit`
   --> tests/ui/main_return_without_appexit/main.rs:18:5
    |
-9  | fn main() {
+ 9 | fn main() {
    |          - help: try: `-> AppExit`
 ...
 18 |     App::run(&mut app);

--- a/bevy_lint/tests/ui/missing_reflect/derived.stderr
+++ b/bevy_lint/tests/ui/missing_reflect/derived.stderr
@@ -12,7 +12,7 @@ note: `Event` implemented here
 note: the lint level is defined here
   --> tests/ui/missing_reflect/derived.rs:7:9
    |
-7  | #![deny(bevy::missing_reflect)]
+ 7 | #![deny(bevy::missing_reflect)]
    |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Event` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: `Reflect` can be automatically derived

--- a/bevy_lint/tests/ui/missing_reflect/impl.stderr
+++ b/bevy_lint/tests/ui/missing_reflect/impl.stderr
@@ -14,7 +14,7 @@ note: `Event` implemented here
 note: the lint level is defined here
   --> tests/ui/missing_reflect/impl.rs:8:9
    |
-8  | #![deny(bevy::missing_reflect)]
+ 8 | #![deny(bevy::missing_reflect)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 help: `Reflect` can be automatically derived
    |

--- a/bevy_lint/tests/ui/missing_reflect/none_reflect_fields.stderr
+++ b/bevy_lint/tests/ui/missing_reflect/none_reflect_fields.stderr
@@ -14,7 +14,7 @@ note: `Event` implemented here
 note: the lint level is defined here
   --> tests/ui/missing_reflect/none_reflect_fields.rs:8:9
    |
-8  | #![deny(bevy::missing_reflect)]
+ 8 | #![deny(bevy::missing_reflect)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 help: `Reflect` can be automatically derived
    |

--- a/bevy_lint/tests/ui/panicking_methods/query.stderr
+++ b/bevy_lint/tests/ui/panicking_methods/query.stderr
@@ -8,7 +8,7 @@ error: called a `Query` method that can panic when a non-panicking alternative e
 note: the lint level is defined here
   --> tests/ui/panicking_methods/query.rs:4:9
    |
-4  | #![deny(bevy::panicking_methods)]
+ 4 | #![deny(bevy::panicking_methods)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called a `Query` method that can panic when a non-panicking alternative exists

--- a/bevy_lint/tests/ui/panicking_methods/world.stderr
+++ b/bevy_lint/tests/ui/panicking_methods/world.stderr
@@ -8,7 +8,7 @@ error: called a `World` method that can panic when a non-panicking alternative e
 note: the lint level is defined here
   --> tests/ui/panicking_methods/world.rs:5:9
    |
-5  | #![deny(bevy::panicking_methods)]
+ 5 | #![deny(bevy::panicking_methods)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called a `World` method that can panic when a non-panicking alternative exists

--- a/bevy_lint/tests/ui/schedule/fixed_update_schedule.stderr
+++ b/bevy_lint/tests/ui/schedule/fixed_update_schedule.stderr
@@ -7,7 +7,7 @@ error: the `FixedUpdate` schedule is disallowed
 note: the lint level is defined here
   --> tests/ui/schedule/fixed_update_schedule.rs:3:9
    |
-3  | #![deny(bevy::fixed_update_schedule)]
+ 3 | #![deny(bevy::fixed_update_schedule)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/bevy_lint/tests/ui/schedule/update_schedule.stderr
+++ b/bevy_lint/tests/ui/schedule/update_schedule.stderr
@@ -7,7 +7,7 @@ error: the `Update` schedule is disallowed
 note: the lint level is defined here
   --> tests/ui/schedule/update_schedule.rs:3:9
    |
-3  | #![deny(bevy::update_schedule)]
+ 3 | #![deny(bevy::update_schedule)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/bevy_lint/tests/ui/unconventional_naming/plugin.stderr
+++ b/bevy_lint/tests/ui/unconventional_naming/plugin.stderr
@@ -1,7 +1,7 @@
 error: unconventional type name for a `Plugin`
   --> tests/ui/unconventional_naming/plugin.rs:9:8
    |
-9  | struct Foo;
+ 9 | struct Foo;
    |        ^^^ help: rename `Foo`: `FooPlugin`
    |
    = note: structures that implement `Plugin` should end in "Plugin"
@@ -15,7 +15,7 @@ note: `Plugin` implemented here
 note: the lint level is defined here
   --> tests/ui/unconventional_naming/plugin.rs:3:9
    |
-3  | #![deny(bevy::unconventional_naming)]
+ 3 | #![deny(bevy::unconventional_naming)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unconventional type name for a `Plugin`

--- a/bevy_lint/tests/ui/unconventional_naming/spoofed_name.stderr
+++ b/bevy_lint/tests/ui/unconventional_naming/spoofed_name.stderr
@@ -15,7 +15,7 @@ note: `Plugin` implemented here
 note: the lint level is defined here
   --> tests/ui/unconventional_naming/spoofed_name.rs:6:9
    |
-6  | #![deny(bevy::unconventional_naming)]
+ 6 | #![deny(bevy::unconventional_naming)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/bevy_lint/tests/ui/unconventional_naming/system_set.stderr
+++ b/bevy_lint/tests/ui/unconventional_naming/system_set.stderr
@@ -8,12 +8,12 @@ error: unconventional type name for a `SystemSet`
 note: `SystemSet` implemented here
   --> tests/ui/unconventional_naming/system_set.rs:9:10
    |
-9  | #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+ 9 | #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
    |          ^^^^^^^^^
 note: the lint level is defined here
   --> tests/ui/unconventional_naming/system_set.rs:3:9
    |
-3  | #![deny(bevy::unconventional_naming)]
+ 3 | #![deny(bevy::unconventional_naming)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `SystemSet` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/bevy_lint/tests/ui/unit_in_bundle/bevy.stderr
+++ b/bevy_lint/tests/ui/unit_in_bundle/bevy.stderr
@@ -8,7 +8,7 @@ error: created a `Bundle` containing a unit `()`
 note: the lint level is defined here
   --> tests/ui/unit_in_bundle/bevy.rs:6:9
    |
-6  | #![deny(bevy::unit_in_bundle)]
+ 6 | #![deny(bevy::unit_in_bundle)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: created a `Bundle` containing a unit `()`

--- a/bevy_lint/tests/ui/unit_in_bundle/general.stderr
+++ b/bevy_lint/tests/ui/unit_in_bundle/general.stderr
@@ -8,7 +8,7 @@ error: created a `Bundle` containing a unit `()`
 note: the lint level is defined here
   --> tests/ui/unit_in_bundle/general.rs:3:9
    |
-3  | #![deny(bevy::unit_in_bundle)]
+ 3 | #![deny(bevy::unit_in_bundle)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: created a `Bundle` containing a unit `()`

--- a/bevy_lint/tests/ui/unit_in_bundle/spawn_empty.stderr
+++ b/bevy_lint/tests/ui/unit_in_bundle/spawn_empty.stderr
@@ -8,7 +8,7 @@ error: created a `Bundle` containing a unit `()`
 note: the lint level is defined here
   --> tests/ui/unit_in_bundle/spawn_empty.rs:3:9
    |
-3  | #![deny(bevy::unit_in_bundle)]
+ 3 | #![deny(bevy::unit_in_bundle)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: created a `Bundle` containing a unit `()`

--- a/bevy_lint/tests/ui/zst_query/query.stderr
+++ b/bevy_lint/tests/ui/zst_query/query.stderr
@@ -8,7 +8,7 @@ error: queried a zero-sized type
 note: the lint level is defined here
   --> tests/ui/zst_query/query.rs:5:9
    |
-5  | #![deny(bevy::zst_query)]
+ 5 | #![deny(bevy::zst_query)]
    |         ^^^^^^^^^^^^^^^
 
 error: queried a zero-sized type

--- a/bevy_lint/tests/ui_cargo.rs
+++ b/bevy_lint/tests/ui_cargo.rs
@@ -1,7 +1,6 @@
 // A convenience feature used in `find_bevy_rlib()` that lets you chain multiple `if let`
 // statements together with `&&`. This feature flag is needed in all integration tests that use the
 // test_utils module, since each integration test is compiled independently.
-#![feature(let_chains)]
 
 use std::env;
 

--- a/docs/src/contribute/linter/how-to/release.md
+++ b/docs/src/contribute/linter/how-to/release.md
@@ -8,7 +8,8 @@
 4. Review the migration guide (`bevy_lint/MIGRATION.md`) and ensure all breaking / significant changes from the previous version are documented.
 5. Remove the `-dev` suffix from the version in `Cargo.toml` and the compatibility table in `bevy_lint/README.md`.
     - Please ensure that `Cargo.lock` also updates!
-6. Update the toolchain install, `bevy_lint` install, and `bevy_lint` uninstall commands in both `README.md` and the [install page](../../../linter/install.md) to use the latest version and toolchain.
+6. Use `grep` to replace most instances of the previous linter version and toolchain with the new ones in the `docs` folder and `README.md`.
+    - Be careful not to change the wrong portions of the changelog, migration guide, and compatibility table.
 7. Update the tags in the [Github Actions docs](../../../linter/github-actions.md#latest-release) to the latest release.
 8. Commit all of these changes and open a pull request.
 9. Merge the PR once a core Bevy maintainer approves it with no outstanding issues from other contributors.

--- a/docs/src/contribute/linter/how-to/release.md
+++ b/docs/src/contribute/linter/how-to/release.md
@@ -65,7 +65,7 @@ rustup run nightly-YYYY-MM-DD cargo install \
 1. Add a new unreleased section to the top of the changelog (`bevy_lint/CHANGELOG.md`) from the following template:
 
 ```markdown
-## [Unreleased]
+## Unreleased
 
 <!-- Update `lint-vX.Y.Z` in the link to point to the latest release tag. -->
 

--- a/docs/src/contribute/linter/how-to/upgrade-rust-toolchain.md
+++ b/docs/src/contribute/linter/how-to/upgrade-rust-toolchain.md
@@ -11,8 +11,8 @@
     > ```
 
 2. Change the `channel` field in `rust-toolchain.toml` to the version specified by `clippy_utils`.
-3. Find and replace occurrences of the old toolchain version with the new toolchain version in the `docs` folder.
-    - Make sure you only modify the toolchain for the latest `-dev` version in the [compatibility table](../../../linter/compatibility.md).
+3. Replace the toolchain version for the latest `-dev` version in the [compatibility table](../../../linter/compatibility.md).
+    - Don't replace the toolchain version in other parts of the docs, as they should use the latest stable toolchain and not the latest development toolchain.
 4. Increase the version of `clippy_utils` in `Cargo.toml` to the latest version.
 
 Once you've finished upgrading the Rust toolchain and `clippy_utils`, there are a few extra steps that can verify `bevy_lint` still functions the same.

--- a/docs/src/linter/compatibility.md
+++ b/docs/src/linter/compatibility.md
@@ -2,7 +2,7 @@
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
-|0.5.0-dev|1.90.0|`nightly-2025-08-07`|0.16|
+|0.5.0-dev|1.91.0|`nightly-2025-08-07`|0.16|
 |0.4.0|1.90.0|`nightly-2025-06-26`|0.16|
 |0.3.0|1.88.0|`nightly-2025-04-03`|0.16|
 |0.2.0|1.87.0|`nightly-2025-02-20`|0.15|

--- a/docs/src/linter/compatibility.md
+++ b/docs/src/linter/compatibility.md
@@ -2,7 +2,7 @@
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
-|0.5.0-dev|1.90.0|`nightly-2025-06-26`|0.16|
+|0.5.0-dev|1.90.0|`nightly-2025-08-07`|0.16|
 |0.4.0|1.90.0|`nightly-2025-06-26`|0.16|
 |0.3.0|1.88.0|`nightly-2025-04-03`|0.16|
 |0.2.0|1.87.0|`nightly-2025-02-20`|0.15|

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version
 # so that builds are reproducible. Note that we use the Regex `^channel = "(.+)"$` to match this
 # line, so be wary when changing its formatting.
-channel = "nightly-2025-06-26"
+channel = "nightly-2025-08-07"
 
 # These components are required to use `rustc` crates. Note that we use the Regex
 # `^components = \[(.*)\]$` to match this line, so be wary when changing its formatting.


### PR DESCRIPTION
[Rust 1.89.0 was released yesterday](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/), meaning we can once again [update to a new nightly Rust toolchain](https://thebevyflock.github.io/bevy_cli/contribute/linter/how-to/upgrade-rust-toolchain.html).

# Notable Changes

It's been a relatively mild release, at least in terms of the APIs we depend on. The only thing visible is a adjustment in the alignment of line numbers in diagnostics, which was caught by our UI tests.

# Drive-By Changes

I also fixed our docs, as before it had us updating the toolchain _before_ we released a new version of `bevy_lint`. This caused installation to fail, since the wrong toolchain would be used.

We now only change the toolchain upon releasing a new version of the linter. (Except for the compatibility table, which we update now.)