### PR TITLE
Add an option to skip any post-web-build steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
   - This is only available when compiling the CLI with the `unstable` feature, however it is enabled by default
   - This depends on an unstable flag in the Rust compiler, and thus requires a nightly toolchain of Rust
   - Bevy doesn't natively utilize multi-threaded WASM, so this will only benefit plugins that support it or code you write yourself
+- `bevy build web` now supports a `--skip-post-processing` flag for skipping post-build binding, optimization or bundling steps. The option can also be enabled by setting the `BEVY_WEB_SKIP_POST_PROCESSING` environment variable to `true`.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ clap = { version = "4.6.0", default-features = false, features = [
     "suggestions",
     "usage",
     "derive",
+    "env"
 ] }
 # autocompletion auto-generation
 clap_complete = { version = "4.6.0", default-features = false }

--- a/src/commands/build/args.rs
+++ b/src/commands/build/args.rs
@@ -150,8 +150,8 @@ pub struct BuildWebArgs {
     #[arg(short = 'b', long = "bundle", action = ArgAction::SetTrue, default_value_t = false)]
     pub create_packed_bundle: bool,
     /// Don't perform any post-build binding, optimization or bundling.
-    #[arg(long = "build-only", action = ArgAction::SetTrue, default_value_t = false, env = "BEVY_BUILD_WEB_BUILD_ONLY")]
-    pub build_only: bool,
+    #[arg(long = "skip-post-processing", action = ArgAction::SetTrue, default_value_t = false, env = "BEVY_WEB_SKIP_POST_PROCESSING")]
+    pub skip_post_processing: bool,
     /// Use `wasm-opt` to optimize the wasm binary
     ///
     /// Defaults to `true` for release builds.

--- a/src/commands/build/args.rs
+++ b/src/commands/build/args.rs
@@ -149,6 +149,9 @@ pub struct BuildWebArgs {
     /// Bundle all web artifacts into a single folder.
     #[arg(short = 'b', long = "bundle", action = ArgAction::SetTrue, default_value_t = false)]
     pub create_packed_bundle: bool,
+    /// Don't perform any post-build binding, optimization or bundling.
+    #[arg(long = "build-only", action = ArgAction::SetTrue, default_value_t = false, env = "BEVY_BUILD_WEB_BUILD_ONLY")]
+    pub build_only: bool,
     /// Use `wasm-opt` to optimize the wasm binary
     ///
     /// Defaults to `true` for release builds.

--- a/src/commands/run/args.rs
+++ b/src/commands/run/args.rs
@@ -220,6 +220,7 @@ impl From<RunArgs> for BuildArgs {
                 RunSubcommands::Web(web_args) => BuildSubcommands::Web(BuildWebArgs {
                     create_packed_bundle: web_args.create_packed_bundle,
                     wasm_opt: web_args.wasm_opt,
+                    build_only: false,
                     #[cfg(feature = "unstable")]
                     unstable: web_args.unstable,
                 }),

--- a/src/commands/run/args.rs
+++ b/src/commands/run/args.rs
@@ -220,7 +220,7 @@ impl From<RunArgs> for BuildArgs {
                 RunSubcommands::Web(web_args) => BuildSubcommands::Web(BuildWebArgs {
                     create_packed_bundle: web_args.create_packed_bundle,
                     wasm_opt: web_args.wasm_opt,
-                    build_only: false,
+                    skip_post_processing: false,
                     #[cfg(feature = "unstable")]
                     unstable: web_args.unstable,
                 }),

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -68,28 +68,32 @@ pub fn build_web(args: &mut BuildArgs, metadata: &Metadata) -> anyhow::Result<We
             }
         })?;
 
-    info!("bundling JavaScript bindings...");
-    wasm_bindgen::bundle(metadata, &bin_target, args.auto_install())?;
-    wasm_opt::optimize_path(&bin_target, args.auto_install(), &args.wasm_opt_args())?;
-
     let web_args = args
         .subcommand
         .as_ref()
         .map(|BuildSubcommands::Web(web_args)| web_args);
 
-    let web_bundle = create_web_bundle(
-        metadata,
-        args.profile(),
-        &bin_target,
-        web_args.is_some_and(|web_args| web_args.create_packed_bundle),
-    )
-    .context("failed to create web bundle")?;
+    if web_args.is_some_and(|web_args| web_args.build_only) {
+        Ok(WebBundle::None)
+    } else {
+        info!("bundling JavaScript bindings...");
+        wasm_bindgen::bundle(metadata, &bin_target, args.auto_install())?;
+        wasm_opt::optimize_path(&bin_target, args.auto_install(), &args.wasm_opt_args())?;
 
-    if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
-        info!("created bundle at file://{}", path.display());
+        let web_bundle = create_web_bundle(
+            metadata,
+            args.profile(),
+            &bin_target,
+            web_args.is_some_and(|web_args| web_args.create_packed_bundle),
+        )
+        .context("failed to create web bundle")?;
+
+        if let WebBundle::Packed(PackedBundle { path }) = &web_bundle {
+            info!("created bundle at file://{}", path.display());
+        }
+
+        Ok(web_bundle)
     }
-
-    Ok(web_bundle)
 }
 
 /// Add multi-threading support for the Wasm binary if enabled.

--- a/src/web/build.rs
+++ b/src/web/build.rs
@@ -73,7 +73,8 @@ pub fn build_web(args: &mut BuildArgs, metadata: &Metadata) -> anyhow::Result<We
         .as_ref()
         .map(|BuildSubcommands::Web(web_args)| web_args);
 
-    if web_args.is_some_and(|web_args| web_args.build_only) {
+    if web_args.is_some_and(|web_args| web_args.skip_post_processing) {
+        info!("skipping post-processing for web build...");
         Ok(WebBundle::None)
     } else {
         info!("bundling JavaScript bindings...");

--- a/src/web/bundle.rs
+++ b/src/web/bundle.rs
@@ -58,6 +58,8 @@ pub enum WebBundle {
     Linked(LinkedBundle),
     /// A bundle packed into a single folder, ready to be deployed on a web server.
     Packed(PackedBundle),
+    /// No bundle was created.
+    None,
 }
 
 /// Create a bundle of all the files needed for serving the app in the web.

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -119,6 +119,11 @@ pub(crate) async fn serve(
                 router = router.fallback_service(ServeDir::new(web_assets));
             }
         }
+        WebBundle::None => {
+            return Err(anyhow::anyhow!(
+                "No web bundle was created during the build process! This should never happen, please report this bug to https://github.com/TheBevyFlock/bevy_cli"
+            ));
+        }
     }
 
     // Add middlewares


### PR DESCRIPTION
I wanted to cache the dependency artifacts of my web build, but because I'm using a dummy entrypoint I ended up hitting this issue with `wasm-bindgen`:

- https://github.com/trunk-rs/trunk/issues/959

So I added a new option to skip any post-web-build steps, such as binding, optimization or bundling.

I could do this manually with `cargo build`, but then I'd need to duplicate the configuration I've set in `bevy-cli`'s CLI configs.

I've also added a `BEVY_WEB_SKIP_POST_PROCESSING` environment variable, because of how useful this option is in the CI.