### PR TITLE
Replace references to bevyengine.org to bevy.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,4 +28,4 @@ Feel free to pick an issue from the [issue tracker], fork the repository, and su
 Please familiarize yourself with [Bevy's Code of Conduct], which applies to this project as well. Additionally, take a look at [Bevy's Contributing Guide], as many of the engine's procedures transfer to the CLI.
 
 [Bevy's Code of Conduct]: https://github.com/bevyengine/bevy/blob/main/CODE_OF_CONDUCT.md
-[Bevy's Contributing Guide]: https://bevyengine.org/learn/contribute/introduction/
+[Bevy's Contributing Guide]: https://bevy.org/learn/contribute/introduction/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A prototype [Bevy] CLI tool intended to streamline common tasks when working on 
 
 If you need assistance or want to help, reach out to the [`bevy_cli` working group channel] in the [Bevy Discord].
 
-[Bevy]: https://bevyengine.org
+[Bevy]: https://bevy.org
 [initial scope document]: https://hackmd.io/cCHAfbtaSviU_MDnbNHKxg
 [original issue]: https://github.com/bevyengine/bevy/issues/436
 [`bevy_cli` working group channel]: https://discord.com/channels/691052431525675048/1278871953721262090

--- a/bevy_lint/MIGRATION.md
+++ b/bevy_lint/MIGRATION.md
@@ -34,8 +34,8 @@ The linter now supports Bevy 0.16, but no longer supports Bevy 0.15. You may sti
 
 To migrate your code base to Bevy 0.16, please see the [release post][bevy 0.16 release post] and [migration guide][bevy 0.16 migration guide].
 
-[bevy 0.16 release post]: https://bevyengine.org/news/bevy-0-16/
-[bevy 0.16 migration guide]: https://bevyengine.org/learn/migration-guides/0-15-to-0-16/
+[bevy 0.16 release post]: https://bevy.org/news/bevy-0-16/
+[bevy 0.16 migration guide]: https://bevy.org/learn/migration-guides/0-15-to-0-16/
 
 ### [Bumped Nightly Toolchain to `nightly-2025-04-03`](https://github.com/TheBevyFlock/bevy_cli/pull/278)
 
@@ -69,8 +69,8 @@ The linter now supports Bevy 0.15, but no longer supports Bevy 0.14. You may sti
 
 To migrate your code base to Bevy 0.15, please see the [release post][bevy 0.15 release post] and [migration guide][bevy 0.15 migration guide].
 
-[bevy 0.15 release post]: https://bevyengine.org/news/bevy-0-15/
-[bevy 0.15 migration guide]: https://bevyengine.org/learn/migration-guides/0-14-to-0-15/
+[bevy 0.15 release post]: https://bevy.org/news/bevy-0-15/
+[bevy 0.15 migration guide]: https://bevy.org/learn/migration-guides/0-14-to-0-15/
 
 ### [Bumped Nightly Toolchain to `nightly-2025-02-20`](https://github.com/TheBevyFlock/bevy_cli/pull/278)
 

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -2,7 +2,7 @@
 
 # `bevy_lint`
 
-`bevy_lint` is a custom linter for the [Bevy game engine](https://bevyengine.org), similar to [Clippy](https://doc.rust-lang.org/stable/clippy).
+`bevy_lint` is a custom linter for the [Bevy game engine](https://bevy.org), similar to [Clippy](https://doc.rust-lang.org/stable/clippy).
 
 </div>
 

--- a/bevy_lint/src/lib.rs
+++ b/bevy_lint/src/lib.rs
@@ -1,4 +1,4 @@
-//! `bevy_lint` is a custom linter for the [Bevy game engine](https://bevyengine.org), similar to
+//! `bevy_lint` is a custom linter for the [Bevy game engine](https://bevy.org), similar to
 //! [Clippy](https://doc.rust-lang.org/stable/clippy).
 //!
 //! This is the primary documentation for its lints and lint groups. `bevy_lint` is not intended to

--- a/bevy_lint/src/lints/suspicious/insert_event_resource.rs
+++ b/bevy_lint/src/lints/suspicious/insert_event_resource.rs
@@ -10,7 +10,7 @@
 //!
 //! For more information, please see the documentation on [`App::add_event()`] and [`Events<T>`].
 //!
-//! [`Events<T>`]: https://dev-docs.bevyengine.org/bevy/ecs/event/struct.Events.html
+//! [`Events<T>`]: https://dev-docs.bevy.org/bevy/ecs/event/struct.Events.html
 //! [`App::add_event()`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.add_event
 //!
 //! # Example

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -5,7 +5,7 @@ This is the combined documentation for the prototype **Bevy CLI** and **Bevy Lin
 - [**Bevy CLI (Alpha)**](cli/index.md)
 - [**Bevy Linter**](linter/index.md)
 
-[Bevy game engine]: https://bevyengine.org
+[Bevy game engine]: https://bevy.org
 
 <div class="warning">
 

--- a/docs/src/linter/index.md
+++ b/docs/src/linter/index.md
@@ -1,6 +1,6 @@
 # About
 
-`bevy_lint` is a custom linter for the [Bevy game engine](https://bevyengine.org), similar to [Clippy](https://doc.rust-lang.org/stable/clippy).
+`bevy_lint` is a custom linter for the [Bevy game engine](https://bevy.org), similar to [Clippy](https://doc.rust-lang.org/stable/clippy).
 
 - [**All Lints**](../api/bevy_lint/lints/index.html)
 - [**Repository**](https://github.com/TheBevyFlock/bevy_cli)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -90,7 +90,7 @@ fn after_help() -> String {
     _ = writeln!(message, "{header}Resources:{header:#}");
     _ = writeln!(
         message,
-        "  {literal}Bevy Website{literal:#}       {underline}https://bevyengine.org{underline:#}"
+        "  {literal}Bevy Website{literal:#}       {underline}https://bevy.org{underline:#}"
     );
     _ = writeln!(
         message,


### PR DESCRIPTION
A few months ago the Bevy foundation purchased the <https://bevy.org> domain and migrated to it. This PR updates all of our links to the new domain! :)