### PR TITLE
Fix regression when calling `bevy_lint` through the cli

### DIFF
--- a/src/commands/lint/args.rs
+++ b/src/commands/lint/args.rs
@@ -15,9 +15,22 @@ pub struct LintArgs {
     #[arg(long = "yes", default_value_t = false)]
     pub confirm_prompts: bool,
 
+    /// Show version information
+    #[arg(long = "version", default_value_t = false)]
+    pub version: bool,
+    /// Automatically fix lint warnings reported by bevy_lint.
+    #[arg(long = "fix", default_value_t = false)]
+    pub fix: bool,
+
     /// Arguments to forward to `cargo check`.
     #[clap(flatten)]
     pub cargo_args: CargoCheckArgs,
+
+    /// Arguments to forward to `bevy_lint`
+    ///
+    /// Specified after `--`.
+    #[clap(last = true, name = "ARGS", global = true)]
+    pub forward_args: Vec<String>,
 }
 
 impl LintArgs {
@@ -60,7 +73,7 @@ impl LintArgs {
         self.cargo_args.compilation_args.target(self.is_web())
     }
 
-    /// Generate arguments to forward to `cargo build`.
+    /// Generate arguments to forward to `cargo check`.
     pub(crate) fn cargo_args_builder(&self) -> ArgBuilder {
         self.cargo_args.args_builder(self.is_web())
     }


### PR DESCRIPTION
# Objective

Pass `--version` and `--fix` to `bevy_lint`. Additionally, support passing arbitrary arguments to `bevy_lint`.

# Testing

## Printing the version of `bevy_lint`

```sh
❯ bevy lint --version
bevy_lint v0.5.0-dev
```

## Passing arbitrary arguments to `bevy_lint`

```sh
❯ bevy lint --  --help
A custom linter for the Bevy game engine

Usage: bevy_lint [OPTIONS]

Options:
  --fix          Automatically apply lint suggestions if possible
  -h, --help     Prints the help text and exits
  -V, --version  Prints the version info and exits

In addition to the options listed above, bevy_lint supports all of cargo check's
options, which you can view with cargo check --help. If you pass --fix,
bevy_lint will support all of cargo fix's options instead.
```

## `bevy_lint --fix`

This wonderful bit of code:

```rs
use bevy::prelude::*;

fn main() {
    println!("Hello, world!");
}

pub fn test_commands(mut commands_owned: Commands) {
    commands_owned.spawn(());
}
```

produces the following output:

```
❯ bevy lint --fix
error: the working directory of this package has uncommitted changes, and `cargo fix` can potentially perform destructive changes; if you'd like to suppress this error pass `--allow-dirty`, or commit the changes to these files:

  * .gitignore (dirty)
  * Cargo.lock (dirty)
  * Cargo.toml (dirty)
  * src/ (dirty)


Check failed: exit status: 101.
error: command `bevy_lint --fix --profile dev` exited with status code exit status: 101
```

Now with ``--allow-dirty` (we forward this flag, the cli does not know about it)

```sh
❯ bevy lint --fix -- --allow-dirty
    Checking autofix v0.1.0 (/tmp/autofix)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
```

```sh
❯ cat -p src/main.rs
use bevy::prelude::*;

fn main() {
    println!("Hello, world!");
}

pub fn test_commands(mut commands_owned: Commands) {
    commands_owned.spawn_empty();
}
```

## Complexer command

So to run `bevy_lint fix` for the web in verbose mode and apply fixes to our uncommitted git directory, we would have to do this:

```
❯ bevy lint --fix -v web -- --allow-dirty
```
