### PR TITLE
Replace `str.to_string()` with `str.to_owned()`

### DIFF
--- a/bevy_lint/src/callback.rs
+++ b/bevy_lint/src/callback.rs
@@ -33,7 +33,7 @@ impl Callbacks for BevyLintCallback {
         crate::config::load_config(config);
 
         // Add `--cfg bevy_lint` so programs can conditionally configure lints.
-        config.crate_cfg.push("bevy_lint".to_string());
+        config.crate_cfg.push("bevy_lint".to_owned());
 
         // We should be the only callback, meaning nothing else should register custom lints.
         assert!(config.register_lints.is_none());

--- a/bevy_lint/src/lints/restriction/panicking_methods.rs
+++ b/bevy_lint/src/lints/restriction/panicking_methods.rs
@@ -140,7 +140,7 @@ impl<'tcx> LateLintPass<'tcx> for PanickingMethods {
             let (src_snippet, generics_snippet, args_snippet) = if is_fully_qualified {
                 // When the method was a fully qualified method call, the beginning of the snippet
                 // is just the `PanickingType`.
-                let mut src_snippet = panicking_type.name().to_string();
+                let mut src_snippet = panicking_type.name().to_owned();
                 src_snippet.push_str("::");
 
                 // Try to find the generic arguments of the method, if any exist. This can

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -212,7 +212,7 @@ where
         let level = if writer.has_ansi_escapes() {
             color.bold().paint(level).to_string()
         } else {
-            level.to_string()
+            level.to_owned()
         };
 
         write!(writer, "{level}: ",)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -259,7 +259,7 @@ fn extract_features(cli_metadata: &Map<String, Value>) -> anyhow::Result<Vec<Str
             .map(|value| {
                 value
                     .as_str()
-                    .map(|str| str.to_string())
+                    .map(|str| str.to_owned())
                     .ok_or_else(|| anyhow::anyhow!("each feature must be a string"))
             })
             .collect(),
@@ -304,7 +304,7 @@ fn extract_headers(cli_metadata: &Map<String, Value>) -> anyhow::Result<Vec<Stri
             .map(|value| {
                 value
                     .as_str()
-                    .map(|str| str.to_string())
+                    .map(|str| str.to_owned())
                     .ok_or_else(|| anyhow::anyhow!("each header must be a string"))
             })
             .collect(),
@@ -405,7 +405,6 @@ impl Display for CliConfig {
             f,
             "{}",
             document
-                .to_string()
                 // Remove trailing newline
                 .trim_end()
                 .lines()
@@ -456,9 +455,9 @@ mod tests {
                     ],
                     default_features: Some(false),
                     rustflags: vec![
-                        "-C opt-level=2".to_string(),
-                        "--cfg".to_string(),
-                        "getrandom_backend=\"wasm_js\"".to_string()
+                        "-C opt-level=2".to_owned(),
+                        "--cfg".to_owned(),
+                        "getrandom_backend=\"wasm_js\"".to_owned()
                     ],
                     wasm_opt: None,
                     web_multi_threading: None,
@@ -502,7 +501,7 @@ mod tests {
                         "native-release".to_owned()
                     ],
                     default_features: Some(false),
-                    rustflags: vec!["-C opt-level=2".to_string(), "-C debuginfo=1".to_string()],
+                    rustflags: vec!["-C opt-level=2".to_owned(), "-C debuginfo=1".to_owned()],
                     wasm_opt: None,
                     web_multi_threading: None,
                     headers: Vec::new()
@@ -617,7 +616,7 @@ mod tests {
             cli_metadata.insert("target".to_owned(), "wasm32v1-none".into());
             assert_eq!(
                 extract_target(&cli_metadata)?,
-                Some("wasm32v1-none".to_string())
+                Some("wasm32v1-none".to_owned())
             );
             Ok(())
         }
@@ -625,7 +624,7 @@ mod tests {
         #[test]
         fn should_return_error_if_target_is_not_a_string() {
             let mut cli_metadata = Map::new();
-            cli_metadata.insert("target".to_string(), 32.into());
+            cli_metadata.insert("target".to_owned(), 32.into());
             assert!(extract_target(&cli_metadata).is_err());
         }
     }
@@ -657,7 +656,7 @@ mod tests {
         fn should_return_error_if_one_feature_is_not_a_string() {
             let mut cli_metadata = Map::new();
             cli_metadata.insert(
-                "features".to_string(),
+                "features".to_owned(),
                 vec![
                     Value::String("dev".to_owned()),
                     Value::Bool(false),
@@ -706,7 +705,7 @@ mod tests {
         fn should_return_error_if_one_feature_is_not_a_string() {
             let mut cli_metadata = Map::new();
             cli_metadata.insert(
-                "headers".to_string(),
+                "headers".to_owned(),
                 vec![
                     Value::String("Cross-Origin-Opener-Policy:same-origin".to_owned()),
                     Value::Bool(false),

--- a/src/external_cli/cargo/mod.rs
+++ b/src/external_cli/cargo/mod.rs
@@ -95,7 +95,7 @@ impl CargoCompilationArgs {
             self.target
                 .clone()
                 // Default to `wasm32-unknown-unknown`
-                .or_else(|| Some("wasm32-unknown-unknown".to_string()))
+                .or_else(|| Some("wasm32-unknown-unknown".to_owned()))
         } else {
             self.target.clone()
         }

--- a/src/external_cli/external_cli_args.rs
+++ b/src/external_cli/external_cli_args.rs
@@ -38,8 +38,8 @@ impl ExternalCliArgs {
     #[cfg(feature = "web")]
     pub fn to_raw(&self) -> Vec<String> {
         match self {
-            Self::Enabled(true) => vec!["true".to_string()],
-            Self::Enabled(false) => vec!["false".to_string()],
+            Self::Enabled(true) => vec!["true".to_owned()],
+            Self::Enabled(false) => vec!["false".to_owned()],
             Self::Args(args) => args.clone(),
         }
     }
@@ -52,25 +52,25 @@ mod tests {
 
     #[test]
     fn should_parse_true() {
-        let args = vec!["true".to_string()];
+        let args = vec!["true".to_owned()];
         let parsed = ExternalCliArgs::from_raw_args(args);
         assert!(matches!(parsed, ExternalCliArgs::Enabled(true)));
     }
 
     #[test]
     fn should_parse_false() {
-        let args = vec!["false".to_string()];
+        let args = vec!["false".to_owned()];
         let parsed = ExternalCliArgs::from_raw_args(args);
         assert!(matches!(parsed, ExternalCliArgs::Enabled(false)));
     }
 
     #[test]
     fn should_parse_args() {
-        let args = vec!["arg1".to_string(), "arg2".to_string()];
+        let args = vec!["arg1".to_owned(), "arg2".to_owned()];
         let parsed = ExternalCliArgs::from_raw_args(args);
         assert!(matches!(
             parsed,
-            ExternalCliArgs::Args(ref args) if args == &["arg1".to_string(), "arg2".to_string()]
+            ExternalCliArgs::Args(ref args) if args == &["arg1".to_owned(), "arg2".to_owned()]
         ));
     }
 }

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -107,7 +107,7 @@ fn support_multi_threading(args: &mut BuildArgs) {
         *rustflags += " ";
         *rustflags += multi_threading_flags;
     } else {
-        args.cargo_args.common_args.rustflags = Some(multi_threading_flags.to_string());
+        args.cargo_args.common_args.rustflags = Some(multi_threading_flags.to_owned());
     }
 
     // The std needs to be rebuilt with Wasm multi-threading support
@@ -120,6 +120,6 @@ fn support_multi_threading(args: &mut BuildArgs) {
         args.cargo_args
             .common_args
             .unstable_flags
-            .push("build-std=std,panic_abort".to_string());
+            .push("build-std=std,panic_abort".to_owned());
     }
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -50,7 +50,7 @@ fn executable(binary: &str) -> String {
     if cfg!(windows) {
         format!("{binary}.exe")
     } else {
-        binary.to_string()
+        binary.to_owned()
     }
 }
 


### PR DESCRIPTION
Both `to_string()` and `to_owned()` do the same thing when run on a `&str`, but `to_owned()` makes it more explicit that we are creating an owned `String`. On the contrary, someone unfamiliar with the API could see `"hello".to_string()` to return a `&str`, not a `String`.

This is a follow-up to #667, specifically from this comment: https://github.com/TheBevyFlock/bevy_cli/pull/667#discussion_r2483808752.