### PR TITLE
Simplify UI test utils

### DIFF
--- a/bevy_lint/tests/test_utils/mod.rs
+++ b/bevy_lint/tests/test_utils/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    env::{self},
     ffi::OsStr,
     path::{Path, PathBuf},
     process::{Command, Stdio},
@@ -12,17 +11,16 @@ use ui_test::{
 };
 // This is set by `build.rs`. It is the version specified in `rust-toolchain.toml`.
 const RUST_TOOLCHAIN_CHANNEL: &str = env!("RUST_TOOLCHAIN_CHANNEL");
-const DRIVER_STEM: &str = "../target/debug/bevy_lint_driver";
+// This is set by Cargo to the absolute path of `bevy_lint_driver`.
+const DRIVER_PATH: &str = env!("CARGO_BIN_EXE_bevy_lint_driver");
 
 /// Generates a custom [`Config`] for `bevy_lint`'s UI tests.
 pub fn base_config(test_dir: &str) -> color_eyre::Result<Config> {
-    // The path to the `bevy_lint_driver` executable, relative from inside the `bevy_lint` folder.
-    // We use `with_extension()` to potentially add the `.exe` suffix, if on Windows.
-    let driver_path = Path::new(DRIVER_STEM).with_extension(env::consts::EXE_EXTENSION);
+    let driver_path = Path::new(DRIVER_PATH);
 
     ensure!(
         driver_path.is_file(),
-        "`bevy_lint_driver` could not be found at {}, make sure to build it with `cargo build -p bevy_lint --bin bevy_lint_driver`.",
+        "`bevy_lint_driver` could not be found at {}, make sure to build it with `cargo build -p bevy_lint --bin bevy_lint_driver`",
         driver_path.display(),
     );
 

--- a/bevy_lint/tests/test_utils/mod.rs
+++ b/bevy_lint/tests/test_utils/mod.rs
@@ -9,8 +9,7 @@ use ui_test::{
     CommandBuilder, Config,
     color_eyre::{self, eyre::ensure},
 };
-// This is set by `build.rs`. It is the version specified in `rust-toolchain.toml`.
-const RUST_TOOLCHAIN_CHANNEL: &str = env!("RUST_TOOLCHAIN_CHANNEL");
+
 // This is set by Cargo to the absolute path of `bevy_lint_driver`.
 const DRIVER_PATH: &str = env!("CARGO_BIN_EXE_bevy_lint_driver");
 
@@ -31,13 +30,10 @@ pub fn base_config(test_dir: &str) -> color_eyre::Result<Config> {
         // specific configuration in UI tests will not work.
         host: Some(String::new()),
         program: CommandBuilder {
-            // We call `rustup run` to setup the proper environmental variables, so that
-            // `bevy_lint_driver` can link to `librustc_driver.so`.
-            program: "rustup".into(),
+            // We don't need `rustup run` here because we're already using the correct toolchain
+            // due to `rust-toolchain.toml`.
+            program: driver_path.into(),
             args: vec![
-                "run".into(),
-                RUST_TOOLCHAIN_CHANNEL.into(),
-                driver_path.into(),
                 // `bevy_lint_driver` expects the first argument to be the path to `rustc`.
                 "rustc".into(),
                 // This is required so that `ui_test` can parse warnings and errors.


### PR DESCRIPTION
This was spun out from #542.

This slightly simplifies the utility used to set up UI tests for the linter in 2 commits:

1. Use Cargo's environmental variable to locate the path to `bevy_lint_driver`, instead of assuming its location is in `target/debug`.
   - This means UI tests now work with other profiles, like `--release` mode.
2. Remove redundant `rustup run` call when executing `bevy_lint_driver`. It's not needed, since the correct toolchain is already setup through `rust-toolchain.toml`.