### PR TITLE
add `--bundle-dir` option to `web` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
   - This depends on an unstable flag in the Rust compiler, and thus requires a nightly toolchain of Rust
   - Bevy doesn't natively utilize multi-threaded WASM, so this will only benefit plugins that support it or code you write yourself
 - `bevy build web` now supports a `--skip-post-processing` flag for skipping post-build binding, optimization or bundling steps. The option can also be enabled by setting the `BEVY_WEB_SKIP_POST_PROCESSING` environment variable to `true`.
+- `bevy build web` now has an option to copy the packed bundle to a specific path using `--bundle-dir`
 
 ### Changed
 

--- a/docs/src/cli/web.md
+++ b/docs/src/cli/web.md
@@ -30,6 +30,7 @@ You can view the [default `index.html` here](web/default-index-html.md).
 To deploy your app on a web server, it's often necessary to bundle the binary, assets and web files into a single folder.
 Using `bevy build web --bundle`, the CLI can create this bundle for you automatically.
 It will be available in the `target/bevy_web` folder, see the command's output for the full file path.
+You can also use `bevy build web --bundle --bundle-dir <path>` to copy the bundle directory to `<path>`.
 
 ## Compilation profiles
 

--- a/src/commands/build/args.rs
+++ b/src/commands/build/args.rs
@@ -1,4 +1,7 @@
 #[cfg(feature = "web")]
+use std::path::PathBuf;
+
+#[cfg(feature = "web")]
 use clap::ArgAction;
 use clap::{Args, Subcommand};
 
@@ -159,6 +162,10 @@ pub struct BuildWebArgs {
     /// You can also specify custom arguments to use.
     #[arg(long = "wasm-opt", allow_hyphen_values = true)]
     pub wasm_opt: Vec<String>,
+
+    /// Copy packed bundle directory to this directory
+    #[arg(long = "bundle-dir", allow_hyphen_values = true)]
+    pub bundle_dir: Option<PathBuf>,
 
     #[cfg(feature = "unstable")]
     #[clap(flatten)]

--- a/src/commands/build/args.rs
+++ b/src/commands/build/args.rs
@@ -165,6 +165,7 @@ pub struct BuildWebArgs {
 
     /// Copy packed bundle directory to this directory
     #[arg(long = "bundle-dir", allow_hyphen_values = true)]
+    #[arg(long = "bundle-dir")]
     pub bundle_dir: Option<PathBuf>,
 
     #[cfg(feature = "unstable")]

--- a/src/commands/build/args.rs
+++ b/src/commands/build/args.rs
@@ -163,8 +163,8 @@ pub struct BuildWebArgs {
     #[arg(long = "wasm-opt", allow_hyphen_values = true)]
     pub wasm_opt: Vec<String>,
 
-    /// Copy packed bundle directory to this directory
-    #[arg(long = "bundle-dir", allow_hyphen_values = true)]
+    /// The directory to copy final packed bundle to. Note that a copy of the Bundle can still be
+    /// found at `target/bevy_web`.
     #[arg(long = "bundle-dir")]
     pub bundle_dir: Option<PathBuf>,
 

--- a/src/commands/build/args.rs
+++ b/src/commands/build/args.rs
@@ -165,7 +165,7 @@ pub struct BuildWebArgs {
 
     /// The directory to copy final packed bundle to. Note that a copy of the Bundle can still be
     /// found at `target/bevy_web`.
-    #[arg(long = "bundle-dir")]
+    #[arg(long = "bundle-dir", requires = "create_packed_bundle")]
     pub bundle_dir: Option<PathBuf>,
 
     #[cfg(feature = "unstable")]

--- a/src/commands/run/args.rs
+++ b/src/commands/run/args.rs
@@ -1,4 +1,7 @@
 #[cfg(feature = "web")]
+use std::path::PathBuf;
+
+#[cfg(feature = "web")]
 use clap::ArgAction;
 use clap::{Args, Subcommand};
 
@@ -167,6 +170,10 @@ pub struct RunWebArgs {
     #[arg(long = "wasm-opt", allow_hyphen_values = true)]
     pub wasm_opt: Vec<String>,
 
+    /// Copy packed bundle directory to this directory
+    #[arg(long = "bundle-dir", allow_hyphen_values = true)]
+    pub bundle_dir: Option<PathBuf>,
+
     #[cfg(feature = "unstable")]
     #[clap(flatten)]
     pub unstable: UnstableWebArgs,
@@ -182,6 +189,7 @@ impl Default for RunWebArgs {
             create_packed_bundle: false,
             headers: Vec::new(),
             wasm_opt: Vec::new(),
+            bundle_dir: None,
             #[cfg(feature = "unstable")]
             unstable: UnstableWebArgs::default(),
         }
@@ -223,6 +231,7 @@ impl From<RunArgs> for BuildArgs {
                     skip_post_processing: false,
                     #[cfg(feature = "unstable")]
                     unstable: web_args.unstable,
+                    bundle_dir: web_args.bundle_dir,
                 }),
             }),
         }

--- a/src/commands/run/args.rs
+++ b/src/commands/run/args.rs
@@ -1,7 +1,4 @@
 #[cfg(feature = "web")]
-use std::path::PathBuf;
-
-#[cfg(feature = "web")]
 use clap::ArgAction;
 use clap::{Args, Subcommand};
 
@@ -170,10 +167,6 @@ pub struct RunWebArgs {
     #[arg(long = "wasm-opt", allow_hyphen_values = true)]
     pub wasm_opt: Vec<String>,
 
-    /// Copy packed bundle directory to this directory
-    #[arg(long = "bundle-dir", allow_hyphen_values = true)]
-    pub bundle_dir: Option<PathBuf>,
-
     #[cfg(feature = "unstable")]
     #[clap(flatten)]
     pub unstable: UnstableWebArgs,
@@ -189,7 +182,6 @@ impl Default for RunWebArgs {
             create_packed_bundle: false,
             headers: Vec::new(),
             wasm_opt: Vec::new(),
-            bundle_dir: None,
             #[cfg(feature = "unstable")]
             unstable: UnstableWebArgs::default(),
         }
@@ -231,7 +223,7 @@ impl From<RunArgs> for BuildArgs {
                     skip_post_processing: false,
                     #[cfg(feature = "unstable")]
                     unstable: web_args.unstable,
-                    bundle_dir: web_args.bundle_dir,
+                    bundle_dir: None,
                 }),
             }),
         }

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -102,6 +102,7 @@ pub fn build_web(args: &mut BuildArgs, metadata: &Metadata) -> anyhow::Result<We
                 fs::create_dir_all(target).context("failed to create target directory")?;
                 dir::copy(path, target, &CopyOptions::new().content_only(true))
                     .context("failed to copy packed bundle directory to target directory")?;
+                info!("copied bundle to file://{}", target.display());
             }
         }
 

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -1,11 +1,14 @@
+use std::fs;
+
 use anyhow::Context as _;
 use cargo_metadata::Metadata;
+use fs_extra::dir::{self, CopyOptions};
 use tracing::info;
 
 use super::bundle::WebBundle;
 use crate::{
     bin_target::select_run_binary,
-    commands::build::{BuildArgs, BuildSubcommands},
+    commands::build::{BuildArgs, BuildSubcommands, BuildWebArgs},
     external_cli::{cargo, wasm_bindgen, wasm_opt},
     web::{
         bundle::{PackedBundle, create_web_bundle},
@@ -91,6 +94,15 @@ pub fn build_web(args: &mut BuildArgs, metadata: &Metadata) -> anyhow::Result<We
 
         if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
             info!("created bundle at file://{}", path.display());
+            if let Some(BuildWebArgs {
+                bundle_dir: Some(target),
+                ..
+            }) = web_args
+            {
+                fs::create_dir_all(target).context("failed to create target directory")?;
+                dir::copy(path, target, &CopyOptions::new().content_only(true))
+                    .context("failed to copy packed bundle directory to target directory")?;
+            }
         }
 
         Ok(web_bundle)

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -95,14 +95,15 @@ pub fn build_web(args: &mut BuildArgs, metadata: &Metadata) -> anyhow::Result<We
         if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
             info!("created bundle at file://{}", path.display());
             if let Some(BuildWebArgs {
-                bundle_dir: Some(target),
+                bundle_dir: Some(destination),
                 ..
             }) = web_args
             {
-                fs::create_dir_all(target).context("failed to create target directory")?;
-                dir::copy(path, target, &CopyOptions::new().content_only(true))
-                    .context("failed to copy packed bundle directory to target directory")?;
-                info!("copied bundle to file://{}", target.display());
+                fs::create_dir_all(destination)
+                    .context("failed to create destination directory")?;
+                dir::copy(path, destination, &CopyOptions::new().content_only(true))
+                    .context("failed to copy packed bundle directory to destination directory")?;
+                info!("copied bundle to file://{}", destination.display());
             }
         }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
-use assert_cmd::cargo::cargo_bin_cmd;
+use assert_cmd::{Command, cargo::cargo_bin_cmd};
 use serial_test::serial;
 
 /// The path to the test repository.
@@ -123,5 +123,35 @@ fn should_build_web_release() -> anyhow::Result<()> {
     ensure_path_exists(target_artifact_path.join("bevy_default_bg.wasm"))
         .context("Wasm bindings do not exist")?;
     ensure_path_exists(target_artifact_path.join("bevy_default.js"))
+        .context("JS bindings do not exist")
+}
+
+#[test]
+#[serial]
+fn should_copy_web_bundle() -> anyhow::Result<()> {
+    let target_artifact_path = target_path()
+        .join("wasm32-unknown-unknown")
+        .join("web-release");
+    clean_target_artifacts(&target_artifact_path)?;
+
+    let _ = fs::remove_dir_all(test_path().join("web-dir"));
+    let mut cmd = Command::cargo_bin("bevy")?;
+    cmd.current_dir(test_path()).args([
+        "build",
+        "-p=bevy_default",
+        "--release",
+        "--yes",
+        "web",
+        "--bundle",
+        "--bundle-dir=web-dir",
+    ]);
+
+    cmd.assert().success();
+
+    ensure_path_exists(test_path().join("web-dir/index.html"))
+        .context("index.html do not exist")?;
+    ensure_path_exists(test_path().join("web-dir/build/bevy_default_bg.wasm"))
+        .context("Wasm bindings do not exist")?;
+    ensure_path_exists(test_path().join("web-dir/build/bevy_default.js"))
         .context("JS bindings do not exist")
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -139,7 +139,6 @@ fn should_copy_web_bundle() -> anyhow::Result<()> {
     cmd.current_dir(test_path()).args([
         "build",
         "-p=bevy_default",
-        "--release",
         "--yes",
         "web",
         "--bundle",


### PR DESCRIPTION
Add an option for copying a packed web bundle directory to a user-specified directory. This lets you skip any error-prone parsing/guessing when locating the bundle directory, which is usually useful for CI-related tasks.

The behavior is modeled after the unstable `--artifact-dir` option from `cargo`:

- https://github.com/rust-lang/cargo/issues/6790

Fix: https://github.com/TheBevyFlock/bevy_cli/issues/649