### PR TITLE
Check `bevy_lint/action.yml` with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,11 @@ updates:
     labels:
       - C-Dependencies
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      # Used to check `.github/workflows`.
+      - /
+      # Used to check `bevy_lint/action.yml`.
+      - /bevy_lint
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
While looking over Dependabot's configuration reference, I read this:

> - For GitHub Actions, use the value `/`. Dependabot will search the `/.github/workflows` directory, as well as the `action.yml`/`action.yaml` file from the root directory.

It appears that Dependabot isn't scanning `bevy_lint/action.yml`, since it's not in the root directory. This PR corrects this by telling Dependabot to also scan the `bevy_lint` folder for Github Actions.