### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directories:
+      - /
+      - /tests/bevy_cli_test
+      - /bevy_lint/tests/ui-cargo/**/*
+    schedule:
+      interval: weekly
+    labels:
+      - C-Dependencies
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - C-Dependencies


### PR DESCRIPTION
Dependabot is a program that opens PRs to automate upgrading dependencies, like as seen in #555. This PR configures Dependabot to run weekly, check both Cargo and Github Actions deps, check all of our Cargo workspaces, and use the correct https://github.com/TheBevyFlock/bevy_cli/labels/C-Dependencies label.