### PR TITLE
ignore `exist_status` code in `bevy_lint` ui tests

### DIFF
--- a/bevy_lint/tests/ui.rs
+++ b/bevy_lint/tests/ui.rs
@@ -8,6 +8,9 @@ use ui_test::run_tests;
 mod test_utils;
 
 fn main() {
-    let config = base_config("ui").unwrap();
+    let mut config = base_config("ui").unwrap();
+    let defaults = config.comment_defaults.base();
+    // This allows for any status code to be considered a success.
+    defaults.exit_status = None.into();
     run_tests(config).unwrap();
 }


### PR DESCRIPTION
# Objective

When using `codegen-backend = "cranelift"`, the ui tests fail because the exit status code is not `1` but `101`

```sh
error: test got exit status: 101, but expected 1
```

This will just allow any status code to be considered a success. We already set this in the `ui_cargo` tests.

# Disclaimer

I have not checked what causes cranelift to return with 101 but the stderr looks correct.