### PR TITLE
Ignore `cargo` lint projects in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directories:
       - /
       - /tests/bevy_cli_test
-      - /bevy_lint/tests/ui-cargo/**/*
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
I think the Dependabot PR's for the `cargo` lint tests are bad. It always tries to update the versions we deliberately use as "old" versions ^^

For example see: https://github.com/TheBevyFlock/bevy_cli/pull/590