### PR TITLE
Add missing entries to the CLI changelog for v0.1.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,23 +13,36 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ### Added
 
-- The `bevy build web` and `bevy run web` commands will now automatically apply the web backend for `getrandom` if necessary. `getrandom` requires both a feature and a rustflag to be enabled by the user, which can quickly lead to compile errors when not set up correctly. The CLI will automatically set the rustflag if needed and provide easy instructions on how to configure the features.
-- Unstable support for building and running web apps using **Wasm multi-threading** features
-  - Use `bevy run web --unstable multi-threading` to run an app using multi-threaded Wasm
-  - Can be configured in `Cargo.toml` by setting `package.metadata.bevy_cli.unstable.web-multi-threading = true`
-  - Only available when compiling the CLI with `unstable` feature enabled
-  - Requires a nightly Rust toolchain
-  - Bevy doesn't natively implement multi-threaded Wasm, so you have to implement it yourself or use a plugin that makes use of it
+- The Bevy CLI now has colorful `--help` output, matching Cargo's style ([#464](https://github.com/TheBevyFlock/bevy_cli/pull/464))
+- The main `--help` message now contains links to Bevy's website, Bevy's source code, and the CLI's documentation ([#457](https://github.com/TheBevyFlock/bevy_cli/pull/457), [#482](https://github.com/TheBevyFlock/bevy_cli/pull/482))
+- You can now specify the host address in `bevy run web` with the `--host` flag ([#472](https://github.com/TheBevyFlock/bevy_cli/pull/472))
+- It is now possible to customize the arguments passed to `wasm-opt` when optimizing a build for the web ([#486](https://github.com/TheBevyFlock/bevy_cli/pull/486))
+  - You can pass flags to the CLI like `--wasm-opt=-Oz --wasm-opt=--enable-bulk-memory`, or you can change the `wasm-opt` configuration value to an array instead of a boolean, like `wasm-opt = ["-Oz", "--enable-bulk-memory"]`
+- You can now run the linter on web builds with `bevy lint web` ([#523](https://github.com/TheBevyFlock/bevy_cli/pull/523))
+- It is now possible to specify `bevy run web` HTTP headers in `Cargo.toml` using the `headers` array ([#544](https://github.com/TheBevyFlock/bevy_cli/pull/544))
+- (Unstable) It is now possible to build apps for the web with support for multi-threading ([#499](https://github.com/TheBevyFlock/bevy_cli/pull/499))
+  - Use the `--unstable multi-threading` flag or set the `unstable.web-multi-threading` config to `true` to run an app using multi-threaded Wasm
+  - This is only available when compiling the CLI with the `unstable` feature, however it is enabled by default
+  - This depends on an unstable flag in the Rust compiler, and thus requires a nightly toolchain of Rust
+  - Bevy doesn't natively utilize multi-threaded WASM, so this will only benefit plugins that support it or code you write yourself
+- The CLI is now able to list and install arbitrary versions of the Bevy linter with `bevy lint list` and `bevy lint install` ([#529](https://github.com/TheBevyFlock/bevy_cli/pull/529))
+- `bevy build web` and `bevy run web` commands will now automatically apply the web backend for `getrandom` if necessary. `getrandom` requires both a feature and a rustflag to be enabled by the user, which can quickly lead to compile errors when not set up correctly. The CLI will automatically set the rustflag if needed and provide easy instructions on how to configure the features ([#547](https://github.com/TheBevyFlock/bevy_cli/pull/547))
 
 ### Changed
 
-- You can now customize the flags passed to `wasm-opt` in both CLI and `Cargo.toml`. Simply pass a list of flags you want to use, e.g. `--wasm-opt=-Oz --wasm-opt=--enable-bulk-memory` in the CLI or `wasm-opt = ["-Oz", "--enable-bulk-memory"]` in the config.
+- The `--no-default-features` option confusingly used to accept `true` and `false ` as inputs, but has been changed to be a simple toggle flag, matching Cargo's behavior ([#473](https://github.com/TheBevyFlock/bevy_cli/pull/473))
+- When building a project, the CLI can now load the `assets` and `web` folders next to the crate `Cargo.toml`, rather than just the workspace `Cargo.toml`. Crate-specific folders will be prioritized over workspace folders ([#485](https://github.com/TheBevyFlock/bevy_cli/pull/485), [#490](https://github.com/TheBevyFlock/bevy_cli/pull/490))
+- `bevy build web` and `bevy run web` now support [JS snippets](https://wasm-bindgen.github.io/wasm-bindgen/reference/js-snippets.html) ([#527](https://github.com/TheBevyFlock/bevy_cli/pull/527))
+- The error message has been improved in cases where the CLI fails to gather project information using `cargo metadata` ([#543](https://github.com/TheBevyFlock/bevy_cli/pull/543), [#545](https://github.com/TheBevyFlock/bevy_cli/pull/545))
+- `rustflags` specified in [`.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html#configuration) are now respected and will be merged with those defined in the CLI's configuration ([#540](https://github.com/TheBevyFlock/bevy_cli/pull/540))
 
-- `bevy run web` and `bevy build web -b` now support [JS snippets](https://rustwasm.github.io/wasm-bindgen/reference/js-snippets.html) ([#527](https://github.com/TheBevyFlock/bevy_cli/pull/527))
+### Fixed
 
-- `bevy lint` no longer installs `bevy_lint` automatically if it is not present. Instead, the new subcommands `bevy lint list` (to list all available versions) and `bevy lint install` have been added ([#529](https://github.com/TheBevyFlock/bevy_cli/pull/529))
-
-- `rustflags` specified in the [`cargo` configuration](https://doc.rust-lang.org/cargo/reference/config.html#configuration) are respected and added with those defined in `Cargo.toml` ([#540](https://github.com/TheBevyFlock/bevy_cli/pull/540))
+- Instructions in `bevy lint --help` incorrectly said `bevy_lint` needed to be installed manually ([#465](https://github.com/TheBevyFlock/bevy_cli/pull/465))
+- The example for `bevy completions` has been reworked to be clearer ([#466](https://github.com/TheBevyFlock/bevy_cli/pull/466))
+- `bevy run` now respects the `default-members` workspace field in `Cargo.toml` when selecting which crate to run ([#477](https://github.com/TheBevyFlock/bevy_cli/pull/477))
+- `bevy new` now emits an error if the name of the crate is invalid ([#480](https://github.com/TheBevyFlock/bevy_cli/pull/480))
+- `bevy build web` and `bevy run web` now respect the `target` configuration option, meaning it's now possible to build for WASM targets like `wasm32v1-none` instead of just `wasm32-unknown-unknown` ([#481](https://github.com/TheBevyFlock/bevy_cli/pull/481))
 
 ## v0.1.0-alpha.1 - 2025-05-23
 


### PR DESCRIPTION
This PR includes the first step in [the release process](https://thebevyflock.github.io/bevy_cli/contribute/cli/release.html): writing the [changelog](https://thebevyflock.github.io/bevy_cli/cli/changelog.html)!

There's some additional docs work and bug fixes that I think is needed before we can release, but I figured we should push this out so early adopters of https://github.com/TheBevyFlock/bevy_new_2d/pull/453 will be able to investigate what's changed without trawling through the commit history.

Please let me know if I missed anything (I used [this to view the individual commits](https://github.com/TheBevyFlock/bevy_cli/compare/cli-v0.1.0-alpha.1...main)), or if I need to go into more detail for specific entries.