### PR TITLE
Expand cargo alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 **All Changes**: [`cli-v0.1.0-alpha.2...main`](https://github.com/TheBevyFlock/bevy_cli/compare/cli-v0.1.0-alpha.2...main)
 
+### Added
+
+- The CLI now expands user-defined aliases from the `.cargo/config.toml`
+
 ### Changed
 
 - In web builds, the canvas now resizes to fill the webpage. This change will not affect projects that use a custom `index.html` file.

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,0 +1,61 @@
+use std::{collections::HashSet, ffi::OsString};
+
+use clap::CommandFactory;
+
+/// Expand a user-defined Cargo alias in `argv`, so that it can be parsed by Clap.
+pub fn expand<C: CommandFactory>(argv: Vec<OsString>) -> Vec<OsString> {
+    let Some(index) = subcommand_index(&argv) else {
+        return argv;
+    };
+
+    let Some(name) = argv[index].to_str() else {
+        return argv;
+    };
+
+    if builtin_subcommands::<C>().contains(name) {
+        return argv;
+    }
+
+    let Ok(config) = cargo_config2::Config::load() else {
+        return argv;
+    };
+
+    let Some(alias) = config.alias.get(name) else {
+        return argv;
+    };
+
+    let mut expanded = argv[..index].to_vec();
+    expanded.extend(alias.list.iter().map(OsString::from));
+    expanded.extend_from_slice(&argv[index + 1..]);
+    expanded
+}
+
+fn builtin_subcommands<C: CommandFactory>() -> HashSet<String> {
+    let mut command = C::command();
+    command.build();
+
+    command
+        .get_subcommands()
+        .flat_map(|subcommand| {
+            std::iter::once(subcommand.get_name().to_owned())
+                .chain(subcommand.get_all_aliases().map(str::to_owned))
+        })
+        .collect()
+}
+
+fn subcommand_index(argv: &[OsString]) -> Option<usize> {
+    for (index, arg) in argv.iter().enumerate().skip(1) {
+        let arg = arg.as_encoded_bytes();
+
+        if arg == b"--" {
+            return None;
+        }
+
+        if !arg.starts_with(b"-") {
+            return Some(index);
+        }
+    }
+
+    None
+}
+

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -58,4 +58,3 @@ fn subcommand_index(argv: &[OsString]) -> Option<usize> {
 
     None
 }
-

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,12 +1,15 @@
 use std::{fmt::Write, process::ExitCode};
 
 use ansi_term::Color::{Blue, Green, Purple, Red, Yellow};
-use bevy_cli::commands::{
-    build::{BuildArgs, build},
-    completions::completions,
-    lint::{LintArgs, lint},
-    new::{NewArgs, new},
-    run::{RunArgs, run},
+use bevy_cli::{
+    alias,
+    commands::{
+        build::{BuildArgs, build},
+        completions::completions,
+        lint::{LintArgs, lint},
+        new::{NewArgs, new},
+        run::{RunArgs, run},
+    },
 };
 use clap::{Parser, Subcommand, builder::styling::Style};
 use clap_cargo::style;
@@ -17,7 +20,7 @@ use tracing_subscriber::{
 };
 
 fn main() -> ExitCode {
-    let cli = Cli::parse();
+    let cli = Cli::parse_from(alias::expand::<Cli>(std::env::args_os().collect()));
 
     // Set default log level to info for the `bevy_cli` crate if `BEVY_LOG` is not set.
     let env = tracing_subscriber::EnvFilter::try_from_env("BEVY_LOG").map_or_else(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! The library backend for the prototype Bevy CLI.
 
+pub mod alias;
 #[cfg(feature = "web")]
 pub(crate) mod bin_target;
 pub mod commands;


### PR DESCRIPTION
The bevy cli is intended to be a superset of cargo. I personally use a lot of cargo alias so I find it surprising when I can't use them while using the bevy cli.

This PR will read the args, try to expand the first subcommand and then pass the resulting string to Clap so it can parse it. This should match what cargo already does.