### PR TITLE
Improve error message when `cargo metadata` fails

### DIFF
--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -3,6 +3,7 @@
 use std::{
     ffi::{OsStr, OsString},
     fmt::Display,
+    io::{self, Write as _},
     process::{Command, ExitStatus, Output},
 };
 
@@ -274,11 +275,9 @@ impl CommandExt {
         let output = output?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+            io::stderr().write_all(&output.stderr)?;
+            io::stderr().flush()?;
 
-            if !stderr.is_empty() {
-                eprintln!("{stderr}");
-            }
             anyhow::bail!(
                 "command `{}` exited with status code {}",
                 self,

--- a/src/external_cli/mod.rs
+++ b/src/external_cli/mod.rs
@@ -273,11 +273,18 @@ impl CommandExt {
 
         let output = output?;
 
-        anyhow::ensure!(
-            output.status.success(),
-            "command `{self}` exited with status code {}",
-            output.status
-        );
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            if !stderr.is_empty() {
+                eprintln!("{stderr}");
+            }
+            anyhow::bail!(
+                "command `{}` exited with status code {}",
+                self,
+                output.status
+            );
+        }
 
         Ok(output)
     }


### PR DESCRIPTION
# Objective

Previously, when `cargo metadata` fails, you'd always get this error:
<img width="734" height="59" alt="error: failed to obtain package metadata, are you in a cargo workspace?" src="https://github.com/user-attachments/assets/bf966066-df7c-4faa-bcaf-e1c5fb8cd4f0" />
But `cargo metadata` failing can also have other causes. We also need to original error from `cargo metadata` to help the user debug the issue.

# Solution

Output `stderr` when the command fails:
<img width="746" height="263" alt="the error from cargo metadata is also shown, though without color" src="https://github.com/user-attachments/assets/8681c31e-db65-411c-b02a-d748c329bcbd" />

We currently lose the color from the command, but still a lot better than before!