### PR TITLE
Do not continue `duplicate_bevy_dependencies` if `bevy` is not a dependency

### DIFF
--- a/bevy_lint/src/lints/nursery/duplicate_bevy_dependencies.rs
+++ b/bevy_lint/src/lints/nursery/duplicate_bevy_dependencies.rs
@@ -100,8 +100,8 @@ fn toml_span(range: Range<usize>, file: &SourceFile) -> Span {
 }
 
 pub(crate) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
-    // no reason to continue the check if there is only one instance of `bevy` required
-    if find_crates(cx.tcx, sym::bevy).len() == 1 {
+    // Check if there are 2 or more crates named `bevy`.
+    if find_crates(cx.tcx, sym::bevy).len() <= 1 {
         return;
     }
 


### PR DESCRIPTION
At the very beginning of the `duplicate_bevy_dependencies` lint, we count how many crates named `bevy` are available. We currently exit early if there is only one `bevy` crate, as there cannot be duplicates in that case.

However, we don't exit early if there are _zero_ `bevy` crates! This means we're doing a bunch of extra work when there is no `bevy` crate, just to immediately discard it. This PR fixes the lint to exit early if there is no crate named `bevy`.