### PR TITLE
Implement a cooldown when updating dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       - /tests/bevy_cli_test
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - C-Dependencies
   - package-ecosystem: github-actions
@@ -16,5 +18,7 @@ updates:
       - /bevy_lint
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - C-Dependencies


### PR DESCRIPTION
Inspired by [this article](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns).

This PR configures Dependabot to implement a cooldown which prevents it from updating dependencies if the new version if less than 7 days old. The intention is that this will help defend against supply-chain attacks, in the hope that malignant releases are caught and yanked before the 7-day cooldown finishes. This cooldown does not apply to security updates, so we'll still see CVE advisories in the Security tab.