### PR TITLE
Post-release CLI v0.1.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## Unreleased
+
+**All Changes**: [`cli-v0.1.0-alpha.2...main`](https://github.com/TheBevyFlock/bevy_cli/compare/cli-v0.1.0-alpha.2...main)
+
 ## v0.1.0-alpha.2 - 2025-09-22
 
 **All Changes**: [`cli-v0.1.0-alpha.1...cli-v0.1.0-alpha.2`](https://github.com/TheBevyFlock/bevy_cli/compare/cli-v0.1.0-alpha.1...cli-v0.1.0-alpha.2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cli"
-version = "0.1.0-alpha.2"
+version = "0.1.0-dev"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3846,7 +3846,6 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-
 version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bevy_lint"]
 
 [package]
 name = "bevy_cli"
-version = "0.1.0-alpha.2"
+version = "0.1.0-dev"
 edition = "2024"
 description = "A prototype Bevy CLI tool"
 documentation = "https://thebevyflock.github.io/bevy_cli/cli/index.html"

--- a/docs/src/contribute/cli/release.md
+++ b/docs/src/contribute/cli/release.md
@@ -26,24 +26,16 @@
 
 You can find the live documentation for this release [here](https://thebevyflock.github.io/bevy_cli/cli/index.html). You may also be interested in [the changelog] and [the migration guide].
 
-<!-- Make sure to update the tags in these links to point to the correct version. -->
+<!-- Make sure to update these links to point to the correct header (after the `#`). -->
 
-[the changelog]: https://github.com/TheBevyFlock/bevy_cli/blob/cli-vX.Y.Z/CHANGELOG.md
-[the migration guide]: https://github.com/TheBevyFlock/bevy_cli/blob/cli-vX.Y.Z/MIGRATION.md
+[the changelog]: https://thebevyflock.github.io/bevy_cli/cli/changelog.html#vXYZ---YYYY-MM-DD
+[the migration guide]: https://thebevyflock.github.io/bevy_cli/cli/migration.html#vXYZ-to-vXYZ
 
 > [!WARNING]
 >
 > This is an unofficial community project, hacked upon by the Bevy CLI working group until it is eventually upstreamed into the main [Bevy Engine organization](https://github.com/bevyengine). Pardon our rough edges, and please consider [submitting an issue](https://github.com/TheBevyFlock/bevy_cli/issues) if you run into trouble!
 
-You can install the precompiled CLI using `cargo-binstall`:
-
-<!-- Update `X.Y.Z` with the correct version. -->
-
-```sh
-cargo binstall --git https://github.com/TheBevyFlock/bevy_cli --version X.Y.Z --locked bevy_cli
-```
-
-You may also compile the CLI yourself with `cargo install`:
+You can install the CLI using:
 
 <!-- Update `cli-vX.Y.Z` with the correct tag. -->
 


### PR DESCRIPTION
As per the [release process](https://thebevyflock.github.io/bevy_cli/contribute/cli/release.html#post-release), this PR undoes the feature-freeze and prepares the repo for more development on the CLI.

Additionally, I updated the template used for [the Github Releases](https://github.com/TheBevyFlock/bevy_cli/releases) to reflect modifications I made in the v0.1.0-alpha.2 description.