### PR TITLE
Rustup to `nightly-2026-01-22`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,9 +1474,9 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.94"
+version = "0.1.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04e700671e8ff87842505ab0f2e2fd6e550b8bc3f7490ec9f0f2c9261b42b7e"
+checksum = "6af9892330fc1b90a993847ff7e4eda74edd45a62a096059280da814a09366d8"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -21,7 +21,7 @@ harness = false
 # Contains a series of useful utilities when writing lints. The version is chosen to work with the
 # currently pinned nightly Rust version. When the Rust version changes, this too needs to be
 # updated!
-clippy_utils = "=0.1.94"
+clippy_utils = "=0.1.95"
 
 # Easy error propagation and contexts.
 anyhow = "1.0.86"

--- a/docs/src/linter/compatibility.md
+++ b/docs/src/linter/compatibility.md
@@ -2,7 +2,7 @@
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
-|0.6.0-dev|1.94.0|`nightly-2025-12-11`|0.17|
+|0.6.0-dev|1.94.0|`nightly-2026-01-22`|0.17|
 |0.5.0|1.94.0|`nightly-2025-12-11`|0.17|
 |0.4.0|1.90.0|`nightly-2025-06-26`|0.16|
 |0.3.0|1.88.0|`nightly-2025-04-03`|0.16|

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version
 # so that builds are reproducible. Note that we use the Regex `^channel = "(.+)"$` to match this
 # line, so be wary when changing its formatting.
-channel = "nightly-2025-12-11"
+channel = "nightly-2026-01-22"
 
 # These components are required to use `rustc` crates. Note that we use the Regex
 # `^components = \[(.*)\]$` to match this line, so be wary when changing its formatting.


### PR DESCRIPTION
Rust [1.93.0](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/) is out, so it's that time again! This release was also very quiet, with no breaking changes impacting our upgrade. Nice!