### PR TITLE
Enable `getrandom` backend with `bevy lint web`

### DIFF
--- a/src/commands/lint/mod.rs
+++ b/src/commands/lint/mod.rs
@@ -14,7 +14,6 @@ use crate::{
             install::{AutoInstall, is_installed},
         },
     },
-    web::getrandom::getrandom_web_feature_config,
 };
 
 mod args;
@@ -57,7 +56,11 @@ pub fn lint(args: &mut LintArgs) -> anyhow::Result<()> {
         // GitHub since there is no easy way of specify "latest".
         .ensure_status(AutoInstall::Never)
         .inspect_err(|_| {
+            #[cfg(feature = "web")]
+            use crate::web::getrandom::getrandom_web_feature_config;
+
             // If the build failed, check if the user has configured `getrandom` correctly
+            #[cfg(feature = "web")]
             if let Some(target) = args.target()
                 && let Ok(Some(feature_config)) = getrandom_web_feature_config(&target)
             {

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -35,7 +35,7 @@ pub fn build_web(
     args.cargo_args.common_args.config = profile_args;
 
     // Apply the `getrandom` web backend if necessary
-    if apply_getrandom_backend(metadata, args) {
+    if apply_getrandom_backend(metadata, &mut args.cargo_args.common_args) {
         info!("automatically configuring `getrandom` web backend");
     }
 

--- a/src/web/getrandom.rs
+++ b/src/web/getrandom.rs
@@ -1,7 +1,7 @@
 use cargo_metadata::{Metadata, Package};
 use semver::VersionReq;
 
-use crate::{commands::build::BuildArgs, external_cli::cargo};
+use crate::external_cli::cargo::{self, CargoCommonArgs};
 
 /// Apply the web backend to getrandom.
 ///
@@ -16,7 +16,7 @@ use crate::{commands::build::BuildArgs, external_cli::cargo};
 /// without modifying the user's `Cargo.toml`.
 ///
 /// When `true` is returned, the rustflag has been configured in the args.
-pub fn apply_getrandom_backend(metadata: &Metadata, args: &mut BuildArgs) -> bool {
+pub fn apply_getrandom_backend(metadata: &Metadata, args: &mut CargoCommonArgs) -> bool {
     let getrandom = getrandom_packages(metadata);
 
     if getrandom.v3_packages.is_empty() {
@@ -24,12 +24,7 @@ pub fn apply_getrandom_backend(metadata: &Metadata, args: &mut BuildArgs) -> boo
         return false;
     }
 
-    let mut rustflags = args
-        .cargo_args
-        .common_args
-        .rustflags
-        .clone()
-        .unwrap_or_default();
+    let mut rustflags = args.rustflags.clone().unwrap_or_default();
 
     if rustflags.contains("getrandom_backend") {
         // The user has already set a backend, so we don't override it
@@ -38,7 +33,7 @@ pub fn apply_getrandom_backend(metadata: &Metadata, args: &mut BuildArgs) -> boo
 
     // Add the backend configuration
     rustflags += " --cfg getrandom_backend=\"wasm_js\"";
-    args.cargo_args.common_args.rustflags = Some(rustflags);
+    args.rustflags = Some(rustflags);
 
     true
 }


### PR DESCRIPTION
Fixes #612!

I copied the changes made in #547 to `web/build.rs` over to `lint/mod.rs`, so they should now behave the same. I also modified `apply_getrandom_backend()` to take a `CargoCommonArgs` instead of a `BuildArgs`, since the linter doesn't have a `BuildArgs` (it has `LintArgs` instead).

I tested this on `bevy_new_2d`, and `bevy lint web` now compiles! :)