### PR TITLE
Update to nightly-2026-04-16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,9 +1354,9 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.96"
+version = "0.1.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89a5c65b57b45dfab53e86f7251c89e9112aa445e2596e336f76065e28e14cd"
+checksum = "bb170400201dae0f1738eadec962b57e5abd8743cf6a6c136a0fcd1994ae6c93"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",

--- a/bevy_lint/Cargo.toml
+++ b/bevy_lint/Cargo.toml
@@ -21,7 +21,7 @@ harness = false
 # Contains a series of useful utilities when writing lints. The version is chosen to work with the
 # currently pinned nightly Rust version. When the Rust version changes, this too needs to be
 # updated!
-clippy_utils = "=0.1.96"
+clippy_utils = "=0.1.97"
 
 # Easy error propagation and contexts.
 anyhow = "1.0.102"

--- a/bevy_lint/src/bin/bevy_lint.rs
+++ b/bevy_lint/src/bin/bevy_lint.rs
@@ -10,7 +10,7 @@ use std::{
     process::{Command, ExitCode},
 };
 
-use anyhow::{Context, ensure};
+use anyhow::{ensure, Context};
 
 /// The Rustup toolchain channel specified by `rust-toolchain.toml`. This is set by `build.rs`.
 const RUST_TOOLCHAIN_CHANNEL: &str = env!("RUST_TOOLCHAIN_CHANNEL");

--- a/bevy_lint/src/bin/bevy_lint.rs
+++ b/bevy_lint/src/bin/bevy_lint.rs
@@ -10,7 +10,7 @@ use std::{
     process::{Command, ExitCode},
 };
 
-use anyhow::{ensure, Context};
+use anyhow::{Context, ensure};
 
 /// The Rustup toolchain channel specified by `rust-toolchain.toml`. This is set by `build.rs`.
 const RUST_TOOLCHAIN_CHANNEL: &str = env!("RUST_TOOLCHAIN_CHANNEL");

--- a/bevy_lint/src/callback.rs
+++ b/bevy_lint/src/callback.rs
@@ -59,12 +59,12 @@ impl Callbacks for BevyLintCallback {
         // Clone the input so we can `move` it into our custom `psess_created()`.
         let input = config.input.clone();
 
-        config.psess_created = Some(Box::new(move |psess| {
+        config.track_state = Some(Box::new(move |sess, _| {
             if !was_invoked_from_cargo() {
                 return;
             }
 
-            let file_depinfo = psess.file_depinfo.get_mut();
+            let mut file_depinfo = sess.file_depinfo.borrow_mut();
 
             for workspace in [false, true] {
                 // Get the paths to the crate or workspace `Cargo.toml`, if they exist.

--- a/bevy_lint/src/lints/suspicious/unit_in_bundle.rs
+++ b/bevy_lint/src/lints/suspicious/unit_in_bundle.rs
@@ -275,7 +275,11 @@ fn bundle_bounded_generics<'tcx>(cx: &LateContext<'tcx>, fn_id: DefId) -> Vec<Ty
                     self_ty.kind(),
                     // It must either be a generic parameter `B`, or a projection
                     // `B::AssociatedType`.
-                    ty::TyKind::Param(_) | ty::TyKind::Alias(ty::AliasTyKind::Projection, _),
+                    ty::TyKind::Param(_)
+                        | ty::TyKind::Alias(ty::AliasTy {
+                            kind: ty::AliasTyKind::Projection { .. },
+                            ..
+                        })
                 ),
                 "type {self_ty} from trait bound {trait_ref} was expected to be a type parameter, but instead was a {self_ty_kind:?}",
                 self_ty_kind = self_ty.kind(),

--- a/docs/src/linter/compatibility.md
+++ b/docs/src/linter/compatibility.md
@@ -2,7 +2,7 @@
 
 |`bevy_lint` Version|Rust Version|Rustup Toolchain|Bevy Version|
 |-|-|-|-|
-|0.7.0-dev|1.96.0|`nightly-2026-03-05`|0.18|
+|0.7.0-dev|1.97.0|`nightly-2026-04-16`|0.18|
 |0.6.0|1.95.0|`nightly-2026-01-22`|0.18|
 |0.5.0|1.94.0|`nightly-2025-12-11`|0.17|
 |0.4.0|1.90.0|`nightly-2025-06-26`|0.16|

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775358767,
-        "narHash": "sha256-f2eC+WIfhjevCPQILuV08i/kmKZzYZpUvkom/33VxCA=",
+        "lastModified": 1782357464,
+        "narHash": "sha256-mXgoT1qDHCdSfF9IvhMtEEFNy9dxrmUfSViwP7RpzOQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "20fd44bc663daa53a2575e01293e24e681d62244",
+        "rev": "77a8263847fb02dc49dbe377278ef6b952f1c6bb",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # Writing custom lints requires using nightly Rust. We pin to a specific version of nightly version
 # so that builds are reproducible. Note that we use the Regex `^channel = "(.+)"$` to match this
 # line, so be wary when changing its formatting.
-channel = "nightly-2026-03-05"
+channel = "nightly-2026-04-16"
 
 # These components are required to use `rustc` crates. Note that we use the Regex
 # `^components = \[(.*)\]$` to match this line, so be wary when changing its formatting.


### PR DESCRIPTION
We are pretty far behind, so let's update!

The main migration was that `file_depinfo` got removed in https://github.com/rust-lang/rust/pull/153778/changes

Other than that, not much. Took me a while to figure out that the huge linker error I got was due to the fact that my tmp dir had not enough space left for all the artifacts xD

One i set a custom `TMPDIR` it worked like a charm.

Closes #832 