### PR TITLE
Hide focus ring on canvas

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -34,6 +34,10 @@
         background-color: var(--web-bg-color);
         color: var(--web-color);
       }
+      
+      canvas {
+        outline: none;
+      }
 
       .spinner {
         width: 128px;


### PR DESCRIPTION
I find the focus ring distracting and redundant since the canvas is the only focusable element.