### PR TITLE
Fix doc links to `insert_message_resource` and `iter_current_update_messages`

### DIFF
--- a/bevy_lint/src/lints/mod.rs
+++ b/bevy_lint/src/lints/mod.rs
@@ -1,8 +1,8 @@
 //! All lints offered by `bevy_lint`, organized by lint group.
 //!
 //! Each module contains the lints for that lint group. [`suspicious`], for example, contains the
-//! documentation for [`suspicious::insert_event_resource`] and
-//! [`suspicious::iter_current_update_events`], since they are both within the `bevy::suspicious`
+//! documentation for [`suspicious::insert_message_resource`] and
+//! [`suspicious::iter_current_update_messages`], since they are both within the `bevy::suspicious`
 //! lint group.
 //!
 //! Just like lints, [lint groups that can be toggled together]. The following lint groups are


### PR DESCRIPTION
Building the linter's API docs (lint catalog) gives two errors:

```sh
$ cargo doc-lints
warning: unresolved link to `suspicious::insert_event_resource`
 --> bevy_lint/src/lints/mod.rs:4:25
  |
4 | //! documentation for [`suspicious::insert_event_resource`] and
  |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `insert_event_resource` in module `suspicious`
  |
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `suspicious::iter_current_update_events`
 --> bevy_lint/src/lints/mod.rs:5:7
  |
5 | //! [`suspicious::iter_current_update_events`], since they are both within the `bevy::suspicious`
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `iter_current_update_events` in module `suspicious`
```

This PR fixes the warnings by updating the links to use the new names, as "events" in Bevy were renamed to "messages" in 0.17.