### PR TITLE
remove log line that prints for each profile

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -295,7 +295,6 @@ fn extract_headers(cli_metadata: &Map<String, Value>) -> anyhow::Result<Vec<Stri
     const KEY: &str = "headers";
 
     let Some(features) = cli_metadata.get(KEY) else {
-        tracing::debug!("no `{KEY}` found in CLI metadata, using default");
         return Ok(Vec::new());
     };
 


### PR DESCRIPTION
# Objective

Remove `debug` output when no header is specified for the given profile, since it's more confusing. I think it's enough that we print the resolved config.


# Before

`Cargo.toml`

```toml
[package.metadata.bevy_cli.dev]
default-features = false

[package.metadata.bevy_cli]
default-features = false

[package.metadata.bevy_cli.web]
default-features = false

[package.metadata.bevy_cli.web.dev]
default-features = false
```

## No headers

```
❯ bevy run web -v
debug: running: `cargo metadata --format-version 1`
debug: no `headers` found in CLI metadata, using default
debug: no `headers` found in CLI metadata, using default
debug: no `headers` found in CLI metadata, using default
debug: no `headers` found in CLI metadata, using default
debug: using defaults from bevy_cli config:
       features = []
       default-features = false
       headers = []
       rustflags = []
```

## With headers

`Cargo.toml`

```toml
[package.metadata.bevy_cli.dev]
default-features = false

[package.metadata.bevy_cli]
headers = ["Cross-Origin-Opener-Policy:same-origin"]
default-features = false

[package.metadata.bevy_cli.web]
default-features = false

[package.metadata.bevy_cli.web.dev]
default-features = false
```

```
❯ bevy run web -v
debug: running: `cargo metadata --format-version 1`
debug: no `headers` found in CLI metadata, using default
debug: no `headers` found in CLI metadata, using default
debug: no `headers` found in CLI metadata, using default
debug: using defaults from bevy_cli config:
       features = []
       default-features = false
       headers = ["Cross-Origin-Opener-Policy:same-origin"]
       rustflags = []
```

# Now

## No headers (same `Cargo.toml`)

```
❯ bevy run web -v
debug: running: `cargo metadata --format-version 1`
debug: using defaults from bevy_cli config:
       features = []
       default-features = false
       headers = []
       rustflags = []
```

## With headers (same `Cargo.toml`)
```
❯ bevy run web -v
debug: running: `cargo metadata --format-version 1`
debug: using defaults from bevy_cli config:
       features = []
       default-features = false
       headers = ["Cross-Origin-Opener-Policy:same-origin"]
       rustflags = []
```