### PR TITLE
add bevy lint install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ With the following steps, you can create a new 2D app with Bevy and run it in yo
     bevy lint
     ```
 
-    > [!NOTE] If you've previously installed the bevy_cli, you may need to also update the bevy linter, which uses a nightly toolchain compatible with recent bevy releases.
-    > 
-    > ```
-    > bevy lint install
-    > ```
+> [!NOTE]
+> If you've previously installed the bevy_cli, you may need to also update the bevy linter, which uses a nightly toolchain compatible with recent bevy releases.
+> 
+> ```
+> bevy lint install
+> ```
+
 
 4. Run the app in the browser:
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ With the following steps, you can create a new 2D app with Bevy and run it in yo
 3. Check the code quality with the linter:
 
     ```sh
+    # Install the latest version of the linter.
+    bevy lint install v0.4.0
+
+    # Run the linter on your project.
     bevy lint
     ```
 

--- a/README.md
+++ b/README.md
@@ -73,19 +73,11 @@ With the following steps, you can create a new 2D app with Bevy and run it in yo
 
     ```sh
     # Install the latest version of the linter.
-    bevy lint install v0.4.0
+    bevy lint install
 
     # Run the linter on your project.
     bevy lint
     ```
-
-> [!NOTE]
-> If you've previously installed the bevy_cli, you may need to also update the bevy linter, which uses a nightly toolchain compatible with recent bevy releases.
-> 
-> ```
-> bevy lint install
-> ```
-
 
 4. Run the app in the browser:
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ With the following steps, you can create a new 2D app with Bevy and run it in yo
     bevy lint
     ```
 
+    > [!NOTE] If you've previously installed the bevy_cli, you may need to also update the bevy linter, which uses a nightly toolchain compatible with recent bevy releases.
+    > 
+    > ```
+    > bevy lint install
+    > ```
+
 4. Run the app in the browser:
 
     ```sh

--- a/docs/src/cli/quick-start.md
+++ b/docs/src/cli/quick-start.md
@@ -19,6 +19,10 @@ With the following steps, you can create a new 2D app with Bevy and run it in yo
 3. Check the code quality with the linter:
 
     ```sh
+    # Install the latest version of the linter.
+    bevy lint install
+
+    # Run the linter on your project.
     bevy lint
     ```
 


### PR DESCRIPTION
If you've previously installed bevy_cli and the linter, you need to manually update it for new installs, especially if Bevy has done a release and bumped the msrv

This is the error you get for an out of date linter:

```
❯ bevy lint
error: rustc 1.86.0-nightly is not supported by the following packages:
  bevy@0.17.0-rc.1 requires rustc 1.88.0
  bevy_skein@0.3.0-rc.1 requires rustc 1.88.0
  sysinfo@0.37.0 requires rustc 1.88
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.86.0-nightly

Check failed: exit status: 101.
error: command `bevy_lint --profile dev` exited with status code exit status: 101
```

PR modifies readme to show a note

<img width="2270" height="924" alt="screenshot-2025-09-25-at-14 30 44@2x" src="https://github.com/user-attachments/assets/a1b4966c-c67a-4824-bb9d-3470e73a56c3" />
