### PR TITLE
Enable `clippy::str_to_string` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 members = ["bevy_lint"]
 
+[workspace.lints.clippy]
+# Prefer `str.to_owned()`, rather than `str.to_string()`.
+str_to_string = "warn"
+
 [package]
 name = "bevy_cli"
 version = "0.1.0-dev"
@@ -144,6 +148,9 @@ fs_extra = { version = "1.3.0", default-features = false, optional = true }
 serial_test = "3.2.0"
 assert_cmd = "2.0.16"
 tempfile = "3"
+
+[lints]
+workspace = true
 
 [package.metadata.binstall]
 # HACK: We currently hard-code the latest version in the URL. The `{ version }` template uses the

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -66,6 +66,9 @@ serde_json = "1.0.145"
 # Ensures the error messages for lints do not regress.
 ui_test = "0.30.1"
 
+[lints]
+workspace = true
+
 [package.metadata.rust-analyzer]
 # Enables Rust-Analyzer support for `rustc` crates.
 rustc_private = true


### PR DESCRIPTION
As a follow up to #669, @lomirus recommended enabling the the [`clippy::str_to_string`](https://rust-lang.github.io/rust-clippy/master/index.html#str_to_string) lint. Sounds useful, let's enforce this as a warning!