### PR TITLE
Enabled required features from examples automatically

### DIFF
--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -1,5 +1,7 @@
 //! Provides functionalities to run a Bevy app targeting either native or web platforms.
 
+use tracing::debug;
+
 pub use self::args::*;
 #[cfg(feature = "web")]
 use crate::web::run::run_web;
@@ -44,6 +46,29 @@ pub fn run(args: &mut RunArgs) -> anyhow::Result<()> {
         args.profile(),
         args.cargo_args.target_args.example.is_some(),
     );
+
+    // Extend the already present features with the required_features from this example.
+    if let Some(example) = &args.cargo_args.target_args.example
+    // Search in the current workspace packages for an `example` target that matches the given
+    // example name.
+        && let Some(example_target) = metadata
+            .workspace_packages()
+            .iter()
+            .flat_map(|p| p.targets.clone())
+            .find(|t| t.name.as_str() == example && t.kind.contains(&cargo_metadata::TargetKind::Example))
+    {
+        let required_features = example_target.required_features;
+
+        debug!(
+            "enabling required_features: {:?}, for example: {example}",
+            required_features
+        );
+
+        args.cargo_args
+            .feature_args
+            .features
+            .extend(required_features);
+    }
 
     #[cfg(feature = "web")]
     if args.is_web() {


### PR DESCRIPTION
# Objective

Enable the required features from examples automatically. If all examples should be built/checked, enable `--all-features`.

# Testing

```sh
❯ bevy run --example web_asset -v
debug: running: `cargo metadata --format-version 1`
debug: enabling required_features: ["https"], for example: web_asset
debug: running: `cargo run --example web_asset --features https --profile dev`
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
```

```sh
❯ bevy build --example web_asset -v
debug: running: `cargo metadata --format-version 1`
debug: enabling required_features: ["https"], for example: web_asset
debug: running: `cargo build --example web_asset --features https --profile dev`
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
```

Closes #622