### PR TITLE
Rename `llvm-tools-preview` component to `llvm-tools`

### DIFF
--- a/bevy_lint/MIGRATION.md
+++ b/bevy_lint/MIGRATION.md
@@ -37,7 +37,7 @@ rustup toolchain uninstall nightly-2025-04-03
 
 rustup toolchain install nightly-2025-06-26 \
     --component rustc-dev \
-    --component llvm-tools-preview
+    --component llvm-tools
 ```
 
 ### [`insert_unit_bundle` Has Been Renamed to `unit_in_bundle`](https://github.com/TheBevyFlock/bevy_cli/pull/502)

--- a/bevy_lint/README.md
+++ b/bevy_lint/README.md
@@ -34,7 +34,7 @@ You can install the toolchain required for the latest release with:
 ```sh
 rustup toolchain install nightly-2025-06-26 \
     --component rustc-dev \
-    --component llvm-tools-preview
+    --component llvm-tools
 ```
 
 If you are installing a different version of the linter, you may need to install a different nightly toolchain as specified by the [compatibility table](https://thebevyflock.github.io/bevy_cli/linter/compatibility.html). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].

--- a/bevy_lint/action.yml
+++ b/bevy_lint/action.yml
@@ -50,8 +50,8 @@ runs:
         CHANNEL=$(sed -nE "s/${CHANNEL_REGEX}/\1/p" < "${RUST_TOOLCHAIN_PATH}")
 
         # This does the same thing, but also strips out double quotes. In practice, this converts
-        # `components = ["rustc-dev", "llvm-tools-preview"]` to `"rustc-dev", "llvm-tools-preview"`
-        # to `rustc-dev, llvm-tools-preview`.
+        # `components = ["rustc-dev", "llvm-tools"]` to `"rustc-dev", "llvm-tools"`
+        # to `rustc-dev, llvm-tools`.
         COMPONENTS=$(sed -nE "s/${COMPONENTS_REGEX}/\1/p" < "${RUST_TOOLCHAIN_PATH}" | tr -d '"')
 
         echo "channel=${CHANNEL}" >> "${GITHUB_OUTPUT}"

--- a/docs/src/contribute/linter/how-to/release.md
+++ b/docs/src/contribute/linter/how-to/release.md
@@ -45,7 +45,7 @@ This release uses the <!-- `nightly-YYYY-MM-DD` --> toolchain, based on Rust <!-
 ```sh
 rustup toolchain install nightly-YYYY-MM-DD \
     --component rustc-dev \
-    --component llvm-tools-preview
+    --component llvm-tools
 
 rustup run nightly-YYYY-MM-DD cargo install \
     --git https://github.com/TheBevyFlock/bevy_cli.git \

--- a/docs/src/linter/install.md
+++ b/docs/src/linter/install.md
@@ -18,12 +18,12 @@ bevy lint install --yes v0.4.0
 
 ## Manual with Rustup
 
-`bevy_lint` requires a specific nightly Rust toolchain with the `rustc-dev` and `llvm-tools-preview` components. You can install the toolchain required for the latest release with:
+`bevy_lint` requires a specific nightly Rust toolchain with the `rustc-dev` and `llvm-tools` components. You can install the toolchain required for the latest release with:
 
 ```sh
 rustup toolchain install nightly-2025-06-26 \
     --component rustc-dev \
-    --component llvm-tools-preview
+    --component llvm-tools
 ```
 
 If you are installing a different version of the linter, you may need to install a different nightly toolchain as specified by the [compatibility table](compatibility.md). Please be aware that you must keep this toolchain installed for `bevy_lint` to function[^keep-toolchain-installed].
@@ -44,7 +44,7 @@ If you're installing a different version of the linter, you may need to switch t
 
 ## Manual without Rustup
 
-It is possible to use the linter without Rustup, however it requires some extra steps. First, you'll need to install the required nightly Rust toolchain (check the [compatibility table](compatibility.md)) through some other means. If you're using Nix, for example, you would use a [Rust overlay](https://nixos.wiki/wiki/Rust#Unofficial_overlays) to do this. Make sure to also install the `rustc-dev` and `llvm-tools-preview` components for the toolchain.
+It is possible to use the linter without Rustup, however it requires some extra steps. First, you'll need to install the required nightly Rust toolchain (check the [compatibility table](compatibility.md)) through some other means. If you're using Nix, for example, you would use a [Rust overlay](https://nixos.wiki/wiki/Rust#Unofficial_overlays) to do this. Make sure to also install the `rustc-dev` and `llvm-tools` components for the toolchain.
 
 Once you've installed the toolchain and components, use that toolchain's `cargo` to build the linter:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -9,4 +9,4 @@ channel = "nightly-2025-09-18"
 
 # These components are required to use `rustc` crates. Note that we use the Regex
 # `^components = \[(.*)\]$` to match this line, so be wary when changing its formatting.
-components = ["rustc-dev", "llvm-tools-preview"]
+components = ["rustc-dev", "llvm-tools"]


### PR DESCRIPTION
The `llvm-tools-preview` Rustup component was [accidentally renamed](https://github.com/rust-lang/rust/issues/85658#issuecomment-1991897200) to `llvm-tools`. As the Rust project has no intention of undoing this change, we should switch to it. It's shorter and removes questions such as "why is this component in preview mode?".