### PR TITLE
Install latest `bevy_lint` release if `--yes` flag was passed

### DIFF
--- a/src/external_cli/cargo/install.rs
+++ b/src/external_cli/cargo/install.rs
@@ -7,7 +7,7 @@ use semver::Version;
 use crate::external_cli::{CommandExt, Package};
 
 /// Whether to automatically install packages.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AutoInstall {
     /// Show a prompt to the user and ask them first before installing.
     AskUser,


### PR DESCRIPTION
# Objective

When installing via: `bevy lint --yes install`, install the latest available `bevy_lint` release. In the case there would be no release (I guess upstreaming) this would install the current `main` branch.

# Testing 

<img width="1487" height="319" alt="image" src="https://github.com/user-attachments/assets/445cb311-81e3-415b-9b57-a1cb62547377" />

<img width="337" height="156" alt="image" src="https://github.com/user-attachments/assets/ca62a346-b414-4bb9-a519-9e4664d56fde" />


#Closes #580
