### PR TITLE
Make the loading spinner look more like a spinner

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -42,13 +42,13 @@
       .spinner {
         width: 128px;
         height: 128px;
-        border: 64px solid transparent;
+        border: 10px solid transparent;
         border-bottom-color: #ececec;
         border-right-color: #b2b2b2;
         border-top-color: #787878;
         border-radius: 50%;
         box-sizing: border-box;
-        animation: spin 1.2s linear infinite;
+        animation: spin 1.5s linear infinite;
       }
 
       @keyframes spin {


### PR DESCRIPTION
The existing spinner has an issue where the spinner has a border size equal to half the diameter, making it look more like a beach ball than a spinner.

I have copied over the spinner that I started using for my own projects. The exact color and style of the spinner isn't too important, but I think this one reads a lot more like a spinner than the existing one, so I do think it's a good improvement.

Before and after comparison: https://playcode.io/2578804